### PR TITLE
Package search

### DIFF
--- a/dcos/api/emitting.py
+++ b/dcos/api/emitting.py
@@ -62,7 +62,7 @@ def print_handler(event):
 
     if isinstance(event, basestring):
         print(event)
-    elif isinstance(event, collections.Mapping):
+    elif isinstance(event, collections.Mapping) or isinstance(event, list):
         print(json.dumps(event, sys.stdout, sort_keys=True, indent=2))
     elif isinstance(event, errors.Error):
         print(event.error())

--- a/integrations/cli/test_package.py
+++ b/integrations/cli/test_package.py
@@ -113,6 +113,29 @@ def test_list():
     assert stderr == b''
 
 
+def test_search():
+    returncode, stdout, stderr = exec_command(
+        ['dcos',
+            'package',
+            'search',
+            'framework'])
+
+    assert returncode == 0
+    assert b'chronos' in stdout
+    assert stderr == b''
+
+    returncode, stdout, stderr = exec_command(
+        ['dcos',
+            'package',
+            'search',
+            'xyzzy'])
+
+    assert returncode == 0
+    assert b'"packages": []' in stdout
+    assert b'"source": "git://github.com/mesosphere/universe.git"' in stdout
+    assert stderr == b''
+
+
 def test_cleanup():
     returncode, stdout, stderr = exec_command(
         ['dcos', 'marathon', 'remove', 'mesos-dns'])


### PR DESCRIPTION
First pass at implementing package search.
- Uses the new index structure introduced here: https://github.com/mesosphere/universe/pull/21
- Added Package.get_index method.
- Added package.search method.

_Example:_

```
$ dcos package search framework
[
  {
    "currentVersion": "2.1.0", 
    "description": "A fault tolerant job scheduler for Mesos which handles dependencies and ISO8601 based schedules.", 
    "name": "chronos", 
    "tags": [
      "mesosphere", 
      "framework"
    ], 
    "versions": [
      "2.1.0"
    ]
  }
]
```
