### PR TITLE
Ensure JSON output has a trailing newline.

### DIFF
--- a/dcos/api/emitting.py
+++ b/dcos/api/emitting.py
@@ -63,7 +63,7 @@ def print_handler(event):
     if isinstance(event, basestring):
         print(event)
     elif isinstance(event, collections.Mapping):
-        json.dump(event, sys.stdout, sort_keys=True, indent=2)
+        print(json.dumps(event, sys.stdout, sort_keys=True, indent=2))
     elif isinstance(event, errors.Error):
         print(event.error())
     else:


### PR DESCRIPTION
This makes the output look a little nicer.  Currently the closing brace for JSON objects can end up on the same line as the user's prompt.
