### PR TITLE
Added make packages target to build egg and wheel.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,6 @@ test:
 
 doc:
 	bin/doc.sh
+
+packages:
+	bin/packages.sh

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -17,8 +17,4 @@ if [ ! -f "$BASEDIR/env/updated" -o $BASEDIR/setup.py -nt $BASEDIR/env/updated ]
     echo "Requirements installed."
 fi
 
-pip install tox
-echo "Tox installed."
-
-pip install Sphinx
-echo "Sphinx installed."
+pip install -r $BASEDIR/requirements.txt

--- a/bin/packages.sh
+++ b/bin/packages.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+echo "Building wheel..."
+python setup.py bdist_wheel
+
+echo "Building egg..."
+python setup.py sdist
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+tox
+wheel


### PR DESCRIPTION
Please rebuild your virtualenv before running `make packages` (since this will pull in wheel for you).  This can be done by simply running `make clean && make env`.

Output:

```
$ make packages
Building wheel...
running bdist_wheel
running build
running build_py
installing to build/bdist.macosx-10.9-x86_64/wheel
running install
running install_lib
creating build/bdist.macosx-10.9-x86_64/wheel
creating build/bdist.macosx-10.9-x86_64/wheel/dcos
copying build/lib/dcos/__init__.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos
creating build/bdist.macosx-10.9-x86_64/wheel/dcos/api
copying build/lib/dcos/api/__init__.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/api
copying build/lib/dcos/api/config.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/api
copying build/lib/dcos/api/constants.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/api
copying build/lib/dcos/api/emitting.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/api
copying build/lib/dcos/api/errors.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/api
copying build/lib/dcos/api/jsonitem.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/api
copying build/lib/dcos/api/marathon.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/api
copying build/lib/dcos/api/options.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/api
copying build/lib/dcos/api/package.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/api
copying build/lib/dcos/api/util.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/api
creating build/bdist.macosx-10.9-x86_64/wheel/dcos/cli
copying build/lib/dcos/cli/__init__.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/cli
creating build/bdist.macosx-10.9-x86_64/wheel/dcos/cli/app
copying build/lib/dcos/cli/app/__init__.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/cli/app
copying build/lib/dcos/cli/app/main.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/cli/app
creating build/bdist.macosx-10.9-x86_64/wheel/dcos/cli/config
copying build/lib/dcos/cli/config/__init__.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/cli/config
copying build/lib/dcos/cli/config/main.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/cli/config
creating build/bdist.macosx-10.9-x86_64/wheel/dcos/cli/help
copying build/lib/dcos/cli/help/__init__.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/cli/help
copying build/lib/dcos/cli/help/main.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/cli/help
copying build/lib/dcos/cli/main.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/cli
creating build/bdist.macosx-10.9-x86_64/wheel/dcos/cli/marathon
copying build/lib/dcos/cli/marathon/__init__.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/cli/marathon
copying build/lib/dcos/cli/marathon/main.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/cli/marathon
creating build/bdist.macosx-10.9-x86_64/wheel/dcos/cli/package
copying build/lib/dcos/cli/package/__init__.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/cli/package
copying build/lib/dcos/cli/package/main.py -> build/bdist.macosx-10.9-x86_64/wheel/dcos/cli/package
creating build/bdist.macosx-10.9-x86_64/wheel/dcos/data
copying build/lib/dcos/data/marathon-schema.json -> build/bdist.macosx-10.9-x86_64/wheel/dcos/data
creating build/bdist.macosx-10.9-x86_64/wheel/toml
copying build/lib/toml/__init__.py -> build/bdist.macosx-10.9-x86_64/wheel/toml
running install_egg_info
running egg_info
writing requirements to dcos.egg-info/requires.txt
writing dcos.egg-info/PKG-INFO
writing top-level names to dcos.egg-info/top_level.txt
writing dependency_links to dcos.egg-info/dependency_links.txt
writing entry points to dcos.egg-info/entry_points.txt
reading manifest file 'dcos.egg-info/SOURCES.txt'
writing manifest file 'dcos.egg-info/SOURCES.txt'
Copying dcos.egg-info to build/bdist.macosx-10.9-x86_64/wheel/dcos-0.1.0-py2.7.egg-info
running install_scripts
creating build/bdist.macosx-10.9-x86_64/wheel/dcos-0.1.0.dist-info/WHEEL
Building egg...
running sdist
running egg_info
writing requirements to dcos.egg-info/requires.txt
writing dcos.egg-info/PKG-INFO
writing top-level names to dcos.egg-info/top_level.txt
writing dependency_links to dcos.egg-info/dependency_links.txt
writing entry points to dcos.egg-info/entry_points.txt
reading manifest file 'dcos.egg-info/SOURCES.txt'
writing manifest file 'dcos.egg-info/SOURCES.txt'
running check
creating dcos-0.1.0
creating dcos-0.1.0/dcos
creating dcos-0.1.0/dcos.egg-info
creating dcos-0.1.0/dcos/api
creating dcos-0.1.0/dcos/cli
creating dcos-0.1.0/dcos/cli/app
creating dcos-0.1.0/dcos/cli/config
creating dcos-0.1.0/dcos/cli/help
creating dcos-0.1.0/dcos/cli/marathon
creating dcos-0.1.0/dcos/cli/package
creating dcos-0.1.0/dcos/data
creating dcos-0.1.0/toml
making hard links in dcos-0.1.0...
hard linking README.rst -> dcos-0.1.0
hard linking setup.cfg -> dcos-0.1.0
hard linking setup.py -> dcos-0.1.0
hard linking dcos/__init__.py -> dcos-0.1.0/dcos
hard linking dcos.egg-info/PKG-INFO -> dcos-0.1.0/dcos.egg-info
hard linking dcos.egg-info/SOURCES.txt -> dcos-0.1.0/dcos.egg-info
hard linking dcos.egg-info/dependency_links.txt -> dcos-0.1.0/dcos.egg-info
hard linking dcos.egg-info/entry_points.txt -> dcos-0.1.0/dcos.egg-info
hard linking dcos.egg-info/requires.txt -> dcos-0.1.0/dcos.egg-info
hard linking dcos.egg-info/top_level.txt -> dcos-0.1.0/dcos.egg-info
hard linking dcos/api/__init__.py -> dcos-0.1.0/dcos/api
hard linking dcos/api/config.py -> dcos-0.1.0/dcos/api
hard linking dcos/api/constants.py -> dcos-0.1.0/dcos/api
hard linking dcos/api/emitting.py -> dcos-0.1.0/dcos/api
hard linking dcos/api/errors.py -> dcos-0.1.0/dcos/api
hard linking dcos/api/jsonitem.py -> dcos-0.1.0/dcos/api
hard linking dcos/api/marathon.py -> dcos-0.1.0/dcos/api
hard linking dcos/api/options.py -> dcos-0.1.0/dcos/api
hard linking dcos/api/package.py -> dcos-0.1.0/dcos/api
hard linking dcos/api/util.py -> dcos-0.1.0/dcos/api
hard linking dcos/cli/__init__.py -> dcos-0.1.0/dcos/cli
hard linking dcos/cli/main.py -> dcos-0.1.0/dcos/cli
hard linking dcos/cli/app/__init__.py -> dcos-0.1.0/dcos/cli/app
hard linking dcos/cli/app/main.py -> dcos-0.1.0/dcos/cli/app
hard linking dcos/cli/config/__init__.py -> dcos-0.1.0/dcos/cli/config
hard linking dcos/cli/config/main.py -> dcos-0.1.0/dcos/cli/config
hard linking dcos/cli/help/__init__.py -> dcos-0.1.0/dcos/cli/help
hard linking dcos/cli/help/main.py -> dcos-0.1.0/dcos/cli/help
hard linking dcos/cli/marathon/__init__.py -> dcos-0.1.0/dcos/cli/marathon
hard linking dcos/cli/marathon/main.py -> dcos-0.1.0/dcos/cli/marathon
hard linking dcos/cli/package/__init__.py -> dcos-0.1.0/dcos/cli/package
hard linking dcos/cli/package/main.py -> dcos-0.1.0/dcos/cli/package
hard linking dcos/data/marathon-schema.json -> dcos-0.1.0/dcos/data
hard linking toml/__init__.py -> dcos-0.1.0/toml
copying setup.cfg -> dcos-0.1.0
Writing dcos-0.1.0/setup.cfg
Creating tar archive
removing 'dcos-0.1.0' (and everything under it)
```
