### PR TITLE
dcos-327 Implements listing tasks per app

### DIFF
--- a/dcos/api/marathon.py
+++ b/dcos/api/marathon.py
@@ -416,6 +416,33 @@ class Client(object):
 
         return self._cancel_deployment(deployment_id, True)
 
+    def get_tasks(self, app_id):
+        """Returns a list of tasks, optionally limited to an app.
+
+        :param app_id: the id of the application to restart
+        :type app_id: str
+        :returns: a list of tasks
+        :rtype: list of dict
+        """
+
+        url = self._create_url('v2/tasks')
+
+        response, error = http.get(url, response_to_error=_response_to_error)
+
+        if error is not None:
+            return (None, error)
+
+        if app_id is not None:
+            app_id = normalize_app_id(app_id)
+            tasks = [
+                task for task in response.json()['tasks']
+                if app_id == task['appId']
+            ]
+        else:
+            tasks = response.json()['tasks']
+
+        return (tasks, None)
+
 
 def normalize_app_id(app_id):
     """Normalizes the application id.

--- a/dcos/cli/app/main.py
+++ b/dcos/cli/app/main.py
@@ -13,6 +13,7 @@ Usage:
     dcos app show [--app-version=<app-version>] <app-id>
     dcos app start [--force] <app-id> [<instances>]
     dcos app stop [--force] <app-id>
+    dcos app task list [<app-id>]
     dcos app update [--force] <app-id> [<properties>...]
     dcos app version list [--max-count=<max-count>] <app-id>
 
@@ -113,6 +114,11 @@ def _cmds():
             hierarchy=['deployment', 'watch'],
             arg_keys=['<deployment-id>', '--max-count', '--interval'],
             function=_deployment_watch),
+
+        cmds.Command(
+            hierarchy=['task', 'list'],
+            arg_keys=['<app-id>'],
+            function=_task_list),
 
         cmds.Command(hierarchy=['info'], arg_keys=[], function=_info),
 
@@ -651,6 +657,28 @@ def _deployment_watch(deployment_id, max_count, interval):
         emitter.publish(deployment)
         time.sleep(interval)
         count += 1
+
+    return 0
+
+
+def _task_list(app_id):
+    """
+    :param app_id: the id of the application
+    :type app_id: str
+    :returns: process status
+    :rtype: int
+    """
+
+    client = marathon.create_client(
+        config.load_from_path(
+            os.environ[constants.DCOS_CONFIG_ENV]))
+
+    tasks, err = client.get_tasks(app_id)
+    if err is not None:
+        emitter.publish(err)
+        return 1
+
+    emitter.publish(tasks)
 
     return 0
 


### PR DESCRIPTION
After running 2 instances of an application:

```
> dcos app task list
[
  {
    "appId": "/zero-instance-app",
    "host": "ubuntu",
    "id": "zero-instance-app.70c70e65-c2b5-11e4-ba56-080027613465",
    "ports": [
      31077
    ],
    "servicePorts": [
      10000
    ],
    "stagedAt": "2015-03-04T21:28:46.492Z",
    "startedAt": "2015-03-04T21:28:46.701Z",
    "version": "2015-03-04T21:28:38.070Z"
  },
  {
    "appId": "/zero-instance-app",
    "host": "ubuntu",
    "id": "zero-instance-app.6d331234-c2b5-11e4-ba56-080027613465",
    "ports": [
      31230
    ],
    "servicePorts": [
      10000
    ],
    "stagedAt": "2015-03-04T21:28:40.490Z",
    "startedAt": "2015-03-04T21:28:40.613Z",
    "version": "2015-03-04T21:28:38.070Z"
  }
]
```

And for a missing application:

```
> dcos app task list missing
[]
```
