### PR TITLE
dcos-516 Fixes `dcos app list` to print JSON

### DIFF
--- a/dcos/cli/app/main.py
+++ b/dcos/cli/app/main.py
@@ -225,7 +225,7 @@ def _add(app_resource):
 
 def _list():
     """
-    :returns: Process status
+    :returns: process status
     :rtype: int
     """
 
@@ -238,11 +238,7 @@ def _list():
         emitter.publish(err)
         return 1
 
-    if not apps:
-        emitter.publish("No applications to list.")
-
-    for app in apps:
-        emitter.publish(app['id'])
+    emitter.publish(apps)
 
     return 0
 

--- a/integrations/cli/test_app.py
+++ b/integrations/cli/test_app.py
@@ -522,16 +522,18 @@ def test_watching_deployment():
 def _list_apps(app_id=None):
     returncode, stdout, stderr = exec_command(['dcos', 'app', 'list'])
 
+    result = json.loads(stdout.decode('utf-8'))
+
     if app_id is None:
-        result = b'No applications to list.\n'
-    elif isinstance(app_id, str):
-        result = '/{}\n'.format(app_id).encode('utf-8')
+        assert len(result) == 0
     else:
-        assert False
+        assert len(result) == 1
+        assert result[0]['id'] == '/' + app_id
 
     assert returncode == 0
-    assert stdout == result
     assert stderr == b''
+
+    return result
 
 
 def _remove_app(app_id):


### PR DESCRIPTION
We should always print JSON files for all of the dcos show/list
commands. The only command that didn't do that was `dcos app list`.
This commit fixes that so that we print the JSON on success.

Marathon with no applications:

```
> dcos app list
[]
```

Marathon with one application:

```
> dcos app list
[
  {
    "args": null,
    "backoffFactor": 1.15,
    "backoffSeconds": 1,
    "cmd": "sleep 1000",
    "constraints": [],
    "container": null,
    "cpus": 0.1,
    "dependencies": [],
    "deployments": [],
    "disk": 0.0,
    "env": {},
    "executor": "",
    "healthChecks": [],
    "id": "/zero-instance-app",
    "instances": 0,
    "labels": {
      "PACKAGE_ID": "zero-instance-app",
      "PACKAGE_VERSION": "1.2.3"
    },
    "maxLaunchDelaySeconds": 3600,
    "mem": 16.0,
    "ports": [
      10000
    ],
    "requirePorts": false,
    "storeUrls": [],
    "tasksRunning": 0,
    "tasksStaged": 0,
    "upgradeStrategy": {
      "maximumOverCapacity": 1.0,
      "minimumHealthCapacity": 1.0
    },
    "uris": [],
    "user": null,
    "version": "2015-03-05T19:47:42.572Z"
  }
]
```
