### PR TITLE
Conditionally pipe output through a pager.

### DIFF
--- a/dcos/api/constants.py
+++ b/dcos/api/constants.py
@@ -8,6 +8,9 @@ DCOS_CONFIG_ENV = 'DCOS_CONFIG'
 DCOS_LOG_LEVEL_ENV = 'DCOS_LOG_LEVEL'
 """Name of the environment variable for the DCOS log level"""
 
+DCOS_PAGER_COMMAND_ENV = 'PAGER'
+"""Command to use to page long command output (e.g. 'less -R')"""
+
 PATH_ENV = 'PATH'
 """Name of the environment variable pointing to the executable directories."""
 

--- a/dcos/api/emitting.py
+++ b/dcos/api/emitting.py
@@ -3,10 +3,13 @@ from __future__ import print_function
 import abc
 import collections
 import json
+import os
+import pydoc
 import sys
 
+import pager
 import pygments
-from dcos.api import errors, util
+from dcos.api import constants, errors, util
 from pygments.formatters import Terminal256Formatter
 from pygments.lexers import JsonLexer
 
@@ -62,33 +65,100 @@ def print_handler(event):
     """Default handler for printing event to stdout.
 
     :param event: event to emit to stdout
-    :type event: str, dict or dcos.api.errors.Error
+    :type event: str, dict, list, or dcos.api.errors.Error
     """
+
+    pager_command = os.environ.get(constants.DCOS_PAGER_COMMAND_ENV)
 
     if event is None:
         # Do nothing
         pass
 
     elif isinstance(event, basestring):
-        print(event)
+        _page(event, pager_command)
 
     elif isinstance(event, collections.Mapping) or isinstance(event, list):
-        json_output = json.dumps(event, sort_keys=True, indent=2)
-
-        supports_colors = sys.platform != 'win32'  # Note: Not tested on Win32
-
-        if sys.stdout.isatty() and supports_colors:
-            json_output = pygments.highlight(
-                json_output, JsonLexer(), Terminal256Formatter()).strip()
-
-        print(json_output)
+        processed_json = _process_json(event, pager_command)
+        _page(processed_json, pager_command)
 
     elif isinstance(event, errors.Error):
         print(event.error(), file=sys.stderr)
 
     else:
         logger.debug('Printing unknown type: %s, %r.', type(event), event)
-        print(event)
+        _page(event, pager_command)
+
+
+def _process_json(event, pager_command):
+    """Conditionally highlights the supplied JSON value.
+
+    :param event: event to emit to stdout
+    :type event: str, dict, list, or dcos.api.errors.Error
+    :returns: String representation of the supplied JSON value,
+              possibly syntax-highlighted.
+    :rtype: str
+    """
+
+    json_output = json.dumps(event, sort_keys=True, indent=2)
+
+    force_colors = False  # TODO(CD): Introduce a --colors flag
+
+    if not sys.stdout.isatty():
+        if force_colors:
+            return _highlight_json(json_output)
+        else:
+            return json_output
+
+    supports_colors = sys.platform != 'win32'  # Note: Not tested on Win32
+
+    pager_is_set = pager_command is not None
+
+    should_highlight = force_colors or supports_colors and not pager_is_set
+
+    if should_highlight:
+        json_output = _highlight_json(json_output)
+
+    return json_output
+
+
+def _page(output, pager_command=None):
+    """Conditionally pipes the supplied output through a pager.
+
+    :param output:
+    :type output: object
+    :param pager_command:
+    :type pager_command: str
+    """
+
+    output = str(output)
+
+    if pager_command is None:
+        pager_command = 'less -R'
+
+    if not sys.stdout.isatty():
+        print(output)
+        return
+
+    num_lines = output.count('\n')
+    exceeds_tty_height = pager.getheight() - 1 < num_lines
+
+    if exceeds_tty_height:
+        pydoc.pipepager(output, cmd=pager_command)
+    else:
+        print(output)
+
+
+def _highlight_json(json_value):
+    """
+    :param json_value: JSON value to syntax-highlight
+    :type json_value: dict, list, number, string, boolean, or None
+    :returns: A string representation of the supplied JSON value,
+              highlighted for a terminal that supports ANSI colors.
+    :rtype: str
+    """
+
+    return pygments.highlight(
+        json_value, JsonLexer(), Terminal256Formatter()).strip()
 
 
 DEFAULT_HANDLER = print_handler

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
         'jsonschema',
         'pkginfo',
         'portalocker',
+        'pager',
         'pygments',
         'pystache',
         'requests',


### PR DESCRIPTION
This patch depends on PR #66.
- The pager is only used if stdout is a TTY.
- The pager is only used if the output is longer than the height of the
  console.
- <strike>The implementation may not be portable to Windows systems (as it
  depends on piping the output through the 'less' unix utility.)</strike>
- Uses the $PAGER environment variable to customize the pager command for long command output.
- Separates JSON syntax highlighting logic from the print handling function.
- Separates pager logic from the print handling function.
