### PR TITLE
Fix master build

### DIFF
--- a/dcos/api/package.py
+++ b/dcos/api/package.py
@@ -908,6 +908,6 @@ class IndexEntries():
         """
 
         return {
-          'source': self.source.url,
-          'packages': self.packages
+            'source': self.source.url,
+            'packages': self.packages
         }

--- a/integrations/cli/test_config.py
+++ b/integrations/cli/test_config.py
@@ -1,6 +1,6 @@
 import os
-import pytest
 
+import pytest
 from common import exec_command
 
 

--- a/integrations/cli/test_dcos.py
+++ b/integrations/cli/test_dcos.py
@@ -1,7 +1,8 @@
 import os
 
-from common import exec_command
 from dcos.api import util
+
+from common import exec_command
 
 
 def test_help():

--- a/integrations/cli/test_help.py
+++ b/integrations/cli/test_help.py
@@ -1,4 +1,5 @@
 import os
+
 from common import exec_command
 
 

--- a/tests/test_cmds.py
+++ b/tests/test_cmds.py
@@ -1,5 +1,6 @@
-import pytest
 from dcos.api import cmds, errors
+
+import pytest
 
 
 @pytest.fixture

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
-import pytest
 from dcos.api import config
+
+import pytest
 
 
 @pytest.fixture

--- a/tests/test_jsonitem.py
+++ b/tests/test_jsonitem.py
@@ -1,5 +1,6 @@
-import pytest
 from dcos.api import errors, jsonitem
+
+import pytest
 
 
 @pytest.fixture(params=range(6))

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
 
 commands =
   flake8 --verbose dcos tests integrations
-  isort --recursive --check-only --diff --verbose {envsitepackagesdir}/dcos
+  isort --recursive --check-only --diff --verbose dcos tests integrations
 
 [testenv:py27-unit]
 commands =


### PR DESCRIPTION
TeamCity is running the latest version of flake8 which is catching more
syntax errors. This changes fixes those new errors. As part of this
change we are also running the syntax checks against the tests and
integrations directories.
