### PR TITLE
dcos-497 Outputs deployment id for rollback

### DIFF
--- a/dcos/api/marathon.py
+++ b/dcos/api/marathon.py
@@ -377,8 +377,8 @@ class Client(object):
                       previous configuration. If set to `True`, simply stop the
                       deployment.
         :type force: bool
-        :returns: an error if unable to rollback the deployment; None otherwise
-        :rtype: Error
+        :returns: cancelation deployment
+        :rtype: (dict, Error)
         """
 
         if not force:
@@ -388,19 +388,25 @@ class Client(object):
 
         url = self._create_url('v2/deployments/{}'.format(deployment_id))
 
-        _, error = http.delete(url,
-                               params=params,
-                               response_to_error=_response_to_error)
+        response, error = http.delete(
+            url,
+            params=params,
+            response_to_error=_response_to_error)
+        if error is not None:
+            return (None, error)
 
-        return error
+        if not force:
+            return (response.json(), None)
+        else:
+            return (None, None)
 
     def rollback_deployment(self, deployment_id):
         """Rolls back an application deployment.
 
         :param deployment_id: the deployment id
         :type deployment_id: str
-        :returns: an error if unable to rollback the deployment; None otherwise
-        :rtype: Error
+        :returns: cancelation deployment
+        :rtype: (dict, Error)
         """
 
         return self._cancel_deployment(deployment_id, False)
@@ -414,7 +420,8 @@ class Client(object):
         :rtype: Error
         """
 
-        return self._cancel_deployment(deployment_id, True)
+        _, err = self._cancel_deployment(deployment_id, True)
+        return err
 
     def get_tasks(self, app_id):
         """Returns a list of tasks, optionally limited to an app.

--- a/dcos/cli/app/main.py
+++ b/dcos/cli/app/main.py
@@ -613,10 +613,12 @@ def _deployment_rollback(deployment_id):
         config.load_from_path(
             os.environ[constants.DCOS_CONFIG_ENV]))
 
-    err = client.rollback_deployment(deployment_id)
+    deployment, err = client.rollback_deployment(deployment_id)
     if err is not None:
         emitter.publish(err)
         return 1
+
+    emitter.publish(deployment)
 
     return 0
 

--- a/integrations/cli/test_app.py
+++ b/integrations/cli/test_app.py
@@ -483,8 +483,11 @@ def test_rollback_deployment():
     returncode, stdout, stderr = exec_command(
         ['dcos', 'app', 'deployment', 'rollback', result[0]['id']])
 
+    result = json.loads(stdout.decode('utf-8'))
+
     assert returncode == 0
-    assert stdout == b''
+    assert 'deploymentId' in result
+    assert 'version' in result
     assert stderr == b''
 
     _list_deployments(0)


### PR DESCRIPTION
This change makes sure that we output the deployment JSON when performing a
deployment rollback.

Rollback back a deployment:

```
> dcos app deployment rollback 622fe550-f110-4f31-ba80-8fc92e2a0a42
{
  "deploymentId": "8edea3c0-6162-4471-844b-b1a14655fb04",
  "version": "2015-03-10T00:38:17.043Z"
}
```

Rolling back an invalid deployment id:

```
> dcos app deployment rollback 622fe550-f110-4f31-ba80-8fc92e2a0a42
Error: DeploymentPlan 622fe550-f110-4f31-ba80-8fc92e2a0a42 does not exist
```
