### PR TITLE
Allow running individual integration tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,10 @@ Other Useful Commands
 
     tox -e <testenv>
 
+#. Run a specific integration test module::
+
+    tox -e py27-integration /cli/test_config.py
+
 .. _packages: https://packaging.python.org/en/latest/installing.html#installing-requirements
 .. _git: http://git-scm.com
 .. _installer: https://www.python.org/downloads/

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands =
 
 [testenv:py27-integration]
 commands =
-  py.test -vv integrations
+  py.test -vv integrations{posargs}
 
 [testenv:py34-unit]
 commands =
@@ -32,4 +32,4 @@ commands =
 
 [testenv:py34-integration]
 commands =
-  py.test -vv integrations
+  py.test -vv integrations{posargs}


### PR DESCRIPTION
With this change the user can run individual tests with:
tox -e py27-integration /cli/test_config.py
