### PR TITLE
dcos-310 Refactor `dcos config` command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,8 @@ Configure Environment and Run
 
 #. Configure Marathon, changing the values below as appropriate for your local installation::
 
-    dcos config marathon.host localhost
-    dcos config marathon.port 8080
+    dcos config set marathon.host localhost
+    dcos config set marathon.port 8080
 
 #. Get started by calling the DCOS CLI help::
 


### PR DESCRIPTION
Show the current config:

```
> dcos config show
marathon.host=localhost
marathon.port=8080
package.cache=/tmp/dcos-cache
package.sources=['git://github.com/mesosphere/universe.git', 'https://github.com/mesosphere/universe/archive/master.zip']
```

Show one value:

```
> dcos config show marathon.host
localhost
```

Show top level property:

```
> dcos config show marathon
Property 'marathon' doesn't fully specify a value
```

Show missing property:

```
> dcos config show missing
Property 'missing' doesn't exist
```

Unset a property:

```
> dcos config unset marathon.host
```

Set a property:

```
> dcos config set marathon.host localhost
```
