### PR TITLE
Added source and framework flag labels to installed packages.

### DIFF
--- a/dcos/api/package.py
+++ b/dcos/api/package.py
@@ -91,12 +91,9 @@ def install(pkg, version, init_client, user_options, cfg):
     init_desc['labels'] = {
         PACKAGE_NAME_KEY: metadata['name'],
         PACKAGE_VERSION_KEY: metadata['version'],
-        PACKAGE_SOURCE_KEY: pkg.registry.source,
-        PACKAGE_FRAMEWORK_KEY: is_framework
+        PACKAGE_SOURCE_KEY: pkg.registry.source.url,
+        PACKAGE_FRAMEWORK_KEY: str(is_framework)
     }
-
-    # Validate the init descriptor
-    # TODO(CD): Is this necessary / desirable at this point?
 
     # Send the descriptor to init
     _, err = init_client.add_app(init_desc)


### PR DESCRIPTION
Labels now look like this for installed things:

``` json
{
  "id": "mesos-dns",
  "labels": {
    "DCOS_PACKAGE_NAME": "mesos-dns",
    "DCOS_PACKAGE_VERSION": "0.1.0-alpha",
    "DCOS_PACKAGE_SOURCE": "git://github.com/mesosphere/marathon.git",
    "DCOS_PACKAGE_IS_FRAMEWORK": "false"
  }
}
```

_Elided example Marathon app JSON._
