### PR TITLE
Implemented package uninstallation.

### DIFF
--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -223,7 +223,7 @@ def _add(app_resource):
             os.environ[constants.DCOS_CONFIG_ENV]))
 
     # Check that the application doesn't exist
-    app_id = marathon.normalize_app_id(application_resource['id'])
+    app_id = client.normalize_app_id(application_resource['id'])
     app, err = client.get_app(app_id)
     if app is not None:
         emitter.publish("Application '{}' already exists".format(app_id))
@@ -513,7 +513,7 @@ def _restart(app_id, force):
         return 1
 
     if desc['instances'] <= 0:
-        app_id = marathon.normalize_app_id(app_id)
+        app_id = client.normalize_app_id(app_id)
         emitter.publish(
             'Unable to restart application {!r} because it is stopped'.format(
                 app_id,

--- a/cli/tests/integrations/cli/test_config.py
+++ b/cli/tests/integrations/cli/test_config.py
@@ -10,7 +10,7 @@ from common import exec_command
 def env():
     return {
         constants.PATH_ENV: os.environ[constants.PATH_ENV],
-        'DCOS_CONFIG': os.path.join("tests", "data", "Dcos.toml")
+        constants.DCOS_CONFIG_ENV: os.path.join("tests", "data", "Dcos.toml")
     }
 
 

--- a/cli/tests/integrations/cli/test_package.py
+++ b/cli/tests/integrations/cli/test_package.py
@@ -13,7 +13,7 @@ def test_package():
     dcos package list
     dcos package search <query>
     dcos package sources
-    dcos package uninstall <package_name>
+    dcos package uninstall [--all | --app-id=<app-id>] <package_name>
     dcos package update
 
 Options:
@@ -116,21 +116,78 @@ def test_install_with_id():
             'install',
             'mesos-dns',
             '--options=tests/data/package/mesos-dns-config.json',
-            '--app-id=dns'])
+            '--app-id=dns-1'])
 
     assert returncode == 0
     assert stdout == b''
     assert stderr == b''
 
     returncode, stdout, stderr = exec_command(
-        ['dcos', 'marathon', 'app', 'remove', 'dns'])
+        ['dcos',
+            'package',
+            'install',
+            'mesos-dns',
+            '--options=tests/data/package/mesos-dns-config.json',
+            '--app-id=dns-2'])
 
     assert returncode == 0
     assert stdout == b''
     assert stderr == b''
 
 
+def test_uninstall_with_id():
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'package', 'uninstall', 'mesos-dns', '--app-id=dns-1'])
+
+    assert returncode == 0
+    assert stdout == b''
+    assert stderr == b''
+
+
+def test_uninstall_all():
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'package', 'uninstall', 'mesos-dns', '--all'])
+
+    assert returncode == 0
+    assert stdout == b''
+    assert stderr == b''
+
+
+def test_uninstall_missing():
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'package', 'uninstall', 'mesos-dns'])
+
+    assert returncode == 1
+    assert stdout == b''
+    assert stderr == b'No instances of package [mesos-dns] are installed.\n'
+
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'package', 'uninstall', 'mesos-dns', '--app-id=dns-1'])
+
+    assert returncode == 1
+    assert stdout == b''
+    assert stderr == b"""No instances of package [mesos-dns] with \
+id [dns-1] are installed.\n"""
+
+
 def test_list():
+    returncode, stdout, stderr = exec_command(['dcos', 'package', 'list'])
+
+    assert returncode == 0
+    assert stdout == b''
+    assert stderr == b''
+
+    returncode, stdout, stderr = exec_command(
+        ['dcos',
+            'package',
+            'install',
+            'mesos-dns',
+            '--options=tests/data/package/mesos-dns-config.json'])
+
+    assert returncode == 0
+    assert stdout == b''
+    assert stderr == b''
+
     returncode, stdout, stderr = exec_command(['dcos', 'package', 'list'])
 
     assert returncode == 0
@@ -163,7 +220,7 @@ def test_search():
 
 def test_cleanup():
     returncode, stdout, stderr = exec_command(
-        ['dcos', 'marathon', 'app', 'remove', 'mesos-dns'])
+        ['dcos', 'package', 'uninstall', 'mesos-dns'])
 
     assert returncode == 0
     assert stdout == b''

--- a/dcos/api/marathon.py
+++ b/dcos/api/marathon.py
@@ -85,7 +85,7 @@ class Client(object):
         :rtype: (dict, errors.Error)
         """
 
-        app_id = normalize_app_id(app_id)
+        app_id = self.normalize_app_id(app_id)
         if version is None:
             url = self._create_url('v2/apps{}'.format(app_id))
         else:
@@ -123,7 +123,7 @@ class Client(object):
                         max_count))
             )
 
-        app_id = normalize_app_id(app_id)
+        app_id = self.normalize_app_id(app_id)
 
         url = self._create_url('v2/apps{}/versions'.format(app_id))
 
@@ -193,7 +193,7 @@ class Client(object):
         :rtype: (str, errors.Error)
         """
 
-        app_id = normalize_app_id(app_id)
+        app_id = self.normalize_app_id(app_id)
 
         if not force:
             params = None
@@ -225,7 +225,7 @@ class Client(object):
         :rtype: (bool, errors.Error)
         """
 
-        app_id = normalize_app_id(app_id)
+        app_id = self.normalize_app_id(app_id)
 
         if not force:
             params = None
@@ -269,7 +269,7 @@ class Client(object):
         :rtype: errors.Error
         """
 
-        app_id = normalize_app_id(app_id)
+        app_id = self.normalize_app_id(app_id)
 
         if not force:
             params = None
@@ -298,7 +298,7 @@ class Client(object):
         :rtype: (dict, errors.Error)
         """
 
-        app_id = normalize_app_id(app_id)
+        app_id = self.normalize_app_id(app_id)
 
         if not force:
             params = None
@@ -357,7 +357,7 @@ class Client(object):
             return (None, error)
 
         if app_id is not None:
-            app_id = normalize_app_id(app_id)
+            app_id = self.normalize_app_id(app_id)
             deployments = [
                 deployment for deployment in response.json()
                 if app_id in deployment['affectedApps']
@@ -439,7 +439,7 @@ class Client(object):
             return (None, error)
 
         if app_id is not None:
-            app_id = normalize_app_id(app_id)
+            app_id = self.normalize_app_id(app_id)
             tasks = [
                 task for task in response.json()['tasks']
                 if app_id == task['appId']
@@ -471,14 +471,13 @@ class Client(object):
 
         return (task, None)
 
+    def normalize_app_id(self, app_id):
+        """Normalizes the application id.
 
-def normalize_app_id(app_id):
-    """Normalizes the application id.
+        :param app_id: raw application ID
+        :type app_id: str
+        :returns: normalized application ID
+        :rtype: str
+        """
 
-    :param app_id: raw application ID
-    :type app_id: str
-    :returns: normalized application ID
-    :rtype: str
-    """
-
-    return quote('/' + app_id.strip('/'))
+        return quote('/' + app_id.strip('/'))


### PR DESCRIPTION
- Adds --app-id flag to match installation.
- Adds --all flag to remove all matching apps.

```
Usage:
    dcos package describe <package_name>
    dcos package info
    dcos package install [--options=<options_file> --app-id=<app_id>]
         <package_name>
    dcos package list
    dcos package search <query>
    dcos package sources
    dcos package uninstall [--all | --app-id=<app-id>] <package_name>
    dcos package update

Options:
    -h, --help          Show this screen
    --version           Show version

Configuration:
    [package]
    # Path to the local package cache.
    cache_dir = "/var/dcos/cache"

    # List of package sources, in search order.
    #
    # Three protocols are supported:
    #   - Local file
    #   - HTTPS
    #   - Git
    sources = [
      "file:///Users/me/test-registry",
      "https://my.org/registry",
      "git://github.com/mesosphere/universe.git"
    ]
```
