### PR TITLE
Improved error output: package.install and util.validate_json.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ pydoc/_build/
 .coverage
 
 *.pyc
+
+Vagrantfile

--- a/bin/clean.sh
+++ b/bin/clean.sh
@@ -5,5 +5,6 @@ set -o errexit -o nounset -o pipefail
 BASEDIR=`dirname $0`/..
 
 rm -rf $BASEDIR/.tox $BASEDIR/env $BASEDIR/dist $BASEDIR/build
+find $BASEDIR -name '*.pyc' -delete
 echo "Deleted virtualenv and test artifacts."
 

--- a/cli/bin/clean.sh
+++ b/cli/bin/clean.sh
@@ -5,5 +5,6 @@ set -o errexit -o nounset -o pipefail
 BASEDIR=`dirname $0`/..
 
 rm -rf $BASEDIR/.tox $BASEDIR/env $BASEDIR/dist $BASEDIR/build
+find $BASEDIR -name '*.pyc' -delete
 echo "Deleted virtualenv and test artifacts."
 

--- a/cli/tests/data/package/mesos-dns-config-bad.json
+++ b/cli/tests/data/package/mesos-dns-config-bad.json
@@ -1,0 +1,5 @@
+{
+  "mesos-dns/host": false
+}
+
+

--- a/cli/tests/integrations/cli/test_package.py
+++ b/cli/tests/integrations/cli/test_package.py
@@ -96,6 +96,27 @@ def test_describe():
     assert stderr == b''
 
 
+def test_bad_install():
+    returncode, stdout, stderr = exec_command(
+        ['dcos',
+            'package',
+            'install',
+            'mesos-dns',
+            '--options=tests/data/package/mesos-dns-config-bad.json'])
+
+    assert returncode == 1
+    assert stdout == b''
+
+    assert stderr == b"""\
+Error: 'mesos-dns/config-url' is a required property
+Value: {"mesos-dns/host": false}
+
+Error: False is not of type 'string'
+Path:  mesos-dns/host
+Value: false
+"""
+
+
 def test_install():
     returncode, stdout, stderr = exec_command(
         ['dcos',

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -5,7 +5,7 @@ envlist = py{27,34}-integration, syntax
 deps =
   pytest
   pytest-cov
-  ..
+  -e..
 
 [testenv:syntax]
 deps =

--- a/dcos/api/package.py
+++ b/dcos/api/package.py
@@ -78,7 +78,14 @@ def install(pkg, version, init_client, user_options, app_id, cfg):
     if tmpl_error is not None:
         return tmpl_error
 
-    init_desc = json.loads(pystache.render(init_template, options))
+    rendered_template = pystache.render(init_template, options)
+
+    try:
+        init_desc = json.loads(rendered_template)
+    except Exception as e:
+        message = 'Error: {}\n'.format(e.message)
+        message += 'Rendered JSON: \n{}'.format(rendered_template)
+        return Error(message)
 
     # Add package metadata
     metadata, meta_error = pkg.package_json(version)

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
         'pygments',
         'pystache',
         'requests',
+        'six',
         'toml',
     ],
 )


### PR DESCRIPTION
```
$ dcos package install hdfs
Error: [u'https://s3.amazonaws.com/downloads.mesosphere.io/hdfs/release/0.1.0/hdfs-mesos-0.1.0.tgz'] is not of type u'string'
Path:  hdfs/scheduler-uris
Value: ["https://s3.amazonaws.com/downloads.mesosphere.io/hdfs/release/0.1.0/hdfs-mesos-0.1.0.tgz"]
```
