### PR TITLE
Validate required config values in package.

### DIFF
--- a/cli/dcoscli/package/main.py
+++ b/cli/dcoscli/package/main.py
@@ -236,7 +236,11 @@ def _install(package_name, options_file, app_id):
 
     config = _load_config()
 
-    pkg = package.resolve_package(package_name, config)
+    pkg, resolve_error = package.resolve_package(package_name, config)
+
+    if resolve_error is not None:
+        emitter.publish(resolve_error)
+        return 1
 
     if pkg is None:
         emitter.publish("Package [{}] not found".format(package_name))
@@ -341,8 +345,7 @@ def _uninstall(package_name, remove_all, app_id):
         package_name,
         remove_all,
         app_id,
-        init_client,
-        config)
+        init_client)
 
     if uninstall_error is not None:
         emitter.publish(uninstall_error)

--- a/dcos/api/package.py
+++ b/dcos/api/package.py
@@ -33,6 +33,30 @@ PACKAGE_SOURCE_KEY = 'DCOS_PACKAGE_SOURCE'
 PACKAGE_FRAMEWORK_KEY = 'DCOS_PACKAGE_IS_FRAMEWORK'
 
 
+def _validate_config(cfg):
+    """
+    :param cfg: Configuration object
+    :type cfg: dcos.api.config.Toml
+    :returns: Configuration validation error, or None
+    :rtype: Error
+    """
+
+    required_fields = ['package.sources', 'package.cache']
+
+    field_errors = []
+
+    for field in required_fields:
+        if cfg.get(field) is None:
+            error = 'Error: config field [{}] is required.'.format(field)
+            field_errors.append(error)
+
+    if len(field_errors) is 0:
+        return None
+    else:
+        message = str.join('\n', field_errors)
+        return Error(message)
+
+
 def install(pkg, version, init_client, user_options, app_id, cfg):
     """Installs a package.
 
@@ -50,6 +74,10 @@ def install(pkg, version, init_client, user_options, app_id, cfg):
     :type cfg: dcos.api.config.Toml
     :rtype: Error
     """
+
+    config_error = _validate_config(cfg)
+    if config_error is not None:
+        return config_error
 
     if user_options is None:
         user_options = {}
@@ -114,7 +142,7 @@ def install(pkg, version, init_client, user_options, app_id, cfg):
     return err
 
 
-def uninstall(package_name, remove_all, app_id, init_client, config):
+def uninstall(package_name, remove_all, app_id, init_client):
     """Uninstalls a package.
 
     :param package_name: The package to uninstall
@@ -125,8 +153,6 @@ def uninstall(package_name, remove_all, app_id, init_client, config):
     :type app_id: str
     :param init_client: The program to use to run the package
     :type init_client: object
-    :param cfg: Configuration dictionary
-    :type cfg: dcos.api.config.Toml
     :rtype: Error
     """
 
@@ -200,6 +226,11 @@ def search(query, cfg):
     :rtype: (list of IndexEntries, Error)
     """
 
+    config_error = _validate_config(cfg)
+
+    if config_error is not None:
+        return (None, config_error)
+
     threshold = 0.5  # Minimum rank required to appear in results
     results = []
 
@@ -210,7 +241,11 @@ def search(query, cfg):
         })
         return result
 
-    for registry in registries(cfg):
+    regs, reg_error = registries(cfg)
+    if reg_error is not None:
+        return (None, reg_error)
+
+    for registry in regs:
         source_results = []
         index, error = registry.get_index()
         if error is not None:
@@ -271,55 +306,63 @@ def _extract_default_values(config_schema):
     return (dict(defaults), None)
 
 
-def resolve_package(package_name, config):
+def resolve_package(package_name, cfg):
     """Returns the first package with the supplied name found by looking at
     the configured sources in the order they are defined.
 
     :param package_name: The name of the package to resolve
     :type package_name: str
-    :param config: Configuration dictionary
-    :type config: dcos.api.config.Toml
+    :param cfg: Configuration dictionary
+    :type cfg: dcos.api.config.Toml
     :returns: The named package, if found
-    :rtype: Package or None
+    :rtype: (Package, Error)
     """
 
-    for registry in registries(config):
+    regs, reg_error = registries(cfg)
+    if reg_error is not None:
+        return (None, reg_error)
+
+    for registry in regs:
         package, error = registry.get_package(package_name)
         if package is not None:
-            return package
+            return (package, None)
 
-    return None
+    return (None, None)
 
 
-def registries(config):
+def registries(cfg):
     """Returns configured cached package registries.
 
-    :param config: Configuration dictionary
-    :type config: dcos.api.config.Toml
+    :param cfg: Configuration dictionary
+    :type cfg: dcos.api.config.Toml
     :returns: The list of registries, in resolution order
-    :rtype: list of Registry
+    :rtype: (list of Registry, Error)
     """
 
-    sources, errors = list_sources(config)
-    return [Registry(source, source.local_cache(config)) for source in sources]
+    config_error = _validate_config(cfg)
+    if config_error is not None:
+        return (None, config_error)
+
+    sources, errors = list_sources(cfg)
+    rs = [Registry(source, source.local_cache(cfg)) for source in sources]
+    return (rs, None)
 
 
-def list_sources(config):
+def list_sources(cfg):
     """List configured package sources.
 
-    :param config: Configuration dictionary
-    :type config: dcos.api.config.Toml
+    :param cfg: Configuration dictionary
+    :type cfg: dcos.api.config.Toml
     :returns: The list of sources, in resolution order
     :rtype: (list of Source, list of Error)
     """
 
-    source_uris = config.get('package.sources')
+    config_error = _validate_config(cfg)
+    if config_error is not None:
+        return (None, config_error)
 
-    if source_uris is None:
-        config_error = Error('No configured value for [package.sources]')
-        return (None, [config_error])
-
-    results = [url_to_source(s) for s in config['package.sources']]
+    source_uris = cfg.get('package.sources')
+    results = [url_to_source(s) for s in source_uris]
     sources = [source for (source, _) in results if source is not None]
     errors = [error for (_, error) in results if error is not None]
     return (sources, errors)
@@ -371,11 +414,11 @@ def acquire_file_lock(lock_file_path):
         return (None, Error("Unable to acquire the package cache lock"))
 
 
-def update_sources(config):
+def update_sources(cfg):
     """Overwrites the local package cache with the latest source data.
 
-    :param config: Configuration dictionary
-    :type config: dcos.api.config.Toml
+    :param cfg: Configuration dictionary
+    :type cfg: dcos.api.config.Toml
     :returns: Error, if any.
     :rtype: list of Error
     """
@@ -383,7 +426,7 @@ def update_sources(config):
     errors = []
 
     # ensure the cache directory is properly configured
-    cache_dir = config.get('package.cache')
+    cache_dir = cfg.get('package.cache')
 
     if cache_dir is None:
         config_error = Error("No configured value for [package.cache]")
@@ -410,7 +453,7 @@ def update_sources(config):
     with lock_fd:
 
         # list sources
-        sources, list_errors = list_sources(config)
+        sources, list_errors = list_sources(cfg)
 
         if len(list_errors) > 0:
             errors = errors + list_errors
@@ -476,16 +519,16 @@ class Source:
 
         return hashlib.sha1(self.url.encode('utf-8')).hexdigest()
 
-    def local_cache(self, config):
+    def local_cache(self, cfg):
         """Returns the file system path to this source's local cache.
 
-        :param config: Configuration dictionary
-        :type config: dcos.api.config.Toml
+        :param cfg: Configuration dictionary
+        :type cfg: dcos.api.config.Toml
         :returns: Path to this source's local cache on disk
         :rtype: str or None
         """
 
-        cache_dir = config.get('package.cache')
+        cache_dir = cfg.get('package.cache')
         if cache_dir is None:
             return None
 


### PR DESCRIPTION
Previously, some `package` commands assumed that the incoming configuration object has all requisite values.  If this assumption was not valid, the program could emit a stack trace to stdout.

This change set introduces a new function, `dcos.api.package._validate_config`, to encapsulate config object validation for the purposes of the package subcommand.

Example output after this change:

```
$ dcos package install hdfs
Error: config field [package.sources] is required.
Error: config field [package.cache] is required.
```

Also normalized configuration object parameter names to always be `cfg` in `dcos.api.package`.
