### PR TITLE
dcos-588 Improve config subcommand 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ clean:
 env:
 	bin/env.sh
 
-test:
+test: env
 	bin/test.sh
 
-doc:
+doc: env
 	bin/doc.sh
 
-packages:
+packages: env
 	bin/packages.sh

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -6,11 +6,11 @@ clean:
 env:
 	bin/env.sh
 
-test:
+test: env
 	bin/test.sh
 
-doc:
+doc: env
 	bin/doc.sh
 
-packages:
+packages: env
 	bin/packages.sh

--- a/cli/dcoscli/config/main.py
+++ b/cli/dcoscli/config/main.py
@@ -1,14 +1,23 @@
 """Get and set DCOS command line options
 
 Usage:
+    dcos config append <name> <value>
     dcos config info
+    dcos config prepend <name> <value>
     dcos config set <name> <value>
-    dcos config unset <name>
     dcos config show [<name>]
+    dcos config unset [--index=<index>] <name>
+    dcos config validate
 
 Options:
-    -h, --help            Show this screen
-    --version             Show version
+    -h, --help       Show this screen
+    --version        Show version
+    --index=<index>  Index into the list. The first element in the list has an
+                     index of zero
+
+Positional Arguments:
+    <name>      The name of the property
+    <value>     The value of the property
 """
 
 import collections
@@ -16,8 +25,10 @@ import os
 
 import dcoscli
 import docopt
+import six
 import toml
-from dcos.api import cmds, config, constants, emitting, errors, options, util
+from dcos.api import (cmds, config, constants, emitting, errors, jsonitem,
+                      options, subcommand, util)
 
 emitter = emitting.FlatEmitter()
 
@@ -59,14 +70,29 @@ def _cmds():
             function=_set),
 
         cmds.Command(
+            hierarchy=['config', 'append'],
+            arg_keys=['<name>', '<value>'],
+            function=_append),
+
+        cmds.Command(
+            hierarchy=['config', 'prepend'],
+            arg_keys=['<name>', '<value>'],
+            function=_prepend),
+
+        cmds.Command(
             hierarchy=['config', 'unset'],
-            arg_keys=['<name>'],
+            arg_keys=['<name>', '--index'],
             function=_unset),
 
         cmds.Command(
             hierarchy=['config', 'show'],
             arg_keys=['<name>'],
             function=_show),
+
+        cmds.Command(
+            hierarchy=['config', 'validate'],
+            arg_keys=[],
+            function=_validate),
     ]
 
 
@@ -87,13 +113,64 @@ def _set(name, value):
     """
 
     config_path, toml_config = _load_config()
-    toml_config[name] = value
+
+    section, subkey = _split_key(name)
+
+    config_schema, err = _get_config_schema(section)
+    if err is not None:
+        emitter.publish(err)
+        return 1
+
+    python_value, err = jsonitem.parse_json_value(subkey, value, config_schema)
+    if err is not None:
+        emitter.publish(err)
+        return 1
+
+    toml_config[name] = python_value
     _save_config_file(config_path, toml_config)
 
     return 0
 
 
-def _unset(name):
+def _append(name, value):
+    """
+    :returns: process status
+    :rtype: int
+    """
+
+    config_path, toml_config = _load_config()
+
+    python_value, err = _parse_array_item(name, value)
+    if err is not None:
+        emitter.publish(err)
+        return 1
+
+    toml_config[name] = toml_config.get(name, []) + python_value
+    _save_config_file(config_path, toml_config)
+
+    return 0
+
+
+def _prepend(name, value):
+    """
+    :returns: process status
+    :rtype: int
+    """
+
+    config_path, toml_config = _load_config()
+
+    python_value, err = _parse_array_item(name, value)
+    if err is not None:
+        emitter.publish(err)
+        return 1
+
+    toml_config[name] = python_value + toml_config.get(name, [])
+    _save_config_file(config_path, toml_config)
+
+    return 0
+
+
+def _unset(name, index):
     """
     :returns: process status
     :rtype: int
@@ -109,6 +186,28 @@ def _unset(name):
         return 1
     elif isinstance(value, collections.Mapping):
         emitter.publish(_generate_choice_msg(name, value))
+        return 1
+    elif (isinstance(value, collections.Sequence) and
+          not isinstance(value, six.string_types)):
+        if index is not None:
+            index, err = util.parse_int(index)
+            if err is not None:
+                emitter.publish(err)
+                return 1
+
+            if index < 0 or index >= len(value):
+                emitter.publish(
+                    errors.DefaultError(
+                        'Index ({}) is out of bounds - possible values are '
+                        'between {} and {}'.format(index, 0, len(value) - 1)))
+                return 1
+
+            value.pop(index)
+            toml_config[name] = value
+    elif index is not None:
+        emitter.publish(
+            errors.DefaultError(
+                'Unsetting based on an index is only supported for lists'))
         return 1
 
     _save_config_file(config_path, toml_config)
@@ -140,6 +239,38 @@ def _show(name):
         # Let's list all of the values
         for key, value in sorted(toml_config.property_items()):
             emitter.publish('{}={}'.format(key, value))
+
+    return 0
+
+
+def _validate():
+    """
+    :returns: process status
+    :rtype: int
+    """
+
+    _, toml_config = _load_config()
+
+    root_schema = {
+        '$schema': 'http://json-schema.org/schema#',
+        'type': 'object',
+        'properties': {},
+        'additionalProperties': False,
+    }
+
+    # Load the config schema from all the subsections into the root schema
+    for section in toml_config.keys():
+        config_schema, err = _get_config_schema(section)
+        if err is not None:
+            emitter.publish(err)
+            return 1
+
+        root_schema['properties'][section] = config_schema
+
+    err = util.validate_json(toml_config._dictionary, root_schema)
+    if err is not None:
+        emitter.publish(err)
+        return 1
 
     return 0
 
@@ -183,3 +314,78 @@ def _save_config_file(config_path, toml_config):
     serial = toml.dumps(toml_config._dictionary)
     with open(config_path, 'w') as config_file:
         config_file.write(serial)
+
+
+def _get_config_schema(command):
+    """
+    :param command: the subcommand name
+    :type command: str
+    :returns: the subcommand's configuration schema
+    :rtype: (dict, dcos.api.errors.Error)
+    """
+
+    executable, err = subcommand.command_executables(
+        command,
+        util.dcos_path())
+    if err is not None:
+        return (None, err)
+
+    return (subcommand.config_schema(executable), None)
+
+
+def _split_key(name):
+    """
+    :param name: the full property path - e.g. marathon.host
+    :type name: str
+    :returns: the section and property name
+    :rtype: ((str, str), Error)
+    """
+
+    terms = name.split('.', 1)
+    if len(terms) != 2:
+        emitter.publish(
+            errors.DefaultError('Property name must have both a section and '
+                                'key: <section>.<key> - E.g. marathon.host'))
+        return 1
+
+    return (terms[0], terms[1])
+
+
+def _parse_array_item(name, value):
+    """
+    :param name: the name of the property
+    :type name: str
+    :param value: the value to parse
+    :type value: str
+    :returns: the parsed value as an array with one element
+    :rtype: (list of any, dcos.api.errors.Error) where any is string, int,
+            float, bool, array or dict
+    """
+
+    section, subkey = _split_key(name)
+
+    config_schema, err = _get_config_schema(section)
+    if err is not None:
+        return (None, err)
+
+    parser, err = jsonitem.find_parser(subkey, config_schema)
+    if err is not None:
+        return (None, err)
+
+    if parser.schema['type'] != 'array':
+        return (
+            None,
+            errors.DefaultError(
+                "Append/Prepend not supported on '{0}' properties - use 'dcos "
+                "config set {0} {1}'".format(name, value))
+        )
+
+    if ('items' in parser.schema and
+       parser.schema['items']['type'] == 'string'):
+
+        value = '["' + value + '"]'
+    else:
+        # We are going to assume that wrapping it in an array is enough
+        value = '[' + value + ']'
+
+    return parser(value)

--- a/cli/dcoscli/data/config-schema/marathon.json
+++ b/cli/dcoscli/data/config-schema/marathon.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "host": {
+      "type": "string",
+      "title": "Marathon hostname or IP address",
+      "description": "",
+      "default": "localhost"
+    },
+    "port": {
+      "type": "integer",
+      "title": "Marathon port",
+      "description": "",
+      "default": 8080,
+      "minimum": 1,
+      "maximum": 65535
+    }
+  },
+  "additionalProperties": false,
+  "required": ["host", "port"]
+}

--- a/cli/dcoscli/data/config-schema/package.json
+++ b/cli/dcoscli/data/config-schema/package.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "title": "Package sources",
+      "description": "The list of package source in search order",
+      "default": [ "git://github.com/mesosphere/universe.git" ],
+      "additionalItems": false
+    },
+    "cache": {
+      "type": "string",
+      "title": "Package cache directory",
+      "description": "Path to the local package cache directory",
+      "default": "/tmp/cache"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["sources", "cache"]
+}

--- a/cli/dcoscli/data/config-schema/subcommand.json
+++ b/cli/dcoscli/data/config-schema/subcommand.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "pip_find_links": {
+      "type": "string",
+      "title": "Location for finding packages",
+      "description": "If a url or path to an html file, then parse for links to archives. If a local path or file:// url that’s a directory, then look for archives in the directory listing."
+    }
+  },
+  "additionalProperties": false
+}

--- a/cli/dcoscli/subcommand/main.py
+++ b/cli/dcoscli/subcommand/main.py
@@ -1,6 +1,7 @@
 """Install and manage DCOS CLI Subcommands
 
 Usage:
+    dcos subcommand --config-schema
     dcos subcommand info
     dcos subcommand install <package>
     dcos subcommand list
@@ -14,12 +15,14 @@ Positional arguments:
     <package>          The subcommand package wheel
     <package_name>     The name of the subcommand package
 """
+import json
 import os
 import shutil
 import subprocess
 
 import dcoscli
 import docopt
+import pkg_resources
 import pkginfo
 from dcos.api import (cmds, config, constants, emitting, errors, options,
                       subcommand, util)
@@ -73,7 +76,31 @@ def _cmds():
             hierarchy=['subcommand', 'info'],
             arg_keys=[],
             function=_info),
+
+        cmds.Command(
+            hierarchy=['subcommand'],
+            arg_keys=['--config-schema'],
+            function=_subcommand),
     ]
+
+
+def _subcommand(config_schema):
+    """
+    :returns: Process status
+    :rtype: int
+    """
+
+    if config_schema:
+        schema = json.loads(
+            pkg_resources.resource_string(
+                'dcoscli',
+                'data/config-schema/subcommand.json').decode('utf-8'))
+        emitter.publish(schema)
+    else:
+        emitter.publish(options.make_generic_usage_message(__doc__))
+        return 1
+
+    return 0
 
 
 def _info():

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -73,7 +73,10 @@ setup(
     # installed, specify them here.  If using Python 2.6 or less, then these
     # have to be included in MANIFEST.in as well.
     package_data={
-        'dcoscli': ['data/*'],
+        'dcoscli': [
+            'data/*.json',
+            'data/config-schema/*.json',
+        ],
     },
 
     # To provide executable scripts, use entry points in preference to the

--- a/cli/tests/data/dcos.toml
+++ b/cli/tests/data/dcos.toml
@@ -1,10 +1,8 @@
 [subcommand]
 pip_find_links = "../dist"
-[foo]
-bar = true
-[marathon]
-host = "localhost"
-port = 8080
 [package]
 sources = [ "git://github.com/mesosphere/universe.git", "https://github.com/mesosphere/universe/archive/master.zip",]
 cache = "tmp/cache"
+[marathon]
+host = "localhost"
+port = 8080

--- a/cli/tests/integrations/cli/test_config.py
+++ b/cli/tests/integrations/cli/test_config.py
@@ -1,5 +1,7 @@
+import json
 import os
 
+import six
 from dcos.api import constants
 
 import pytest
@@ -21,14 +23,23 @@ def test_help():
     assert stdout == b"""Get and set DCOS command line options
 
 Usage:
+    dcos config append <name> <value>
     dcos config info
+    dcos config prepend <name> <value>
     dcos config set <name> <value>
-    dcos config unset <name>
     dcos config show [<name>]
+    dcos config unset [--index=<index>] <name>
+    dcos config validate
 
 Options:
-    -h, --help            Show this screen
-    --version             Show version
+    -h, --help       Show this screen
+    --version        Show version
+    --index=<index>  Index into the list. The first element in the list has an
+                     index of zero
+
+Positional Arguments:
+    <name>      The name of the property
+    <value>     The value of the property
 """
     assert stderr == b''
 
@@ -55,8 +66,7 @@ def test_list_property(env):
         env)
 
     assert returncode == 0
-    assert stdout == b"""foo.bar=True
-marathon.host=localhost
+    assert stdout == b"""marathon.host=localhost
 marathon.port=8080
 package.cache=tmp/cache
 package.sources=['git://github.com/mesosphere/universe.git', \
@@ -72,10 +82,6 @@ def test_get_existing_string_property(env):
 
 def test_get_existing_integral_property(env):
     _get_value('marathon.port', 8080, env)
-
-
-def test_get_existing_boolean_property(env):
-    _get_value('foo.bar', True, env)
 
 
 def test_get_missing_property(env):
@@ -97,14 +103,114 @@ def test_get_top_property(env):
     )
 
 
-def test_set_existing_property(env):
+def test_set_existing_string_property(env):
     _set_value('marathon.host', 'newhost', env)
     _get_value('marathon.host', 'newhost', env)
     _set_value('marathon.host', 'localhost', env)
 
 
+def test_set_existing_integral_property(env):
+    _set_value('marathon.port', '8181', env)
+    _get_value('marathon.port', 8181, env)
+    _set_value('marathon.port', '8080', env)
+
+
+def test_append_empty_list(env):
+    _unset_value('package.sources', None, env)
+    _append_value(
+        'package.sources',
+        'git://github.com/mesosphere/universe.git',
+        env)
+    _get_value(
+        'package.sources',
+        ['git://github.com/mesosphere/universe.git'],
+        env)
+    _append_value(
+        'package.sources',
+        'https://github.com/mesosphere/universe/archive/master.zip',
+        env)
+    _get_value(
+        'package.sources',
+        ['git://github.com/mesosphere/universe.git',
+         'https://github.com/mesosphere/universe/archive/master.zip'],
+        env)
+
+
+def test_prepend_empty_list(env):
+    _unset_value('package.sources', None, env)
+    _prepend_value(
+        'package.sources',
+        'https://github.com/mesosphere/universe/archive/master.zip',
+        env)
+    _get_value(
+        'package.sources',
+        ['https://github.com/mesosphere/universe/archive/master.zip'],
+        env)
+    _prepend_value(
+        'package.sources',
+        'git://github.com/mesosphere/universe.git',
+        env)
+    _get_value(
+        'package.sources',
+        ['git://github.com/mesosphere/universe.git',
+         'https://github.com/mesosphere/universe/archive/master.zip'],
+        env)
+
+
+def test_append_list(env):
+    _append_value(
+        'package.sources',
+        'new_uri',
+        env)
+    _get_value(
+        'package.sources',
+        ['git://github.com/mesosphere/universe.git',
+         'https://github.com/mesosphere/universe/archive/master.zip',
+         'new_uri'],
+        env)
+    _unset_value('package.sources', '2', env)
+
+
+def test_prepend_list(env):
+    _prepend_value(
+        'package.sources',
+        'new_uri',
+        env)
+    _get_value(
+        'package.sources',
+        ['new_uri',
+         'git://github.com/mesosphere/universe.git',
+         'https://github.com/mesosphere/universe/archive/master.zip'],
+        env)
+    _unset_value('package.sources', '0', env)
+
+
+def test_append_non_list(env):
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'config', 'append', 'marathon.host', 'new_uri'],
+        env)
+
+    assert returncode == 1
+    assert stdout == b''
+    assert (stderr ==
+            b"Append/Prepend not supported on 'marathon.host' "
+            b"properties - use 'dcos config set marathon.host new_uri'\n")
+
+
+def test_prepend_non_list(env):
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'config', 'prepend', 'marathon.host', 'new_uri'],
+        env)
+
+    assert returncode == 1
+    assert stdout == b''
+    assert (stderr ==
+            b"Append/Prepend not supported on 'marathon.host' "
+            b"properties - use 'dcos config set marathon.host new_uri'\n")
+
+
 def test_unset_property(env):
-    _unset_value('marathon.host', env)
+    _unset_value('marathon.host', None, env)
     _get_missing_value('marathon.host', env)
     _set_value('marathon.host', 'localhost', env)
 
@@ -134,10 +240,102 @@ def test_unset_top_property(env):
     )
 
 
+def test_unset_whole_list(env):
+    _unset_value('package.sources', None, env)
+    _get_missing_value('package.sources', env)
+    _set_value(
+        'package.sources',
+        '["git://github.com/mesosphere/universe.git", '
+        '"https://github.com/mesosphere/universe/archive/master.zip"]',
+        env)
+
+
+def test_unset_list_index(env):
+    _unset_value('package.sources', '0', env)
+    _get_value(
+        'package.sources',
+        ['https://github.com/mesosphere/universe/archive/master.zip'],
+        env)
+    _prepend_value(
+        'package.sources',
+        'git://github.com/mesosphere/universe.git',
+        env)
+
+
+def test_unset_outbound_index(env):
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'config', 'unset', '--index=3', 'package.sources'],
+        env)
+
+    assert returncode == 1
+    assert stdout == b''
+    assert (stderr ==
+            b'Index (3) is out of bounds - possible values are '
+            b'between 0 and 1\n')
+
+
+def test_unset_bad_index(env):
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'config', 'unset', '--index=number', 'package.sources'],
+        env)
+
+    assert returncode == 1
+    assert stdout == b''
+    assert stderr == b'Error parsing string as int\n'
+
+
+def test_unset_index_from_string(env):
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'config', 'unset', '--index=0', 'marathon.host'],
+        env)
+
+    assert returncode == 1
+    assert stdout == b''
+    assert (stderr ==
+            b'Unsetting based on an index is only supported for lists\n')
+
+
+def test_validate(env):
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'config', 'validate'],
+        env)
+
+    assert returncode == 0
+    assert stdout == b''
+    assert stderr == b''
+
+
+def test_validation_error(env):
+    _unset_value('marathon.host', None, env)
+
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'config', 'validate'],
+        env)
+
+    assert returncode == 1
+    assert stdout == b''
+    assert stderr == b"""Error: 'host' is a required property
+Path: marathon
+Value: {"port": 8080}
+"""
+
+    _set_value('marathon.host', 'localhost', env)
+
+
+def test_set_property_key(env):
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'config', 'set', 'path.to.value', 'cool new value'],
+        env)
+
+    assert returncode == 1
+    assert stdout == b''
+    assert stderr == b"'path' is not a dcos command.\n"
+
+
 def test_set_missing_property(env):
-    _set_value('path.to.value', 'cool new value', env)
-    _get_value('path.to.value', 'cool new value', env)
-    _unset_value('path.to.value', env)
+    _unset_value('marathon.host', None, env)
+    _set_value('marathon.host', 'localhost', env)
+    _get_value('marathon.host', 'localhost', env)
 
 
 def _set_value(key, value, env):
@@ -150,20 +348,47 @@ def _set_value(key, value, env):
     assert stderr == b''
 
 
+def _append_value(key, value, env):
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'config', 'append', key, value],
+        env)
+
+    assert returncode == 0
+    assert stdout == b''
+    assert stderr == b''
+
+
+def _prepend_value(key, value, env):
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'config', 'prepend', key, value],
+        env)
+
+    assert returncode == 0
+    assert stdout == b''
+    assert stderr == b''
+
+
 def _get_value(key, value, env):
     returncode, stdout, stderr = exec_command(
         ['dcos', 'config', 'show', key],
         env)
 
+    if isinstance(value, six.string_types):
+        result = json.loads('"' + stdout.decode('utf-8').strip() + '"')
+    else:
+        result = json.loads(stdout.decode('utf-8').strip())
+
     assert returncode == 0
-    assert stdout == '{}\n'.format(value).encode('utf-8')
+    assert result == value
     assert stderr == b''
 
 
-def _unset_value(key, env):
-    returncode, stdout, stderr = exec_command(
-        ['dcos', 'config', 'unset', key],
-        env)
+def _unset_value(key, index, env):
+    cmd = ['dcos', 'config', 'unset', key]
+    if index is not None:
+        cmd.append('--index={}'.format(index))
+
+    returncode, stdout, stderr = exec_command(cmd, env)
 
     assert returncode == 0
     assert stdout == b''

--- a/cli/tests/integrations/cli/test_marathon.py
+++ b/cli/tests/integrations/cli/test_marathon.py
@@ -7,7 +7,10 @@ def test_help():
     returncode, stdout, stderr = exec_command(['dcos', 'marathon', '--help'])
 
     assert returncode == 0
-    assert stdout == b"""Usage:
+    assert stdout == b"""Deploy and manage applications on the DCOS
+
+Usage:
+    dcos marathon --config-schema
     dcos marathon app add [<app-resource>]
     dcos marathon app list
     dcos marathon app remove [--force] <app-id>
@@ -30,7 +33,7 @@ Options:
     -h, --help                   Show this screen
     --version                    Show version
     --force                      This flag disable checks in Marathon during
-                                 update operations.
+                                 update operations
     --app-version=<app-version>  This flag specifies the application version to
                                  use for the command. The application version
                                  (<app-version>) can be specified as an
@@ -39,22 +42,24 @@ Options:
                                  Relative values must be specified as a
                                  negative integer and they represent the
                                  version from the currently deployed
-                                 application definition.
+                                 application definition
+    --config-schema              Show the configuration schema for the Marathon
+                                 subcommand
     --max-count=<max-count>      Maximum number of entries to try to fetch and
                                  return
     --interval=<interval>        Number of seconds to wait between actions
 
 Positional arguments:
-    <app-id>                The application id
-    <app-resource>          The application resource; for a detailed
-                            description see (https://mesosphere.github.io/
-                            marathon/docs/rest-api.html#post-/v2/apps)
-    <deployment-id>         The deployment id
-    <instances>             The number of instances to start
-    <properties>            Optional key-value pairs to be included in the
-                            command. The separator between the key and value
-                            must be the '=' character. E.g. cpus=2.0
-    <task-id>               The task id
+    <app-id>                    The application id
+    <app-resource>              The application resource; for a detailed
+                                description see (https://mesosphere.github.io/
+                                marathon/docs/rest-api.html#post-/v2/apps)
+    <deployment-id>             The deployment id
+    <instances>                 The number of instances to start
+    <properties>                Optional key-value pairs to be included in the
+                                command. The separator between the key and
+                                value must be the '=' character. E.g. cpus=2.0
+    <task-id>                   The task id
 """
     assert stderr == b''
 

--- a/cli/tests/integrations/cli/test_package.py
+++ b/cli/tests/integrations/cli/test_package.py
@@ -5,7 +5,10 @@ def test_package():
     returncode, stdout, stderr = exec_command(['dcos', 'package', '--help'])
 
     assert returncode == 0
-    assert stdout == b"""Usage:
+    assert stdout == b"""Install and manage DCOS software packages
+
+Usage:
+    dcos package --config-schema
     dcos package describe <package_name>
     dcos package info
     dcos package install [--options=<options_file> --app-id=<app_id>]
@@ -112,7 +115,7 @@ Error: 'mesos-dns/config-url' is a required property
 Value: {"mesos-dns/host": false}
 
 Error: False is not of type 'string'
-Path:  mesos-dns/host
+Path: mesos-dns/host
 Value: false
 """
 

--- a/dcos/api/emitting.py
+++ b/dcos/api/emitting.py
@@ -9,6 +9,7 @@ import sys
 
 import pager
 import pygments
+import six
 from dcos.api import constants, errors, util
 from pygments.formatters import Terminal256Formatter
 from pygments.lexers import JsonLexer
@@ -74,15 +75,18 @@ def print_handler(event):
         # Do nothing
         pass
 
-    elif isinstance(event, basestring):
+    elif isinstance(event, six.string_types):
         _page(event, pager_command)
-
-    elif isinstance(event, collections.Mapping) or isinstance(event, list):
-        processed_json = _process_json(event, pager_command)
-        _page(processed_json, pager_command)
 
     elif isinstance(event, errors.Error):
         print(event.error(), file=sys.stderr)
+
+    elif (isinstance(event, collections.Mapping) or
+          isinstance(event, collections.Sequence) or isinstance(event, bool) or
+          isinstance(event, six.integer_types) or isinstance(event, float)):
+        # These are all valid JSON types let's treat them different
+        processed_json = _process_json(event, pager_command)
+        _page(processed_json, pager_command)
 
     else:
         logger.debug('Printing unknown type: %s, %r.', type(event), event)

--- a/dcos/api/util.py
+++ b/dcos/api/util.py
@@ -199,7 +199,7 @@ def validate_json(instance, schema):
     def format(error):
         message = 'Error: {}\n'.format(hack_error_message_fix(error.message))
         if len(error.absolute_path) > 0:
-            message += 'Path:  {}\n'.format(error.absolute_path[0])
+            message += 'Path: {}\n'.format('.'.join(error.absolute_path))
         message += 'Value: {}'.format(json.dumps(error.instance))
         return message
 
@@ -210,3 +210,24 @@ def validate_json(instance, schema):
     else:
         errors_as_str = str.join('\n\n', formatted_errors)
         return errors.DefaultError(errors_as_str)
+
+
+def parse_int(string):
+    """Parse string and an integer
+
+    :param string: string to parse as an integer
+    :type string: str
+    :returns: the interger value of the string
+    :rtype: (int, Error)
+    """
+
+    try:
+        return (int(string), None)
+    except:
+        error = sys.exc_info()[0]
+        logger = get_logger(__name__)
+        logger.error(
+            'Unhandled exception while parsing string as int: %r -- %r',
+            string,
+            error)
+        return (None, errors.DefaultError('Error parsing string as int'))

--- a/setup.py
+++ b/setup.py
@@ -70,8 +70,8 @@ setup(
     install_requires=[
         'gitpython',
         'jsonschema',
-        'portalocker',
         'pager',
+        'portalocker',
         'pygments',
         'pystache',
         'requests',

--- a/tests/test_jsonitem.py
+++ b/tests/test_jsonitem.py
@@ -197,9 +197,9 @@ def test_parse_invalid_arrays(bad_array):
     assert isinstance(error, errors.Error)
 
 
-def test_check_key_with_schema(schema, jsonitem_tuple):
+def test_find_parser(schema, jsonitem_tuple):
     key, string_value, value = jsonitem_tuple
-    value_type, err = jsonitem._check_key_with_schema(key, schema)
+    value_type, err = jsonitem.find_parser(key, schema)
 
     assert err is None
     assert value_type(string_value) == (value, None)


### PR DESCRIPTION
There is quite a bit going on in this commit. At a high-level this improves the config subcommand so that it can support more value type and not just strings. To do this we need to know the schema for each subsection. The config subcommand queries all of the subcommands for this information. Here are all of the changes includes in this commit:
- Fix the makefile so that the test, doc and packages target depend on
  env.
- Add support for append, prepend, unset a list element and validate in
  the config subcommand.
- Extend the marathon, package and subcommand subcommands so that they
  return the schema for their section of the config file.
- Adds config schema file the python package.
- The module jsonschema returns poorly formatted validation errors. This
  commit includes regular expression to clean up those messages.
