### PR TITLE
Output complete package JSON in dcos package list.

### DIFF
--- a/cli/dcoscli/package/main.py
+++ b/cli/dcoscli/package/main.py
@@ -315,8 +315,7 @@ def _list():
         emitter.publish(error)
         return 1
 
-    for name, version in installed:
-        emitter.publish('{} [{}]'.format(name, version))
+    emitter.publish(installed)
 
     return 0
 

--- a/cli/tests/integrations/cli/test_package.py
+++ b/cli/tests/integrations/cli/test_package.py
@@ -234,7 +234,7 @@ def test_list():
     returncode, stdout, stderr = exec_command(['dcos', 'package', 'list'])
 
     assert returncode == 0
-    assert stdout == b''
+    assert stdout == b'[]\n'
     assert stderr == b''
 
     returncode, stdout, stderr = exec_command(
@@ -251,7 +251,27 @@ def test_list():
     returncode, stdout, stderr = exec_command(['dcos', 'package', 'list'])
 
     assert returncode == 0
-    assert stdout == b'mesos-dns [alpha]\n'
+    assert stdout == b"""\
+[
+  {
+    "appId": "/mesos-dns",
+    "description": "DNS-based service discovery for Mesos.",
+    "maintainer": "support@mesosphere.io",
+    "name": "mesos-dns",
+    "packageSource": "git://github.com/mesosphere/universe.git",
+    "postInstallNotes": "Please refer to the tutorial instructions for \
+further setup requirements: http://mesosphere.github.io/mesos-dns/docs\
+/tutorial-gce.html",
+    "registryVersion": "0.1.0-alpha",
+    "scm": "https://github.com/mesosphere/mesos-dns.git",
+    "tags": [
+      "mesosphere"
+    ],
+    "version": "alpha",
+    "website": "http://mesosphere.github.io/mesos-dns"
+  }
+]
+"""
     assert stderr == b''
 
 

--- a/dcos/api/emitting.py
+++ b/dcos/api/emitting.py
@@ -5,6 +5,7 @@ import collections
 import json
 import os
 import pydoc
+import re
 import sys
 
 import pager
@@ -104,6 +105,9 @@ def _process_json(event, pager_command):
     """
 
     json_output = json.dumps(event, sort_keys=True, indent=2)
+
+    # Strip trailing whitespace
+    json_output = re.sub(r'\s+$', '', json_output, 0, re.M)
 
     force_colors = False  # TODO(CD): Introduce a --colors flag
 


### PR DESCRIPTION
- Made package.list_installed_packages a bit more useful,
  taking a predicate to filter results.
- Updated JSON output in emitting to strip trailing whitespace.
- Updated package integration tests accordingly.

Related to [DCOS-634](https://mesosphere.atlassian.net/browse/DCOS-634)
