### PR TITLE
Hint to help users install package subcommands.

### DIFF
--- a/cli/dcoscli/subcommand/main.py
+++ b/cli/dcoscli/subcommand/main.py
@@ -139,6 +139,8 @@ def _install(package):
     distribution_name, err = _distribution_name(package)
     if err is not None:
         emitter.publish(err)
+        emitter.publish(errors.DefaultError("Note: To install only the \
+subcommand for a package, run `dcos package install <package> --cli` instead"))
         return 1
 
     err = subcommand.install(


### PR DESCRIPTION
Example output:

```
$ dcos subcommand install foobar
Failed to read file: No such file: /Users/connor/projects/mesosphere/dcos-cli/foobar
Note: To install a package subcommand, run `dcos package install <package> --cli` instead
```
