### PR TITLE
enable core.* config vars -- DCOS-1049

### DIFF
--- a/cli/dcoscli/config/main.py
+++ b/cli/dcoscli/config/main.py
@@ -22,10 +22,12 @@ Positional Arguments:
 """
 
 import collections
+import json
 import os
 
 import dcoscli
 import docopt
+import pkg_resources
 import six
 import toml
 from dcos.api import (cmds, config, constants, emitting, errors, jsonitem,
@@ -326,6 +328,16 @@ def _get_config_schema(command):
     :returns: the subcommand's configuration schema
     :rtype: (dict, dcos.api.errors.Error)
     """
+
+    # core.* config variables are special.  They're valid, but don't
+    # correspond to any particular subcommand, so we must handle them
+    # separately.
+    if command == "core":
+        return (json.loads(
+            pkg_resources.resource_string(
+                'dcoscli',
+                'data/config-schema/core.json').decode('utf-8')),
+                None)
 
     executable, err = subcommand.command_executables(
         command,

--- a/cli/dcoscli/data/config-schema/core.json
+++ b/cli/dcoscli/data/config-schema/core.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "reporting": {
+      "type": "boolean",
+      "title": "Usage Reporting",
+      "description": "Whether to report usage events to Mesosphere",
+      "default": true
+    },
+    "email": {
+      "type": "string",
+      "title": "Your email address",
+      "description": "Your email address"
+    },
+    "token": {
+      "type": "string",
+      "title": "Your OAuth token",
+      "description": "Your OAuth token"
+    }
+  },
+  "additionalProperties": false
+}

--- a/cli/tests/data/dcos.toml
+++ b/cli/tests/data/dcos.toml
@@ -1,3 +1,5 @@
+[core]
+reporting = true
 [subcommand]
 pip_find_links = "../dist"
 [marathon]

--- a/cli/tests/integrations/cli/test_config.py
+++ b/cli/tests/integrations/cli/test_config.py
@@ -67,7 +67,8 @@ def test_list_property(env):
         env)
 
     assert returncode == 0
-    assert stdout == b"""marathon.host=localhost
+    assert stdout == b"""core.reporting=True
+marathon.host=localhost
 marathon.port=8080
 package.cache=tmp/cache
 package.sources=['git://github.com/mesosphere/universe.git', \
@@ -337,6 +338,12 @@ def test_set_missing_property(env):
     _unset_value('marathon.host', None, env)
     _set_value('marathon.host', 'localhost', env)
     _get_value('marathon.host', 'localhost', env)
+
+
+def test_set_core_property(env):
+    _set_value('core.reporting', 'false', env)
+    _get_value('core.reporting', False, env)
+    _set_value('core.reporting', 'true', env)
 
 
 def _set_value(key, value, env):


### PR DESCRIPTION
Where are the title and description properties of a config-schema used?  How do we want to educate users about these new core properties?  What about config properties in general?  Are they only surfaced through --config-schema?  If so, then these new core properties wan't be surfaced anywhere, since they don't have any corresponding subcommand for which to run a --config-schema.

Also, we could explicitly set reporting to true in install-dcos-cli.sh, so that it explicitly appears in their dcos.toml.

Let me know what you think
