### PR TITLE
updated api.dcos_path() to work properly on both Unix and Windows systems

### DIFF
--- a/dcos/api/util.py
+++ b/dcos/api/util.py
@@ -93,12 +93,14 @@ def process_executable_path():
 
 
 def dcos_path():
-    """Returns the real path to the DCOS path based on the executable
+    """Returns the real DCOS path based on the current executable
 
     :returns: the real path to the DCOS path
     :rtype: str
     """
-    return os.path.dirname(os.path.dirname(process_executable_path()))
+    dcos_bin_dir = os.path.realpath(sys.argv[0])
+    dcos_dir = os.path.dirname(os.path.dirname(dcos_bin_dir))
+    return dcos_dir
 
 
 def configure_logger_from_environ():


### PR DESCRIPTION
This now checks sys.argv[0], which is a more stable way than using install.stack() and works properly on unix, os x and windows.
