### PR TITLE
Added --validate option to dcos package update.

### DIFF
--- a/cli/dcoscli/package/main.py
+++ b/cli/dcoscli/package/main.py
@@ -11,18 +11,19 @@ Usage:
     dcos package search <query>
     dcos package sources
     dcos package uninstall [--all | --app-id=<app-id>] <package_name>
-    dcos package update
+    dcos package update [--validate]
 
 Options:
     -h, --help         Show this screen
     --info             Show a short description of this subcommand
     --version          Show version
     --all              Apply the operation to all matching packages
+    --app              Apply the operation only to the package's application
     --app-id=<app-id>  The application id
     --cli              Apply the operation only to the package's CLI
     --options=<file>   Path to a JSON file containing package installation
                        options
-    --app              Apply the operation only to the package's application
+    --validate         Validate package content when updating sources
 
 Configuration:
     [package]
@@ -87,7 +88,7 @@ def _cmds():
 
         cmds.Command(
             hierarchy=['package', 'update'],
-            arg_keys=[],
+            arg_keys=['--validate'],
             function=_update),
 
         cmds.Command(
@@ -190,16 +191,18 @@ def _list_sources():
     return 0
 
 
-def _update():
+def _update(validate):
     """Update local package definitions from sources.
 
+    :param validate: Whether to validate package content when updating sources.
+    :type validate: bool
     :returns: Process status
     :rtype: int
     """
 
     config = _load_config()
 
-    errs = package.update_sources(config)
+    errs = package.update_sources(config, validate)
 
     if len(errs) > 0:
         for err in errs:

--- a/cli/tests/integrations/cli/test_package.py
+++ b/cli/tests/integrations/cli/test_package.py
@@ -22,18 +22,19 @@ Usage:
     dcos package search <query>
     dcos package sources
     dcos package uninstall [--all | --app-id=<app-id>] <package_name>
-    dcos package update
+    dcos package update [--validate]
 
 Options:
     -h, --help         Show this screen
     --info             Show a short description of this subcommand
     --version          Show version
     --all              Apply the operation to all matching packages
+    --app              Apply the operation only to the package's application
     --app-id=<app-id>  The application id
     --cli              Apply the operation only to the package's CLI
     --options=<file>   Path to a JSON file containing package installation
                        options
-    --app              Apply the operation only to the package's application
+    --validate         Validate package content when updating sources
 
 Configuration:
     [package]
@@ -83,8 +84,19 @@ https://github.com/mesosphere/universe/archive/master.zip
     assert stderr == b''
 
 
-def test_update():
+def test_update_without_validation():
     returncode, stdout, stderr = exec_command(['dcos', 'package', 'update'])
+
+    assert returncode == 0
+    assert b'source' in stdout
+    assert b'Validating package definitions...' not in stdout
+    assert b'OK' not in stdout
+    assert stderr == b''
+
+
+def test_update_with_validation():
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'package', 'update', '--validate'])
 
     assert returncode == 0
     assert b'source' in stdout

--- a/dcos/api/package.py
+++ b/dcos/api/package.py
@@ -483,7 +483,7 @@ def acquire_file_lock(lock_file_path):
         return (None, Error("Unable to acquire the package cache lock"))
 
 
-def update_sources(config):
+def update_sources(config, validate=False):
     """Overwrites the local package cache with the latest source data.
 
     :param config: Configuration dictionary
@@ -544,10 +544,11 @@ def update_sources(config):
                     continue  # keep updating the other sources
 
                 # validate content
-                validation_errors = Registry(source, stage_dir).validate()
-                if len(validation_errors) > 0:
-                    errors += validation_errors
-                    continue  # keep updating the other sources
+                if validate:
+                    validation_errors = Registry(source, stage_dir).validate()
+                    if len(validation_errors) > 0:
+                        errors += validation_errors
+                        continue  # keep updating the other sources
 
                 # remove the $CACHE/source.hash() directory
                 target_dir = os.path.join(cache_dir, source.hash())


### PR DESCRIPTION
- Update no longer validates packages by default.
- Motivated in part by Windows support.

CC @swartzrock 
