### PR TITLE
dcos-1142 have dcos package install give helpful error messaging

### DIFF
--- a/cli/dcoscli/package/main.py
+++ b/cli/dcoscli/package/main.py
@@ -321,7 +321,7 @@ def _install(package_name, options_path, app_id, cli, app):
             return 1
     except Exception as e:
         logger.exception('Exception while generating options')
-        emitter.publish(errors.DefaultError(e.message))
+        emitter.publish(errors.DefaultError(e))
         return 1
 
     if app:

--- a/cli/tests/integrations/cli/test_config.py
+++ b/cli/tests/integrations/cli/test_config.py
@@ -293,9 +293,9 @@ def test_validate(env):
 def test_validation_error(env):
     _unset_value('marathon.host', None, env)
 
-    stderr = b"""Error: 'host' is a required property
-Path: marathon
-Value: {"port": 8080}
+    stderr = b"""\
+Error: missing required property 'host'. \
+Add to JSON file and pass in /path/to/file with the --options argument.
 """
     assert_command(['dcos', 'config', 'validate'],
                    returncode=1,

--- a/cli/tests/integrations/cli/test_package.py
+++ b/cli/tests/integrations/cli/test_package.py
@@ -129,13 +129,17 @@ tutorial-gce.html",
 def test_bad_install():
     args = ['--options=tests/data/package/mesos-dns-config-bad.json']
     stderr = b"""\
-Error: 'mesos-dns/config-url' is a required property
-Value: {"mesos-dns/host": false}
+Error: missing required property 'mesos-dns/config-url'. \
+Add to JSON file and pass in /path/to/file with the --options argument.
 
 Error: False is not of type 'string'
 Path: mesos-dns/host
 Value: false
 """
+    assert_command(['dcos', 'package', 'install', 'mesos-dns', args[0]],
+                   returncode=1,
+                   stderr=stderr)
+
     _install_mesos_dns(args=args,
                        returncode=1,
                        stdout=b'',

--- a/dcos/api/util.py
+++ b/dcos/api/util.py
@@ -249,7 +249,14 @@ def validate_json(instance, schema):
     validation_errors = sorted(validation_errors, key=sort_key)
 
     def format(error):
-        message = 'Error: {}\n'.format(hack_error_message_fix(error.message))
+        error_message = hack_error_message_fix(error.message)
+        match = re.search("(.+) is a required property", error_message)
+        if match:
+            return ('Error: missing required property ' +
+                    match.group(1) +
+                    '. Add to JSON file and pass in /path/to/file with the' +
+                    ' --options argument.')
+        message = 'Error: {}\n'.format(error_message)
         if len(error.absolute_path) > 0:
             message += 'Path: {}\n'.format('.'.join(error.absolute_path))
         message += 'Value: {}'.format(json.dumps(error.instance))


### PR DESCRIPTION
```
Tamars-MacBook-Pro:dcos-cli tamar$ dcos package install mesos-dns
Installing package [mesos-dns] version [alpha]
Error: missing required property 'mesos-dns/config-url'. Add to json file and pass in file with --options.

Error: missing required property 'mesos-dns/host'. Add to json file and pass in file with --options.
```

instead of 

```
Tamars-MacBook-Pro:dcos-cli tamar$ dcos package install mesos-dns
Installing package [mesos-dns] version [alpha]
Error: 'mesos-dns/config-url' is a required property
Value: {}

Error: 'mesos-dns/host' is a required property
Value: {}
```
