### PR TITLE
list command in 'dcos package list-installed' -- DCOS-1142

### DIFF
--- a/cli/dcoscli/analytics.py
+++ b/cli/dcoscli/analytics.py
@@ -71,7 +71,7 @@ def _send_segment_event(event, properties):
         requests.post(SEGMENT_URL,
                       json=data,
                       auth=HTTPBasicAuth(key, ''),
-                      timeout=3)
+                      timeout=1)
     except Exception as e:
         logger.exception(e)
 

--- a/cli/tests/integrations/cli/common.py
+++ b/cli/tests/integrations/cli/common.py
@@ -30,3 +30,33 @@ def exec_command(cmd, env=None, stdin=None):
     print('STDERR: {}'.format(stderr.decode('utf-8')))
 
     return (process.returncode, stdout, stderr)
+
+
+def assert_command(cmd,
+                   returncode=0,
+                   stdout=b'',
+                   stderr=b'',
+                   env=None,
+                   stdin=None):
+    """Execute CLI command and assert expected behavior.
+
+    :param cmd: Program and arguments
+    :type cmd: list of str
+    :param returncode: Expected return code
+    :type returncode: int
+    :param stdout: Expected stdout
+    :type stdout: str
+    :param stderr: Expected stderr
+    :type stderr: str
+    :param env: Environment variables
+    :type env: dict of str to str
+    :param stdin: File to use for stdin
+    :type stdin: file
+    :rtype: None
+    """
+
+    returncode_, stdout_, stderr_ = exec_command(cmd, env, stdin)
+
+    assert returncode_ == returncode
+    assert stdout_ == stdout
+    assert stderr_ == stderr

--- a/cli/tests/integrations/cli/test_analytics.py
+++ b/cli/tests/integrations/cli/test_analytics.py
@@ -53,7 +53,7 @@ def test_no_exc():
         assert kwargs['json'] == {'anonymousId': ANON_ID,
                                   'event': SEGMENT_IO_CLI_EVENT,
                                   'properties': props}
-        assert kwargs['timeout'] == 3
+        assert kwargs['timeout'] == 1
 
         # rollbar
         assert rollbar.report_message.call_count == 0

--- a/dcos/api/subcommand.py
+++ b/dcos/api/subcommand.py
@@ -415,3 +415,50 @@ def _generic_error(package_name):
 
     return errors.DefaultError(
         'Error installing {!r} package'.format(package_name))
+
+
+class InstalledSubcommand(object):
+    """ Represents an installed subcommand.
+
+    :param name: The name of the subcommand
+    :type name: str
+    """
+
+    def __init__(self, name):
+        self.name = name
+
+    def _dir(self):
+        """
+        :returns: path to this subcommand's directory.
+        :rtype: (str, Error)
+        """
+
+        return package_dir(self.name)
+
+    def package_version(self):
+        """
+        :returns: this subcommand's version.
+        :rtype: (str, Error)
+        """
+
+        version_path = os.path.join(self._dir(), 'version')
+        return util.read_file(version_path)
+
+    def package_source(self):
+        """
+        :returns: this subcommand's source.
+        :rtype: (str, Error)
+        """
+
+        source_path = os.path.join(self._dir(), 'source')
+        return util.read_file(source_path)
+
+    def package_json(self):
+        """
+        :returns: contents of this subcommand's package.json file.
+        :rtype: (dict, Error)
+        """
+
+        package_json_path = os.path.join(self._dir(), 'package.json')
+        with open(package_json_path) as package_json_file:
+            return util.load_json(package_json_file)

--- a/dcos/api/util.py
+++ b/dcos/api/util.py
@@ -70,6 +70,26 @@ def ensure_dir(directory):
         os.makedirs(directory, 0o775)
 
 
+def read_file(path):
+    """
+    :param path: path to file
+    :type path: str
+    :returns: contents of file
+    :rtype: (str, Error)
+    """
+    if not os.path.isfile(path):
+        return (None, errors.DefaultError(
+            'Path [{}] is not a file'.format(path)))
+
+    try:
+        with open(path) as fd:
+            content = fd.read()
+            return (content, None)
+    except IOError:
+        return (None, errors.DefaultError(
+            'Unable to open file [{}]'.format(path)))
+
+
 def which(program):
     """Returns the path to the named executable program.
 
@@ -103,8 +123,7 @@ def dcos_path():
     """
 
     dcos_bin_dir = os.path.realpath(sys.argv[0])
-    dcos_dir = os.path.dirname(os.path.dirname(dcos_bin_dir))
-    return dcos_dir
+    return os.path.dirname(os.path.dirname(dcos_bin_dir))
 
 
 def configure_logger_from_environ():


### PR DESCRIPTION
`dcos package list-installed` used to list packages in the format:

```
[<app_dict>]
```

now:

```
[{'name': <name>,
  'app': <app_dict>, 
  'command': <command_name>}]
```

NOTE: There are a few dictionary formats defined ad-hoc in our code base.  `app_dict` is one of them.  This new package is another.  It took a while for me to figure out what exactly `app_dict` was.  It would help to create documented classes for these objects rather than constructing them ad-hoc in the code.

NOTE 2: It would be nice if by default `list-installed` prints one line per package similar to `dpkg -l`.  Current output seems excessive. 
