### PR TITLE
support --cli and --app in `dcos package describe` -- DCOS-1137

### DIFF
--- a/cli/tests/data/package/marathon.json
+++ b/cli/tests/data/package/marathon.json
@@ -1,0 +1,5 @@
+{
+    "marathon": {
+        "zk": "zk://localhost:2181/mesos"
+    }
+}

--- a/cli/tests/integrations/cli/test_package.py
+++ b/cli/tests/integrations/cli/test_package.py
@@ -13,7 +13,7 @@ def test_package():
 Usage:
     dcos package --config-schema
     dcos package --info
-    dcos package describe <package_name>
+    dcos package describe [--app --options=<file> --cli] <package_name>
     dcos package info
     dcos package install [--cli | [--app --app-id=<app_id]]
                          [--options=<file>]
@@ -108,23 +108,114 @@ def test_describe_nonexistent():
 def test_describe():
     stdout = b"""\
 {
-  "description": "DNS-based service discovery for Mesos.",
+  "description": "A cluster-wide init and control system for services in \
+cgroups or Docker containers.",
+  "framework": true,
+  "images": {
+    "icon-large": "https://downloads.mesosphere.io/marathon/assets/\
+icon-service-marathon-large.png",
+    "icon-medium": "https://downloads.mesosphere.io/marathon/assets/\
+icon-service-marathon-medium.png",
+    "icon-small": "https://downloads.mesosphere.io/marathon/assets/\
+icon-service-marathon-small.png"
+  },
   "maintainer": "support@mesosphere.io",
-  "name": "mesos-dns",
-  "postInstallNotes": "Please refer to the tutorial instructions for further \
-setup requirements: http://mesosphere.github.io/mesos-dns/docs/\
-tutorial-gce.html",
-  "scm": "https://github.com/mesosphere/mesos-dns.git",
+  "name": "marathon",
+  "scm": "https://github.com/mesosphere/marathon.git",
   "tags": [
-    "mesosphere"
+    "mesosphere",
+    "framework"
   ],
   "versions": [
-    "alpha"
-  ],
-  "website": "http://mesosphere.github.io/mesos-dns"
+    "0.8.1"
+  ]
 }
 """
-    assert_command(['dcos', 'package', 'describe', 'mesos-dns'],
+    assert_command(['dcos', 'package', 'describe', 'marathon'],
+                   stdout=stdout)
+
+    stdout = b"""\
+{
+  "command": {
+    "pip": [
+      "http://downloads.mesosphere.io/dcos-cli/\
+dcos-0.1.0-py2.py3-none-any.whl",
+      "git+https://github.com/mesosphere/\
+dcos-helloworld.git#dcos-helloworld=0.1.0"
+    ]
+  },
+  "description": "Example DCOS application package",
+  "maintainer": "support@mesosphere.io",
+  "name": "helloworld",
+  "tags": [
+    "mesosphere",
+    "example",
+    "subcommand"
+  ],
+  "versions": [
+    "0.1.0"
+  ],
+  "website": "https://github.com/mesosphere/dcos-helloworld"
+}
+"""
+    assert_command(['dcos', 'package', 'describe', '--cli', 'helloworld'],
+                   stdout=stdout)
+
+    stdout = b"""\
+{
+  "app": {
+    "cmd": "LIBPROCESS_PORT=$PORT1 && ./bin/start --master zk://master\
+.mesos:2181/mesos   --checkpoint    --failover_timeout 604800   --framework_\
+name marathon-user   --ha         --zk zk://localhost:2181/mesos/\
+marathon-user       --http_port $PORT0 ",
+    "constraints": [
+      [
+        "hostname",
+        "UNIQUE"
+      ]
+    ],
+    "container": {
+      "docker": {
+        "image": "mesosphere/marathon:v0.8.1",
+        "network": "HOST"
+      },
+      "type": "DOCKER"
+    },
+    "cpus": 1.0,
+    "id": "marathon-user",
+    "instances": 1,
+    "mem": 512.0,
+    "ports": [
+      0,
+      0
+    ],
+    "uris": []
+  },
+  "description": "A cluster-wide init and control system for services \
+in cgroups or Docker containers.",
+  "framework": true,
+  "images": {
+    "icon-large": "https://downloads.mesosphere.io/marathon/assets/\
+icon-service-marathon-large.png",
+    "icon-medium": "https://downloads.mesosphere.io/marathon/assets/\
+icon-service-marathon-medium.png",
+    "icon-small": "https://downloads.mesosphere.io/marathon/assets/\
+icon-service-marathon-small.png"
+  },
+  "maintainer": "support@mesosphere.io",
+  "name": "marathon",
+  "scm": "https://github.com/mesosphere/marathon.git",
+  "tags": [
+    "mesosphere",
+    "framework"
+  ],
+  "versions": [
+    "0.8.1"
+  ]
+}
+"""
+    assert_command(['dcos', 'package', 'describe', '--app', '--options',
+                    'tests/data/package/marathon.json', 'marathon'],
                    stdout=stdout)
 
 


### PR DESCRIPTION
Prior to this, describe only printed the package.json contents.  I've augmented this dictionary with 'app' and 'command' keys if the user provides --app and/or --cli, respectively.  These contain marathon.json and command.json, rendered with config.json and no user options.

One oddity is that it seems that in the `describe` output, the 'version' field is rewritten to include all software versions supported by any version of the package.  I don't know why we do this, because AFAICT, we only support installing the most recent package.  So I don't know why we're presenting all of those versions to the user.

But I'm only including the marathon.json and command.json of the most recent version of the package.  So describe can now output this:

```
{
  ...
  versions: ['1.0', '2.0', '3.0']
  marathon: {...}
  command: {...}
}
```

where `marathon` and `command` only correspond to the package that exports '3.0'

Let me know what you think, or if this made no sense whatsoever.
