### PR TITLE
remove validation check for `config unset`

### DIFF
--- a/cli/dcoscli/config/main.py
+++ b/cli/dcoscli/config/main.py
@@ -60,7 +60,7 @@ def _main():
     return cmds.execute(_cmds(), args)
 
 
-def compare_validations(toml_config_pre, toml_config_post):
+def _check_config(toml_config_pre, toml_config_post):
     """
     :param toml_config_pre: dictionary for the value before change
     :type toml_config_pre: dcos.api.config.Toml
@@ -172,7 +172,7 @@ def _set(name, value):
 
     _save_config_file(config_path, toml_config)
 
-    compare_validations(toml_config_pre, toml_config)
+    _check_config(toml_config_pre, toml_config)
 
     _save_config_file(config_path, toml_config)
     return 0
@@ -194,7 +194,7 @@ def _append(name, value):
 
     toml_config[name] = toml_config.get(name, []) + python_value
 
-    compare_validations(toml_config_pre, toml_config)
+    _check_config(toml_config_pre, toml_config)
 
     _save_config_file(config_path, toml_config)
     return 0
@@ -215,7 +215,7 @@ def _prepend(name, value):
     if section not in toml_config_pre._dictionary:
         toml_config_pre._dictionary[section] = {}
     toml_config[name] = python_value + toml_config.get(name, [])
-    compare_validations(toml_config_pre, toml_config)
+    _check_config(toml_config_pre, toml_config)
 
     _save_config_file(config_path, toml_config)
     return 0
@@ -252,8 +252,6 @@ def _unset(name, index):
     elif index is not None:
         raise DCOSException(
             'Unsetting based on an index is only supported for lists')
-
-    compare_validations(toml_config_pre, toml_config)
 
     _save_config_file(config_path, toml_config)
     return 0

--- a/cli/tests/integrations/test_config.py
+++ b/cli/tests/integrations/test_config.py
@@ -276,15 +276,21 @@ def test_validate(env):
 
 
 def test_validation_error(env):
-    stderr = b"Error: missing required property 'sources'.\n"
+    source = ["https://github.com/mesosphere/universe/archive/version-1.x.zip"]
+    assert_command(['dcos', 'config', 'unset', 'package.sources'], env=env)
 
-    assert_command(['dcos', 'config', 'unset', 'package.sources'],
+    stdout = b"Error: missing required property 'sources'.\n"
+    assert_command(['dcos', 'config', 'validate'],
                    returncode=1,
-                   stderr=stderr,
+                   stdout=stdout,
+                   env=env)
+
+    assert_command(['dcos', 'config', 'set', 'package.sources',
+                   json.dumps(source)],
                    env=env)
     _get_value(
         'package.sources',
-        ["https://github.com/mesosphere/universe/archive/version-1.x.zip"],
+        source,
         env)
 
 


### PR DESCRIPTION
validations for unset make it impossible to unset old config names or required properties. See discussion in jira DCOS-1507. Always allowing a user to unset any property seems reasonable. If it causes them to accidentally unset something they need, they will be told so in a future command that needs that property. 
