### PR TITLE
Feature/framework id support

### DIFF
--- a/cli/dcoscli/data/help/task.txt
+++ b/cli/dcoscli/data/help/task.txt
@@ -2,13 +2,15 @@ Manage DCOS tasks
 
 Usage:
     dcos task --info
-    dcos task [--completed --json <task>]
-    dcos task log [--completed --follow --lines=N] <task> [<file>]
-    dcos task ls [--long] <task> [<path>]
+    dcos task [--completed] [--json] [--framework=<framework_id>] [<task>]
+    dcos task log [--completed] [--follow] [--lines=N] [--framework=<framework_id>] <task> [<file>]
+    dcos task ls [--long] [--framework=<framework_id>] <task> [<path>]
 
 Options:
     -h, --help    Show this screen
     --info        Show a short description of this subcommand
+    --framework=<framework_id>
+                  All tasks related to this framework_id
     --completed   Include completed tasks as well
     --follow      Print data as the file grows
     --json        Print json-formatted tasks

--- a/cli/dcoscli/task/main.py
+++ b/cli/dcoscli/task/main.py
@@ -189,9 +189,8 @@ def _ls(fltr, path, long_, framework_id=None):
     tasks = _get_tasks(completed=True, fltr=fltr,
                        framework_id=framework_id)
     for task_obj in tasks:
-        print("Task: {} ({} on {})".format(task_obj["id"],
-                                           task_obj["framework_id"],
-                                           task_obj["slave_id"]))
+        emitter.publish("Task: {} ({} on {})".format(task_obj["id"],
+                        task_obj["framework_id"], task_obj["slave_id"]))
         dir_ = posixpath.join(task_obj.directory(), path)
 
         try:

--- a/cli/dcoscli/task/main.py
+++ b/cli/dcoscli/task/main.py
@@ -55,7 +55,7 @@ def _cmds():
         cmds.Command(
             hierarchy=['task', 'log'],
             arg_keys=['--follow', '--completed', '--lines', '<task>',
-                      '<file>'],
+                      '<file>', '--framework'],
             function=_log),
 
         cmds.Command(

--- a/cli/dcoscli/task/main.py
+++ b/cli/dcoscli/task/main.py
@@ -189,8 +189,9 @@ def _ls(fltr, path, long_, framework_id=None):
     tasks = _get_tasks(completed=True, fltr=fltr,
                        framework_id=framework_id)
     for task_obj in tasks:
-        emitter.publish("Task: {} ({} on {})".format(task_obj["id"],
-                        task_obj["framework_id"], task_obj["slave_id"]))
+        if len(tasks) != 1:
+            emitter.publish("===> {} ({} on {}) <===".format(task_obj["id"],
+                            task_obj["framework_id"], task_obj["slave_id"]))
         dir_ = posixpath.join(task_obj.directory(), path)
 
         try:

--- a/dcos/mesos.py
+++ b/dcos/mesos.py
@@ -707,7 +707,9 @@ class Task(object):
                            ['completed_tasks',
                             'tasks',
                             'queued_tasks'])
-            if any(task['id'] == self['id'] for task in tasks):
+            if any(task['id'] == self['id'] and 
+                   task.get('framework_id',None) == self['framework_id']
+                   for task in tasks):
                 return executor
         return None
 

--- a/dcos/mesos.py
+++ b/dcos/mesos.py
@@ -410,21 +410,25 @@ class Master(object):
                 for slave in self.state()['slaves']
                 if fltr in slave['id']]
 
-    def tasks(self, fltr="", completed=False):
+    def tasks(self, fltr="", completed=False, active=True,):
         """Returns tasks running under the master
 
         :param fltr: May be a substring or regex.  Only return tasks
                      whose 'id' matches `fltr`.
         :type fltr: str
-        :param completed: also include completed tasks
+        :param completed: include completed tasks
         :type completed: bool
+        :param active: include active tasks
+        :type active: bool
         :returns: a list of tasks
         :rtype: [Task]
         """
 
-        keys = ['tasks']
+        keys = []
+        if active:
+            keys.append('tasks')
         if completed:
-            keys = ['completed_tasks']
+            keys.append('completed_tasks')
 
         tasks = []
         for framework in self._framework_dicts(completed, completed):

--- a/dcos/mesos.py
+++ b/dcos/mesos.py
@@ -410,7 +410,7 @@ class Master(object):
                 for slave in self.state()['slaves']
                 if fltr in slave['id']]
 
-    def tasks(self, fltr="", completed=False, active=True,):
+    def tasks(self, fltr="", completed=False, active=True, framework_id=None):
         """Returns tasks running under the master
 
         :param fltr: May be a substring or regex.  Only return tasks
@@ -420,6 +420,8 @@ class Master(object):
         :type completed: bool
         :param active: include active tasks
         :type active: bool
+        :param framework_id: framework_id to filter by
+        :type framework_id: str
         :returns: a list of tasks
         :rtype: [Task]
         """
@@ -432,6 +434,7 @@ class Master(object):
 
         tasks = []
         for framework in self._framework_dicts(completed, completed):
+            if not framework_id or framework['id'] == framework_id:
             for task in _merge(framework, keys):
                 if fltr in task['id'] or fnmatch.fnmatchcase(task['id'], fltr):
                     task = self._framework_obj(framework).task(task['id'])

--- a/dcos/mesos.py
+++ b/dcos/mesos.py
@@ -435,10 +435,10 @@ class Master(object):
         tasks = []
         for framework in self._framework_dicts(completed, completed):
             if not framework_id or framework['id'] == framework_id:
-            for task in _merge(framework, keys):
-                if fltr in task['id'] or fnmatch.fnmatchcase(task['id'], fltr):
-                    task = self._framework_obj(framework).task(task['id'])
-                    tasks.append(task)
+                for task in _merge(framework, keys):
+                    if fltr in task['id'] or fnmatch.fnmatchcase(task['id'], fltr):
+                        task = self._framework_obj(framework).task(task['id'])
+                        tasks.append(task)
 
         return tasks
 


### PR DESCRIPTION
This adds the ability to find/list/log tasks filtered by framework ID.  Some frameworks (Spark for example) don't provide very unique task IDs and this is easier into the bargain.

It also fixes one issue with mesos.py where when "completed" was set, _only_ completed tasks were returned (the documentation claimed both were).

One buglet I can't see how to resolve is that the argument parsing forces the user to provide a task name for the "ls" and "logs" commands (I've tried a few approaches to no avail).