### PR TITLE
be less strict in mesos schema checks

### DIFF
--- a/cli/tests/data/package/json/test_describe_app_options.json
+++ b/cli/tests/data/package/json/test_describe_app_options.json
@@ -13,7 +13,7 @@
     },
     "type": "DOCKER"
   },
-  "cpus": 2.0,
+  "cpus": 2,
   "env": {
     "JVM_OPTS": "-Xms256m -Xmx768m"
   },
@@ -31,7 +31,6 @@
   "id": "marathon-user",
   "instances": 1,
   "labels": {
-    "DCOS_PACKAGE_FRAMEWORK_NAME": "marathon-user",
     "DCOS_PACKAGE_IS_FRAMEWORK": "true",
     "DCOS_PACKAGE_METADATA": "eyJsaWNlbnNlcyI6W3sibmFtZSI6IkFwYWNoZSBMaWNlbnNlIFZlcnNpb24gMi4wIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL21lc29zcGhlcmUvbWFyYXRob24vYmxvYi9tYXN0ZXIvTElDRU5TRSJ9XSwibmFtZSI6Im1hcmF0aG9uIiwicG9zdEluc3RhbGxOb3RlcyI6Ik1hcmF0aG9uIERDT1MgU2VydmljZSBoYXMgYmVlbiBzdWNjZXNzZnVsbHkgaW5zdGFsbGVkIVxuXG5cdERvY3VtZW50YXRpb246IGh0dHBzOi8vbWVzb3NwaGVyZS5naXRodWIuaW8vbWFyYXRob25cblx0SXNzdWVzOiBodHRwczovZ2l0aHViLmNvbS9tZXNvc3BoZXJlL21hcmF0aG9uL2lzc3Vlc1xuIiwic2NtIjoiaHR0cHM6Ly9naXRodWIuY29tL21lc29zcGhlcmUvbWFyYXRob24uZ2l0IiwiZGVzY3JpcHRpb24iOiJBIGNsdXN0ZXItd2lkZSBpbml0IGFuZCBjb250cm9sIHN5c3RlbSBmb3Igc2VydmljZXMgaW4gY2dyb3VwcyBvciBEb2NrZXIgY29udGFpbmVycy4iLCJwYWNrYWdpbmdWZXJzaW9uIjoiMi4wIiwidGFncyI6WyJpbml0IiwibG9uZy1ydW5uaW5nIl0sInBvc3RVbmluc3RhbGxOb3RlcyI6IlRoZSBNYXJhdGhvbiBEQ09TIFNlcnZpY2UgaGFzIGJlZW4gdW5pbnN0YWxsZWQgYW5kIHdpbGwgbm8gbG9uZ2VyIHJ1bi5cblBsZWFzZSBmb2xsb3cgdGhlIGluc3RydWN0aW9ucyBhdCBodHRwOi8vZG9jcy5tZXNvc3BoZXJlLmNvbS9zZXJ2aWNlcy9tYXJhdGhvbi8jdW5pbnN0YWxsIHRvIGNsZWFuIHVwIGFueSBwZXJzaXN0ZWQgc3RhdGUiLCJtYWludGFpbmVyIjoic3VwcG9ydEBtZXNvc3BoZXJlLmlvIiwiZnJhbWV3b3JrIjp0cnVlLCJ2ZXJzaW9uIjoiMC4xMS4xIiwicHJlSW5zdGFsbE5vdGVzIjoiV2UgcmVjb21tZW5kIGEgbWluaW11bSBvZiBvbmUgbm9kZSB3aXRoIGF0IGxlYXN0IDIgQ1BVJ3MgYW5kIDFHQiBvZiBSQU0gYXZhaWxhYmxlIGZvciB0aGUgTWFyYXRob24gU2VydmljZS4iLCJpbWFnZXMiOnsiaWNvbi1zbWFsbCI6Imh0dHBzOi8vZG93bmxvYWRzLm1lc29zcGhlcmUuY29tL21hcmF0aG9uL2Fzc2V0cy9pY29uLXNlcnZpY2UtbWFyYXRob24tc21hbGwucG5nIiwiaWNvbi1tZWRpdW0iOiJodHRwczovL2Rvd25sb2Fkcy5tZXNvc3BoZXJlLmNvbS9tYXJhdGhvbi9hc3NldHMvaWNvbi1zZXJ2aWNlLW1hcmF0aG9uLW1lZGl1bS5wbmciLCJpY29uLWxhcmdlIjoiaHR0cHM6Ly9kb3dubG9hZHMubWVzb3NwaGVyZS5jb20vbWFyYXRob24vYXNzZXRzL2ljb24tc2VydmljZS1tYXJhdGhvbi1sYXJnZS5wbmciLCJzY3JlZW5zaG90cyI6bnVsbH19",
     "DCOS_PACKAGE_NAME": "marathon",
@@ -40,7 +39,7 @@
     "DCOS_PACKAGE_SOURCE": "https://github.com/mesosphere/universe/archive/cli-test-4.zip",
     "DCOS_PACKAGE_VERSION": "0.11.1"
   },
-  "mem": 1024.0,
+  "mem": 1024,
   "ports": [
     0,
     0

--- a/cli/tests/data/package/json/test_describe_marathon_app_render.json
+++ b/cli/tests/data/package/json/test_describe_marathon_app_render.json
@@ -13,7 +13,7 @@
     },
     "type": "DOCKER"
   },
-  "cpus": 2.0,
+  "cpus": 2,
   "env": {
     "JVM_OPTS": "-Xms256m -Xmx768m"
   },
@@ -31,7 +31,6 @@
   "id": "marathon-user",
   "instances": 1,
   "labels": {
-    "DCOS_PACKAGE_FRAMEWORK_NAME": "marathon-user",
     "DCOS_PACKAGE_IS_FRAMEWORK": "true",
     "DCOS_PACKAGE_METADATA": "eyJsaWNlbnNlcyI6W3sibmFtZSI6IkFwYWNoZSBMaWNlbnNlIFZlcnNpb24gMi4wIiwidXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL21lc29zcGhlcmUvbWFyYXRob24vYmxvYi9tYXN0ZXIvTElDRU5TRSJ9XSwibmFtZSI6Im1hcmF0aG9uIiwicG9zdEluc3RhbGxOb3RlcyI6Ik1hcmF0aG9uIERDT1MgU2VydmljZSBoYXMgYmVlbiBzdWNjZXNzZnVsbHkgaW5zdGFsbGVkIVxuXG5cdERvY3VtZW50YXRpb246IGh0dHBzOi8vbWVzb3NwaGVyZS5naXRodWIuaW8vbWFyYXRob25cblx0SXNzdWVzOiBodHRwczovZ2l0aHViLmNvbS9tZXNvc3BoZXJlL21hcmF0aG9uL2lzc3Vlc1xuIiwic2NtIjoiaHR0cHM6Ly9naXRodWIuY29tL21lc29zcGhlcmUvbWFyYXRob24uZ2l0IiwiZGVzY3JpcHRpb24iOiJBIGNsdXN0ZXItd2lkZSBpbml0IGFuZCBjb250cm9sIHN5c3RlbSBmb3Igc2VydmljZXMgaW4gY2dyb3VwcyBvciBEb2NrZXIgY29udGFpbmVycy4iLCJwYWNrYWdpbmdWZXJzaW9uIjoiMi4wIiwidGFncyI6WyJpbml0IiwibG9uZy1ydW5uaW5nIl0sInBvc3RVbmluc3RhbGxOb3RlcyI6IlRoZSBNYXJhdGhvbiBEQ09TIFNlcnZpY2UgaGFzIGJlZW4gdW5pbnN0YWxsZWQgYW5kIHdpbGwgbm8gbG9uZ2VyIHJ1bi5cblBsZWFzZSBmb2xsb3cgdGhlIGluc3RydWN0aW9ucyBhdCBodHRwOi8vZG9jcy5tZXNvc3BoZXJlLmNvbS9zZXJ2aWNlcy9tYXJhdGhvbi8jdW5pbnN0YWxsIHRvIGNsZWFuIHVwIGFueSBwZXJzaXN0ZWQgc3RhdGUiLCJtYWludGFpbmVyIjoic3VwcG9ydEBtZXNvc3BoZXJlLmlvIiwiZnJhbWV3b3JrIjp0cnVlLCJ2ZXJzaW9uIjoiMC4xMS4xIiwicHJlSW5zdGFsbE5vdGVzIjoiV2UgcmVjb21tZW5kIGEgbWluaW11bSBvZiBvbmUgbm9kZSB3aXRoIGF0IGxlYXN0IDIgQ1BVJ3MgYW5kIDFHQiBvZiBSQU0gYXZhaWxhYmxlIGZvciB0aGUgTWFyYXRob24gU2VydmljZS4iLCJpbWFnZXMiOnsiaWNvbi1zbWFsbCI6Imh0dHBzOi8vZG93bmxvYWRzLm1lc29zcGhlcmUuY29tL21hcmF0aG9uL2Fzc2V0cy9pY29uLXNlcnZpY2UtbWFyYXRob24tc21hbGwucG5nIiwiaWNvbi1tZWRpdW0iOiJodHRwczovL2Rvd25sb2Fkcy5tZXNvc3BoZXJlLmNvbS9tYXJhdGhvbi9hc3NldHMvaWNvbi1zZXJ2aWNlLW1hcmF0aG9uLW1lZGl1bS5wbmciLCJpY29uLWxhcmdlIjoiaHR0cHM6Ly9kb3dubG9hZHMubWVzb3NwaGVyZS5jb20vbWFyYXRob24vYXNzZXRzL2ljb24tc2VydmljZS1tYXJhdGhvbi1sYXJnZS5wbmciLCJzY3JlZW5zaG90cyI6bnVsbH19",
     "DCOS_PACKAGE_NAME": "marathon",
@@ -40,7 +39,7 @@
     "DCOS_PACKAGE_SOURCE": "https://github.com/mesosphere/universe/archive/cli-test-4.zip",
     "DCOS_PACKAGE_VERSION": "0.11.1"
   },
-  "mem": 1024.0,
+  "mem": 1024,
   "ports": [
     0,
     0

--- a/cli/tests/integrations/common.py
+++ b/cli/tests/integrations/common.py
@@ -6,9 +6,8 @@ import pty
 import subprocess
 import time
 
-import requests
 import six
-from dcos import util
+from dcos import http, util
 
 from six.moves import urllib
 
@@ -326,7 +325,7 @@ def delete_zk_node(znode):
     znode_url = urllib.parse.urljoin(
         dcos_url,
         '/exhibitor/exhibitor/v1/explorer/znode/{}'.format(znode))
-    requests.delete(znode_url)
+    http.delete(znode_url)
 
 
 def assert_lines(cmd, num_lines):

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -185,6 +185,7 @@ def _node_ssh(args):
 
 def _get_schema(slave):
     schema = create_schema(slave)
+    schema['additionalProperties'] = True
     schema['required'].remove('reregistered_time')
 
     schema['required'].remove('reserved_resources')

--- a/cli/tests/integrations/test_package.py
+++ b/cli/tests/integrations/test_package.py
@@ -16,6 +16,8 @@ from .common import (assert_command, assert_lines, delete_zk_node,
 
 def setup_module(module):
     assert_command(
+        ['dcos', 'package', 'repo', 'remove', 'Universe-1.7'])
+    assert_command(
         ['dcos', 'package', 'repo', 'remove', 'Universe'])
     repo = "https://github.com/mesosphere/universe/archive/cli-test-4.zip"
     assert_command(['dcos', 'package', 'repo', 'add', 'test4', repo])
@@ -24,6 +26,8 @@ def setup_module(module):
 def teardown_module(module):
     assert_command(
         ['dcos', 'package', 'repo', 'remove', 'test4'])
+    repo17 = "https://universe.mesosphere.com/repo-1.7"
+    assert_command(['dcos', 'package', 'repo', 'add', 'Universe-1.7', repo17])
     repo = "https://universe.mesosphere.com/repo"
     assert_command(['dcos', 'package', 'repo', 'add', 'Universe', repo])
 
@@ -324,7 +328,7 @@ def test_bad_install_marathon_msg():
 
     stderr = (b'Object is not valid\n'
               b'Groups and Applications may not have the same '
-              b'identifier: /foo\n')
+              b'identifier.\n')
 
     _install_helloworld(['--yes', '--app-id=/foo/bar'],
                         stdout=stdout2,

--- a/cli/tests/integrations/test_service.py
+++ b/cli/tests/integrations/test_service.py
@@ -16,6 +16,11 @@ from .common import (assert_command, assert_lines, delete_zk_node,
 
 
 def setup_module(module):
+    exec_command(['dcos', 'package', 'repo', 'remove', 'Universe-1.7'])
+    exec_command(
+        ['dcos', 'package', 'repo', 'remove', 'Universe'])
+    repo = "https://github.com/mesosphere/universe/archive/cli-test-4.zip"
+    assert_command(['dcos', 'package', 'repo', 'add', 'test4', repo])
     package_install('chronos', True)
 
 
@@ -28,6 +33,12 @@ def teardown_module(module):
                b'mesosphere.com/services/chronos/#uninstall to clean up any '
                b'persisted state\n')
     delete_zk_nodes()
+    assert_command(
+        ['dcos', 'package', 'repo', 'remove', 'test4'])
+    repo17 = "https://universe.mesosphere.com/repo-1.7"
+    assert_command(['dcos', 'package', 'repo', 'add', 'Universe-1.7', repo17])
+    repo = "https://universe.mesosphere.com/repo"
+    assert_command(['dcos', 'package', 'repo', 'add', 'Universe', repo])
 
 
 def test_help():
@@ -252,5 +263,6 @@ def _get_schema(service):
     schema['properties']['offered_resources']['required'].remove('ports')
     schema['properties']['resources']['required'].remove('ports')
     schema['properties']['used_resources']['required'].remove('ports')
+    schema['additionalProperties'] = True
 
     return schema

--- a/cli/tests/integrations/test_task.py
+++ b/cli/tests/integrations/test_task.py
@@ -64,6 +64,7 @@ def test_task():
     assert len(tasks) == NUM_TASKS
 
     schema = create_schema(task_fixture().dict())
+    schema['additionalProperties'] = True
     schema['required'].remove('labels')
 
     for task in tasks:

--- a/dcos/cosmospackage.py
+++ b/dcos/cosmospackage.py
@@ -1,7 +1,9 @@
+import collections
 import functools
 import json
 
 import pystache
+import six
 from dcos import emitting, http, util
 from dcos.errors import (DCOSAuthenticationException,
                          DCOSAuthorizationException, DCOSException,
@@ -566,5 +568,10 @@ def _format_marathon_bad_response_message(error):
     data = error.get("data")
     error_messages = [error.get("message")]
     if data is not None:
-        error_messages += [err.get("error") for err in data.get("errors")]
+        for err in data.get("errors"):
+            if err.get("error") and isinstance(err["error"], six.string_types):
+                error_messages += [err["error"]]
+            elif err.get("errors") and \
+                    isinstance(err["errors"], collections.Sequence):
+                error_messages += err["errors"]
     return "\n".join(error_messages)


### PR DESCRIPTION
We shouldn't fail when mesos adds new properties, instead verify
specific properties