### PR TITLE
limit length of description in search table

### DIFF
--- a/cli/dcoscli/tables.py
+++ b/cli/dcoscli/tables.py
@@ -302,7 +302,8 @@ def package_search_table(search_results):
         ('VERSION', lambda p: p['currentVersion']),
         ('SELECTED', lambda p: p.get("selected", False)),
         ('FRAMEWORK', lambda p: p['framework']),
-        ('DESCRIPTION', lambda p: p['description'])
+        ('DESCRIPTION', lambda p: p['description']
+            if len(p['description']) < 77 else p['description'][0:77] + "...")
     ])
 
     packages = []

--- a/cli/tests/unit/data/package_search.txt
+++ b/cli/tests/unit/data/package_search.txt
@@ -1,8 +1,8 @@
-NAME        VERSION                               SELECTED  FRAMEWORK  DESCRIPTION                                                                                       
-cassandra   0.1.0-SNAPSHOT-447-master-3ad1bbf8f7  False     True       Apache Cassandra running on Apache Mesos                                                          
-chronos     2.3.4                                 False     True       A fault tolerant job scheduler for Mesos which handles dependencies and ISO8601 based schedules.  
-hdfs        0.1.1                                 False     True       Hadoop Distributed File System (HDFS), Highly Available                                           
-helloworld  0.1.0                                 False     False      Example DCOS application package                                                                  
-kafka       0.9.0-beta                            False     True       Apache Kafka running on top of Apache Mesos                                                       
-marathon    0.8.1                                 False     True       A cluster-wide init and control system for services in cgroups or Docker containers.              
-spark       1.4.0-SNAPSHOT                        False     True       Spark is a fast and general cluster computing system for Big Data                                 
+NAME        VERSION                               SELECTED  FRAMEWORK  DESCRIPTION                                                                       
+cassandra   0.1.0-SNAPSHOT-447-master-3ad1bbf8f7  False     True       Apache Cassandra running on Apache Mesos                                          
+chronos     2.3.4                                 False     True       A fault tolerant job scheduler for Mesos which handles dependencies and ISO86...  
+hdfs        0.1.1                                 False     True       Hadoop Distributed File System (HDFS), Highly Available                           
+helloworld  0.1.0                                 False     False      Example DCOS application package                                                  
+kafka       0.9.0-beta                            False     True       Apache Kafka running on top of Apache Mesos                                       
+marathon    0.8.1                                 False     True       A cluster-wide init and control system for services in cgroups or Docker cont...  
+spark       1.4.0-SNAPSHOT                        False     True       Spark is a fast and general cluster computing system for Big Data                 


### PR DESCRIPTION
PrettyTable renders each row to be the width of the largest row.
Packages with long descriptions make the table very hard to read.