### PR TITLE
Make dcos task ls work for completed tasks

### DIFF
--- a/cli/dcoscli/data/help/task.txt
+++ b/cli/dcoscli/data/help/task.txt
@@ -5,7 +5,7 @@ Usage:
     dcos task --info
     dcos task [--completed --json <task>]
     dcos task log [--completed --follow --lines=N] <task> [<file>]
-    dcos task ls [--long] <task> [<path>]
+    dcos task ls [--long --completed] <task> [<path>]
 
 Command:
     log

--- a/cli/dcoscli/task/main.py
+++ b/cli/dcoscli/task/main.py
@@ -50,7 +50,7 @@ def _cmds():
 
         cmds.Command(
             hierarchy=['task', 'ls'],
-            arg_keys=['<task>', '<path>', '--long'],
+            arg_keys=['<task>', '<path>', '--long', '--completed'],
             function=_ls),
 
         cmds.Command(
@@ -159,7 +159,7 @@ def _log(follow, completed, lines, task, file_):
     return 0
 
 
-def _ls(task, path, long_):
+def _ls(task, path, long_, completed):
     """ List files in a task's sandbox.
 
     :param task: task pattern to match
@@ -168,6 +168,8 @@ def _ls(task, path, long_):
     :type path: str
     :param long_: whether to use a long listing format
     :type long_: bool
+    :param completed: If True, include completed tasks
+    :type completed: bool
     :returns: process return code
     :rtype: int
     """
@@ -178,7 +180,8 @@ def _ls(task, path, long_):
         path = path[1:]
 
     dcos_client = mesos.DCOSClient()
-    task_obj = mesos.get_master(dcos_client).task(task)
+    task_obj = mesos.get_master(dcos_client).task(
+                   fltr=task, completed=completed)
     dir_ = posixpath.join(task_obj.directory(), path)
 
     try:

--- a/cli/tests/data/help/task.txt
+++ b/cli/tests/data/help/task.txt
@@ -5,7 +5,7 @@ Usage:
     dcos task --info
     dcos task [--completed --json <task>]
     dcos task log [--completed --follow --lines=N] <task> [<file>]
-    dcos task ls [--long] <task> [<path>]
+    dcos task ls [--long --completed] <task> [<path>]
 
 Command:
     log

--- a/cli/tests/integrations/test_task.py
+++ b/cli/tests/integrations/test_task.py
@@ -257,6 +257,21 @@ def test_ls_bad_path():
         returncode=1)
 
 
+def test_ls_completed():
+    """ Test `dcos task ls --completed` """
+    assert_command(
+        ['dcos', 'task', 'ls', 'test-app-completed'],
+        stdout=b'',
+        stderr=b'Cannot find a task with ID containing "test-app-completed"\n',
+        returncode=1)
+
+    assert_command(
+        ['dcos', 'task', 'ls', '--completed', 'test-app-completed'],
+        stdout=b'stderr  stderr.logrotate.conf  stdout  stdout.logrotate.conf\n',
+        stderr=b'',
+        returncode=0)
+
+
 def _mark_non_blocking(file_):
     fcntl.fcntl(file_.fileno(), fcntl.F_SETFL, os.O_NONBLOCK)
 

--- a/dcos/mesos.py
+++ b/dcos/mesos.py
@@ -358,17 +358,19 @@ class Master(object):
         else:
             return slaves[0]
 
-    def task(self, fltr):
+    def task(self, fltr, completed=False):
         """Returns the task with `fltr` in its ID.  Raises a DCOSException if
         there is not exactly one such task.
 
         :param fltr: filter string
         :type fltr: str
         :returns: the task that has `fltr` in its ID
+        :param completed: also include completed tasks
+        :type completed: bool
         :rtype: Task
         """
 
-        tasks = self.tasks(fltr)
+        tasks = self.tasks(fltr, completed)
 
         if len(tasks) == 0:
             raise DCOSException(


### PR DESCRIPTION
This is for https://dcosjira.atlassian.net/browse/DCOS-81

I have tested for 2 cases and got expected results: 
1) If the task is completed and has entry on both master and slave --> ls successfully lists file
2) If the task is listed on master but the sandbox is deletec from the slave --> Cannot find a task with ID containing "driver-20160504203014-0002"

@tamarrow @jsancio I'm sure there would be cases I haves missed. Let me know if any comes to your mind and I will test for those.
