### PR TITLE
Make --completed great again

### DIFF
--- a/cli/dcoscli/data/help/task.txt
+++ b/cli/dcoscli/data/help/task.txt
@@ -5,7 +5,7 @@ Usage:
     dcos task --info
     dcos task [--completed --json <task>]
     dcos task log [--completed --follow --lines=N] <task> [<file>]
-    dcos task ls [--long] <task> [<path>]
+    dcos task ls [--long --completed] <task> [<path>]
 
 Command:
     log

--- a/cli/dcoscli/task/main.py
+++ b/cli/dcoscli/task/main.py
@@ -50,7 +50,7 @@ def _cmds():
 
         cmds.Command(
             hierarchy=['task', 'ls'],
-            arg_keys=['<task>', '<path>', '--long'],
+            arg_keys=['<task>', '<path>', '--long', '--completed'],
             function=_ls),
 
         cmds.Command(
@@ -159,7 +159,7 @@ def _log(follow, completed, lines, task, file_):
     return 0
 
 
-def _ls(task, path, long_):
+def _ls(task, path, long_, completed):
     """ List files in a task's sandbox.
 
     :param task: task pattern to match
@@ -168,6 +168,8 @@ def _ls(task, path, long_):
     :type path: str
     :param long_: whether to use a long listing format
     :type long_: bool
+    :param completed: If True, include completed tasks
+    :type completed: bool
     :returns: process return code
     :rtype: int
     """
@@ -178,7 +180,8 @@ def _ls(task, path, long_):
         path = path[1:]
 
     dcos_client = mesos.DCOSClient()
-    task_obj = mesos.get_master(dcos_client).task(task)
+    task_obj = mesos.get_master(dcos_client).task(
+                   fltr=task, completed=completed)
     dir_ = posixpath.join(task_obj.directory(), path)
 
     try:

--- a/cli/tests/data/help/task.txt
+++ b/cli/tests/data/help/task.txt
@@ -5,7 +5,7 @@ Usage:
     dcos task --info
     dcos task [--completed --json <task>]
     dcos task log [--completed --follow --lines=N] <task> [<file>]
-    dcos task ls [--long] <task> [<path>]
+    dcos task ls [--long --completed] <task> [<path>]
 
 Command:
     log

--- a/cli/tests/data/marathon/apps/sleep-completed1.json
+++ b/cli/tests/data/marathon/apps/sleep-completed1.json
@@ -1,0 +1,11 @@
+{
+    "id": "test-app-completed1",
+    "cmd": "sleep 1000",
+    "cpus": 0.1,
+    "mem": 16,
+    "instances": 1,
+    "labels": {
+        "PACKAGE_ID": "test-app",
+        "PACKAGE_VERSION": "1.2.3"
+    }
+}

--- a/cli/tests/integrations/test_task.py
+++ b/cli/tests/integrations/test_task.py
@@ -77,13 +77,13 @@ def test_task_table():
 
 def test_task_completed():
     returncode, stdout, stderr = exec_command(
-        ['dcos', 'task', '--completed', '--json'])
+        ['dcos', 'task', '--completed', '--json', '*-app*'])
     assert returncode == 0
     assert stderr == b''
     assert len(json.loads(stdout.decode('utf-8'))) > NUM_TASKS
 
     returncode, stdout, stderr = exec_command(
-        ['dcos', 'task', '--json'])
+        ['dcos', 'task', '--json', '*-app*'])
     assert returncode == 0
     assert stderr == b''
     assert len(json.loads(stdout.decode('utf-8'))) == NUM_TASKS

--- a/cli/tests/integrations/test_task.py
+++ b/cli/tests/integrations/test_task.py
@@ -14,6 +14,7 @@ from .common import (add_app, app, assert_command, assert_lines,
                      exec_command, remove_app, watch_all_deployments)
 
 SLEEP_COMPLETED = 'tests/data/marathon/apps/sleep-completed.json'
+SLEEP_COMPLETED1 = 'tests/data/marathon/apps/sleep-completed1.json'
 SLEEP1 = 'tests/data/marathon/apps/sleep1.json'
 SLEEP2 = 'tests/data/marathon/apps/sleep2.json'
 FOLLOW = 'tests/data/file/follow.json'
@@ -257,6 +258,30 @@ def test_ls_bad_path():
         returncode=1)
 
 
+def test_ls_completed():
+    # create a completed task
+    with app(SLEEP_COMPLETED1, 'test-app-completed1'):
+        # get its task id
+        task_id_completed = _get_completed_task_id('test-app-completed1')
+
+    """ Test `dcos task ls --completed` """
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'task', 'ls', task_id_completed])
+
+    err = b'Cannot find a task with ID containing "test-app-completed1'
+    assert returncode == 1
+    assert stdout == b''
+    assert stderr.startswith(err)
+
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'task', 'ls', '--completed', task_id_completed])
+
+    out = b'stderr  stderr.logrotate.conf  stdout  stdout.logrotate.conf\n'
+    assert returncode == 0
+    assert stdout == out
+    assert stderr == b''
+
+
 def _mark_non_blocking(file_):
     fcntl.fcntl(file_.fileno(), fcntl.F_SETFL, os.O_NONBLOCK)
 
@@ -273,3 +298,13 @@ def _uninstall_helloworld(args=[]):
 
 def _uninstall_sleep(app_id='test-app'):
     assert_command(['dcos', 'marathon', 'app', 'remove', app_id])
+
+
+def _get_completed_task_id(app_id='test-app-completed'):
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'task', '--json', app_id])
+    assert returncode == 0
+    tasks = json.loads(stdout.decode('utf-8'))
+    assert len(tasks) == 1
+    task_id = tasks[0]['id']
+    return task_id

--- a/dcos/mesos.py
+++ b/dcos/mesos.py
@@ -424,7 +424,7 @@ class Master(object):
 
         keys = ['tasks']
         if completed:
-            keys = ['completed_tasks']
+            keys.extend(['completed_tasks'])
 
         tasks = []
         for framework in self._framework_dicts(completed, completed):

--- a/dcos/mesos.py
+++ b/dcos/mesos.py
@@ -358,17 +358,19 @@ class Master(object):
         else:
             return slaves[0]
 
-    def task(self, fltr):
+    def task(self, fltr, completed=False):
         """Returns the task with `fltr` in its ID.  Raises a DCOSException if
         there is not exactly one such task.
 
         :param fltr: filter string
         :type fltr: str
         :returns: the task that has `fltr` in its ID
+        :param completed: also include completed tasks
+        :type completed: bool
         :rtype: Task
         """
 
-        tasks = self.tasks(fltr)
+        tasks = self.tasks(fltr, completed)
 
         if len(tasks) == 0:
             raise DCOSException(


### PR DESCRIPTION
As per documentation `dcos task --completed` was intended to show BOTH completed and running tasks. In practice it only shows completed tasks.