### PR TITLE
External license

### DIFF
--- a/EXTERNAL_LICENSES.md
+++ b/EXTERNAL_LICENSES.md
@@ -1,0 +1,106 @@
+# List of external Python packages and their license
+
+Babel (2.3.4)
+    License: BSD
+
+GitPython (1.0.2)
+    License: BSD License
+
+Jinja2 (2.8)
+    License: BSD
+
+MarkupSafe (0.23)
+    License: BSD
+
+Pygments (2.1.3)
+    License: BSD License
+
+Sphinx (1.4.1)
+    License: BSD
+
+alabaster (0.7.8)
+    License: UNKNOWN
+
+docopt (0.6.2)
+    License: MIT
+
+docutils (0.12)
+    License: public domain, Python, 2-Clause BSD, GPL 3 (see COPYING.txt)
+
+futures (3.0.5)
+    License: BSD
+
+gitdb (0.6.4)
+    License: BSD License
+
+imagesize (0.7.1)
+    License: MIT
+
+jsonschema (2.4.0)
+    License: MIT
+
+pager (3.3)
+    License: Public Domain
+
+pip (8.1.2)
+    License: MIT
+
+pkginfo (1.2.1)
+    License: Python
+
+pluggy (0.3.1)
+    License: MIT license
+
+portalocker (0.5.7)
+    License: PSF
+
+prettytable (0.7.2)
+    License: BSD (3 clause)
+
+py (1.4.31)
+    License: MIT license
+
+pypng (0.0.18)
+    License: UNKNOWN
+
+pystache (0.5.4)
+    License: MIT
+
+pytest (2.9.1)
+    License: MIT license
+
+pytz (2016.4)
+    License: MIT
+
+requests (2.10.0)
+    License: Apache 2.0
+
+rollbar (0.12.1)
+    License: UNKNOWN
+
+setuptools (21.0.0)
+    License: UNKNOWN
+
+six (1.10.0)
+    License: MIT
+
+smmap (0.9.0)
+    License: BSD
+
+snowballstemmer (1.2.1)
+    License: BSD
+
+toml (0.9.1)
+    License: License :: OSI Approved :: MIT License
+
+tox (2.3.1)
+    License: http://opensource.org/licenses/MIT
+
+virtualenv (13.1.2)
+    License: MIT
+
+wheel (0.29.0)
+    License: MIT
+
+yolk3k (0.8.8)
+    License: BSD License

--- a/EXTERNAL_LICENSES.md
+++ b/EXTERNAL_LICENSES.md
@@ -79,7 +79,7 @@ rollbar (0.12.1)
     License: UNKNOWN
 
 setuptools (21.0.0)
-    License: UNKNOWN
+    License: MIT
 
 six (1.10.0)
     License: MIT


### PR DESCRIPTION
Generated with `yolk -l -f License > EXTERNAL_LICENSES.md` in the dcos-cli/cli virtualenv environment.

Manually changed setuptools to MIT.