### PR TITLE
update `package describe --cli` to look at command + resource json

### DIFF
--- a/cli/dcoscli/package/main.py
+++ b/cli/dcoscli/package/main.py
@@ -219,7 +219,8 @@ def _describe(package_name,
     :type package_name: str
     :param app: If True, marathon.json will be printed
     :type app: boolean
-    :param cli: If True, command.json should be printed
+    :param cli: If True, command.json | resource.json's cli property should
+                be printed
     :type cli: boolean
     :param options_path: Path to json file with options to override
                          config.json defaults.
@@ -267,7 +268,7 @@ def _describe(package_name,
         options = pkg.options(user_options)
 
         if cli:
-            emitter.publish(pkg.command_json())
+            emitter.publish(pkg.cli_definition())
         if app:
             if render:
                 app_output = pkg.marathon_json(options)

--- a/dcos/cosmospackage.py
+++ b/dcos/cosmospackage.py
@@ -416,6 +416,18 @@ class CosmosPackageVersion():
         return self._command_json is not None or (
             self._resource_json and self._resource_json.get("cli"))
 
+    def cli_definition(self):
+        """Returns the JSON content that defines a cli subcommand. Looks for
+        "cli" property in resource.json first and if that is None, checks for
+        command.json
+
+        :returns: Package data
+        :rtype: dict
+        """
+
+        return (self._resource_json and self._resource_json.get("cli")) or (
+            self._command_json)
+
     def command_json(self):
         """Returns the JSON content of the command.json file.
 


### PR DESCRIPTION
With universe updates to change where the cli is defined, we now first
look for the cli definition in resource.cli, and if not found, look for
command.json in the package definition.