### PR TITLE
Pin the pkginfo package to 1.2.1

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -67,7 +67,7 @@ setup(
     install_requires=[
         'dcos=={}'.format(dcoscli.version),
         'docopt>=0.6, <1.0',
-        'pkginfo>=1.2, <2.0',
+        'pkginfo==1.2.1',
         'toml>=0.9, <1.0',
         'virtualenv>=13.0, <14.0',
         'rollbar>=0.9, <1.0',


### PR DESCRIPTION
Version 1.3.0 of the package was just release and it breaks the CLI