### PR TITLE
Enable dcos node ssh to run a command

### DIFF
--- a/cli/dcoscli/data/help/node.txt
+++ b/cli/dcoscli/data/help/node.txt
@@ -10,6 +10,7 @@ Usage:
                   [--user=<user>]
                   [--master-proxy]
                   (--leader | --master | --mesos-id=<mesos-id> | --slave=<slave-id>)
+                  [<command>]
 
 Commands:
     log
@@ -50,3 +51,7 @@ Options:
         The SSH user, where the default user [default: core].
     --version
         Print version information.
+
+Positional Arguments:
+    <command>
+        Command to execute on the DCOS cluster node.

--- a/cli/tests/data/help/node.txt
+++ b/cli/tests/data/help/node.txt
@@ -10,6 +10,7 @@ Usage:
                   [--user=<user>]
                   [--master-proxy]
                   (--leader | --master | --mesos-id=<mesos-id> | --slave=<slave-id>)
+                  [<command>]
 
 Commands:
     log
@@ -50,3 +51,7 @@ Options:
         The SSH user, where the default user [default: core].
     --version
         Print version information.
+
+Positional Arguments:
+    <command>
+        Command to execute on the DCOS cluster node.


### PR DESCRIPTION
Because `echo <command> | dcos node ssh ` felt hacky and did not work so well for me