### PR TITLE
Apply --option to connection from master-proxy as well

### DIFF
--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -205,7 +205,7 @@ def _ssh(leader, slave, option, config_file, user, master_proxy):
                                  "'PUBLIC_IPV4' at {}").format(
                                      dcos_client.get_dcos_url('metadata')))
 
-        cmd = "ssh -A -t {0}{1}@{2} ssh -A -t {1}@{3}".format(
+        cmd = "ssh -A -t {0}{1}@{2} ssh -A -t {0}{1}@{3}".format(
             ssh_options,
             user,
             master_public_ip,


### PR DESCRIPTION
If I try to skip HostKeyChecking while sshing into a DC/OS node it only works if I'm not using `--master-proxy`

```
dcos node ssh  --option="StrictHostKeyChecking=no" --leader --master-proxy
Running `ssh -A -t -o StrictHostKeyChecking=no core@52.38.226.230 ssh -A -t core@10.0.7.49`
The authenticity of host '10.0.7.49 (10.0.7.49)' can't be established.
ED25519 key fingerprint is 53:5b:89:66:bb:f7:aa:7e:60:39:87:4b:5c:33:42:e0.
Are you sure you want to continue connecting (yes/no)? 
```
Currently `dcos node ssh  --option="StrictHostKeyChecking=no" --leader --master-proxy--option="StrictHostKeyChecking=no"` gets interpreted as `ssh -A -t -o StrictHostKeyChecking=no core@52.38.226.230 ssh -A -t core@10.0.7.49` with this change it will be interpreted as `ssh -A -t -o StrictHostKeyChecking=no core@52.38.226.230 ssh -A -t -o StrictHostKeyChecking=no core@10.0.7.49`