### PR TITLE
Let's start a discussion around auth with the dcos-cli

### DIFF
--- a/cli/dcoscli/data/help/node.txt
+++ b/cli/dcoscli/data/help/node.txt
@@ -10,6 +10,7 @@ Usage:
                   [--user=<user>]
                   [--master-proxy]
                   (--leader | --master | --mesos-id=<mesos-id> | --slave=<slave-id>)
+                  [<command>]
 
 Commands:
     log
@@ -50,3 +51,7 @@ Options:
         The SSH user, where the default user [default: core].
     --version
         Print version information.
+
+Positional Arguments:
+    <command>
+        Command to execute on the DCOS cluster node.

--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -603,7 +603,7 @@ def _deploy(deploy_resource, properties, force):
         logger.info("Group '{}' already exists, performing a rolling update".format(resource_id))
 
         properties = _parse_properties(properties)
-        deployment = client.update_app(resource_id, properties, force)
+        deployment = client.update_group(resource_id, properties, force)
 
         emitter.publish('Created deployment {}'.format(deployment))
         return 0

--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -571,6 +571,10 @@ def _deploy(deploy_resource, properties, force):
     """
     :param deploy_resource: optional filename for the application/group resource
     :type deploy_resource: str
+    :param properties: json items used to update application/group
+    :type properties: [str]
+    :param force: whether to override running deployments
+    :type force: bool
     :returns: process return code
     :rtype: int
     """

--- a/cli/tests/data/help/node.txt
+++ b/cli/tests/data/help/node.txt
@@ -10,6 +10,7 @@ Usage:
                   [--user=<user>]
                   [--master-proxy]
                   (--leader | --master | --mesos-id=<mesos-id> | --slave=<slave-id>)
+                  [<command>]
 
 Commands:
     log
@@ -50,3 +51,7 @@ Options:
         The SSH user, where the default user [default: core].
     --version
         Print version information.
+
+Positional Arguments:
+    <command>
+        Command to execute on the DCOS cluster node.

--- a/dcos/http.py
+++ b/dcos/http.py
@@ -342,8 +342,14 @@ def _get_auth_credentials(username, hostname):
     :rtype: str, str
     """
 
-    username = os.environ['DCOS_USERNAME']
-    password = os.environ['DCOS_PASSWORD']
+    try:
+        username = os.environ['DCOS_USERNAME']
+    except KeyError:
+        username = None
+    try:
+        password = os.environ['DCOS_PASSWORD']
+    except KeyError:
+        password = None
 
     if username is None:
         sys.stdout.write("{}'s username: ".format(hostname))

--- a/dcos/http.py
+++ b/dcos/http.py
@@ -342,12 +342,16 @@ def _get_auth_credentials(username, hostname):
     :rtype: str, str
     """
 
+    username = os.environ['DCOS_USERNAME']
+    password = os.environ['DCOS_PASSWORD']
+
     if username is None:
         sys.stdout.write("{}'s username: ".format(hostname))
         sys.stdout.flush()
         username = sys.stdin.readline().strip().lower()
 
-    password = getpass.getpass("{}@{}'s password: ".format(username, hostname))
+    if password is None:
+        password = getpass.getpass("{}@{}'s password: ".format(username, hostname))
 
     return username, password
 


### PR DESCRIPTION
Having to put in a username and password every 5 days for the dcos-cli is annoying when using it via an automated build process. Granted, one could use `expect` or similar, but there isn't any documentation on this and it feels weird to use it this way. In our automated build process, usernames/passwords are typically passed in through Bamboo (CI). I don't expect this to get merged, but this is how we currently use the DC/OS cli. So, how is the DC/OS team approaching this?