### PR TITLE
handle mesos tasks having ids that are substrings of each other

### DIFF
--- a/cli/tests/unit/test_task.py
+++ b/cli/tests/unit/test_task.py
@@ -33,6 +33,16 @@ def test_log_no_tasks():
         assert_mock(main, args, returncode=1, stderr=stderr)
 
 
+def test_task_exact_match():
+    """Test a task gets returned if it is an exact match, even if
+    it is a substring of another task.
+    """
+    with patch('dcos.mesos.Master.slaves',
+               return_value=[{"id": "foo"}, {"id": "foobar"}]):
+        master = mesos.Master(None)
+        assert master.slave("foo") == {"id": "foo"}
+
+
 def test_log_file_unavailable():
     """ Test a file's read.json being unavailable """
     files = [mesos.MesosFile('bogus')]

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -3,7 +3,6 @@ envlist = py34-syntax, py{27,34}-unit, py{27,34}-integration
 
 [testenv]
 deps =
-  teamcity-messages
   mock
   pytest
   pytest-cov
@@ -13,7 +12,6 @@ passenv = DCOS_* CI_FLAGS CLI_TEST_SSH_KEY_PATH CLI_TEST_MASTER_PROXY
 
 [testenv:py34-syntax]
 deps =
-  teamcity-messages
   flake8
   isort
   ..

--- a/cli/tox.win.ini
+++ b/cli/tox.win.ini
@@ -5,7 +5,6 @@ envlist = py{27,34}-unit, py{27,34}-integration
 setenv =
   DCOS_CONFIG = {env:DCOS_CONFIG}
 deps =
-  teamcity-messages
   pytest
   pytest-cov
   mock
@@ -15,7 +14,6 @@ deps =
 
 [testenv:syntax]
 deps =
-  teamcity-messages
   flake8
   isort
   ..

--- a/dcos/mesos.py
+++ b/dcos/mesos.py
@@ -331,7 +331,8 @@ class Master(object):
                                         'slave/{}/'.format(slave['id']))
 
     def slave(self, fltr):
-        """Returns the slave that has `fltr` in its ID.  Raises a
+        """Returns the slave that has `fltr` in its ID. If any slaves
+        are an exact match, returns that task, id not raises a
         DCOSException if there is not exactly one such slave.
 
         :param fltr: filter string
@@ -346,10 +347,16 @@ class Master(object):
             raise DCOSException('No slave found with ID "{}".'.format(fltr))
 
         elif len(slaves) > 1:
-            matches = ['\t{0}'.format(slave['id']) for slave in slaves]
-            raise DCOSException(
-                "There are multiple slaves with that ID. " +
-                "Please choose one: {}".format('\n'.join(matches)))
+
+            exact_matches = [s for s in slaves if s['id'] == fltr]
+            if len(exact_matches) == 1:
+                return exact_matches[0]
+
+            else:
+                matches = ['\t{0}'.format(s['id']) for s in slaves]
+                raise DCOSException(
+                    "There are multiple slaves with that ID. " +
+                    "Please choose one:\n{}".format('\n'.join(matches)))
 
         else:
             return slaves[0]

--- a/tox.ini
+++ b/tox.ini
@@ -3,14 +3,12 @@ envlist = py34-syntax, py{27,34}-unit
 
 [testenv]
 deps =
-  teamcity-messages
   pytest
   pytest-cov
 passenv = DCOS_* CI_FLAGS CLI_TEST_SSH_KEY_PATH
 
 [testenv:py34-syntax]
 deps =
-  teamcity-messages
   flake8
   isort
 

--- a/tox.win.ini
+++ b/tox.win.ini
@@ -5,14 +5,12 @@ envlist = py{27,34}-unit
 setenv =
   DCOS_CONFIG = {env:DCOS_CONFIG}
 deps =
-  teamcity-messages
   pytest
   pytest-cov
   pypiwin32
 
 [testenv:syntax]
 deps =
-  teamcity-messages
   flake8
   isort
 


### PR DESCRIPTION
Instead of crashing, if looking for a task by a fltr, if a task is an
exact match, return that task.