### PR TITLE
use BatchMode instead of PasswordAuthentication for ssh

### DIFF
--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -117,7 +117,7 @@ def test_node_ssh_config_file():
 def test_node_ssh_user():
     stdout, stderr, _ = _node_ssh_output(
         ['--master-proxy', '--leader', '--user=bogus', '--option',
-         'PasswordAuthentication=no'])
+         'BatchMode=yes'])
     assert stdout == b''
     assert b'Permission denied' in stderr
 


### PR DESCRIPTION
DC/OS bumped the coreOS version, and just using PasswordAuthentication
is now no longer enough to turn off interactive mode. BatchMode covers
all types of authentication.