### PR TITLE
revert "remove code duplication (#648)"

### DIFF
--- a/cli/dcoscli/subcommand.py
+++ b/cli/dcoscli/subcommand.py
@@ -1,11 +1,9 @@
 import traceback
-from importlib import import_module
 
 import pkg_resources
 
-from dcos import subcommand
 
-
+# must also add subcommand name to dcos.subcommand.default_subcommands
 def _default_modules():
     """Dict of the default dcos cli subcommands and their main methods
 
@@ -13,8 +11,25 @@ def _default_modules():
     :rtype: {}
     """
 
-    defaults = subcommand.default_subcommands()
-    return {s: import_module('dcoscli.{}.main'.format(s)) for s in defaults}
+    # avoid circular imports
+    from dcoscli.auth import main as auth_main
+    from dcoscli.config import main as config_main
+    from dcoscli.help import main as help_main
+    from dcoscli.marathon import main as marathon_main
+    from dcoscli.node import main as node_main
+    from dcoscli.package import main as package_main
+    from dcoscli.service import main as service_main
+    from dcoscli.task import main as task_main
+
+    return {'auth': auth_main,
+            'config': config_main,
+            'help': help_main,
+            'marathon': marathon_main,
+            'node': node_main,
+            'package': package_main,
+            'service': service_main,
+            'task': task_main
+            }
 
 
 def default_doc(command):

--- a/dcos/subcommand.py
+++ b/dcos/subcommand.py
@@ -134,6 +134,7 @@ def distributions():
         return []
 
 
+# must also add subcommand name to dcoscli.subcommand._default_modules
 def default_subcommands():
     """List the default dcos cli subcommands
 


### PR DESCRIPTION
With this change, we need to specify the imports in pyinstaller spec
file, so leave as is.