### PR TITLE
Wait for `cluster_info` JSON field to be populated

### DIFF
--- a/ccm/wait_for_ccm_cluster.sh
+++ b/ccm/wait_for_ccm_cluster.sh
@@ -14,14 +14,16 @@ while true; do
                   Authorization:"Token ${CCM_AUTH_TOKEN}" | \
                     jq ".status");
     if [ $STATUS -eq 0 ]; then
-        break;
+        CLUSTER_INFO=$(http GET https://ccm.mesosphere.com/api/cluster/${CLUSTER_ID}/ Authorization:"Token ${CCM_AUTH_TOKEN}" | jq ".cluster_info")
+
+#        # ensure cluster_info is populated
+         if [ ! -z "$CLUSTER_INFO" ]; then
+            eval CLUSTER_INFO=$CLUSTER_INFO  # unescape json
+            break;
+         fi;
     fi;
     sleep 10;
 done;
-
-# get dcos_url
-CLUSTER_INFO=$(http GET https://ccm.mesosphere.com/api/cluster/${CLUSTER_ID}/ Authorization:"Token ${CCM_AUTH_TOKEN}" | jq ".cluster_info")
-eval CLUSTER_INFO=$CLUSTER_INFO  # unescape json
 
 DCOS_URL=$(echo "$CLUSTER_INFO" | jq ".MastersIpAddresses[0]")
 DCOS_URL=${DCOS_URL:1:-1} # remove JSON string quotes


### PR DESCRIPTION
This will allow dcos-cli tests not to fail until the [CCM fix](https://github.com/mesosphere/cloud-cluster-manager/pull/136) can be deployed.