### PR TITLE
Fix incorrect handling of HTTP retries

### DIFF
--- a/dcos/http.py
+++ b/dcos/http.py
@@ -159,6 +159,10 @@ def _request_with_auth(response,
             else:
                 auth = AUTH_CREDS[creds]
 
+        # if the data is a file buffer, seek to the beginning
+        if 'data' in kwargs and isinstance(kwargs['data'], file):
+            kwargs['data'].seek(0)
+
         # try request again, with auth
         response = _request(method, url, is_success, timeout, auth,
                             verify, **kwargs)


### PR DESCRIPTION
There is a bug in dcos/http.py (https://github.com/dcos/dcos-cli/blob/master/dcos/http.py#L221-L226). 

Symptom: `ConnectionError: ('Connection aborted.', BadStatusLine("''"))`

The typical way of sending data with an HTTP request is something like

```
with open(filename) as payload:
            r = dcos.http.request(‘put’, url, data=payload)
```

The problem is that the underlying requests lib will read the file buffer on the first attempt, get a 401 unauthorized, and then retry the request using authorization. Since the file buffer has already been “read”, the second request ends up with a calculated Content-Length of 0 (as well as an empty payload)

A workaround is something like this, but it isn’t ideal:

```
with open(filename) as payload_file:
            payload = payload_file.read()
            r = dcos.http.request(‘put’, url, data=payload)
```

This PR implements a fix which seeks to the beginning of file buffers before attempting a retry.