### PR TITLE
fix docopt resolution order in `dcos task`

### DIFF
--- a/cli/dcoscli/data/help/task.txt
+++ b/cli/dcoscli/data/help/task.txt
@@ -4,9 +4,9 @@ Description:
 Usage:
     dcos task --help
     dcos task --info
+    dcos task log [--completed --follow --lines=N] [<task>] [<file>]
+    dcos task ls [--long --completed] [<task>] [<path>]
     dcos task [--completed --json <task>]
-    dcos task log [--completed --follow --lines=N] <task> [<file>]
-    dcos task ls [--long --completed] <task> [<path>]
 
 Command:
     log

--- a/cli/dcoscli/task/main.py
+++ b/cli/dcoscli/task/main.py
@@ -72,11 +72,11 @@ def _info():
     return 0
 
 
-def _task(fltr, completed, json_):
+def _task(task, completed, json_):
     """List DCOS tasks
 
-    :param fltr: task id filter
-    :type fltr: str
+    :param task: task id filter
+    :type task: str
     :param completed: If True, include completed tasks
     :type completed: bool
     :param json_: If True, output json.  Otherwise, output a human
@@ -85,14 +85,14 @@ def _task(fltr, completed, json_):
     :returns: process return code
     """
 
-    if fltr is None:
-        fltr = ""
+    if task is None:
+        task = ""
 
-    tasks = sorted(mesos.get_master().tasks(completed=completed, fltr=fltr),
-                   key=lambda task: task['name'])
+    tasks = sorted(mesos.get_master().tasks(completed=completed, fltr=task),
+                   key=lambda t: t['name'])
 
     if json_:
-        emitter.publish([task.dict() for task in tasks])
+        emitter.publish([t.dict() for t in tasks])
     else:
         table = tables.task_table(tasks)
         output = six.text_type(table)
@@ -175,6 +175,8 @@ def _ls(task, path, long_, completed):
     :rtype: int
     """
 
+    if task is None:
+        task = ""
     if path is None:
         path = '.'
     if path.startswith('/'):

--- a/cli/tests/data/help/task.txt
+++ b/cli/tests/data/help/task.txt
@@ -4,9 +4,9 @@ Description:
 Usage:
     dcos task --help
     dcos task --info
+    dcos task log [--completed --follow --lines=N] [<task>] [<file>]
+    dcos task ls [--long --completed] [<task>] [<path>]
     dcos task [--completed --json <task>]
-    dcos task log [--completed --follow --lines=N] <task> [<file>]
-    dcos task ls [--long --completed] <task> [<path>]
 
 Command:
     log

--- a/cli/tests/integrations/test_task.py
+++ b/cli/tests/integrations/test_task.py
@@ -231,6 +231,24 @@ def test_log_completed():
     assert len(stdout.decode('utf-8').split('\n')) > 4
 
 
+def test_ls_no_params():
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'task', 'ls'])
+
+    assert returncode == 0
+    assert stderr == b''
+
+    ls_line = 'stderr  stderr.logrotate.conf  stdout  stdout.logrotate.conf'
+    lines = stdout.decode('utf-8').split('\n')
+    assert len(lines) == 7
+    assert re.match('===>.*<===', lines[0])
+    assert re.match(ls_line, lines[1])
+    assert re.match('===>.*<===', lines[2])
+    assert re.match(ls_line, lines[3])
+    assert re.match('===>.*<===', lines[4])
+    assert re.match(ls_line, lines[5])
+
+
 def test_ls():
     stdout = b'stderr  stderr.logrotate.conf  stdout  stdout.logrotate.conf\n'
     assert_command(['dcos', 'task', 'ls', 'test-app1'],


### PR DESCRIPTION
If no arguments were given for`dcos task log` and `dcos task ls`, we
were processing the command as `dcos task` with task-id log|ls.