### PR TITLE
change `package describe` to output package.json without modification

### DIFF
--- a/cli/dcoscli/package/main.py
+++ b/cli/dcoscli/package/main.py
@@ -256,11 +256,6 @@ def _describe(package_name,
 
     pkg_json = pkg.package_json()
 
-    if package_version is None:
-        pkg_versions = pkg.package_versions()
-        del pkg_json['version']
-        pkg_json['versions'] = pkg_versions
-
     if package_versions:
         emitter.publish(pkg.package_versions())
     elif cli or app or config:

--- a/cli/tests/data/package/json/test_describe_marathon.json
+++ b/cli/tests/data/package/json/test_describe_marathon.json
@@ -18,5 +18,5 @@
     "init",
     "long-running"
   ],
-  "versions": ["0.11.1"]
+  "version": "0.11.1"
 }


### PR DESCRIPTION
We were adding in all versions of a package, but this doesn't make sense
since different versions have different package.json contents. A user
can still see all versions of a package with `--package-versions` flag.