### PR TITLE
service name for dcos

### DIFF
--- a/cli/dcoscli/data/help/dcos.txt
+++ b/cli/dcoscli/data/help/dcos.txt
@@ -21,6 +21,11 @@ Options:
         * critical Prints only critical messages to stderr.
     --version
         Print version information
+    --service-name=<service-name>
+        Sets the non-default name of the service to invoke request against.
+        For example if marathon is installed to invoke `dcos marathon`
+        commands with the default installation invoke
+        `dcos --service-name=marathon-user marathon`
 
 Environment Variables:
     DCOS_CONFIG
@@ -32,3 +37,6 @@ Environment Variables:
     DCOS_LOG_LEVEL
         Prints log messages to stderr at or above the level indicated. This is
         equivalent to the --log-level command-line option.
+    DCOS_SERVICE_NAME
+      Sets the service name to be used for commands that invoked against a
+      service endpoint.  Otherwise it has no effect.

--- a/cli/dcoscli/main.py
+++ b/cli/dcoscli/main.py
@@ -66,6 +66,9 @@ def _main():
     if args['--debug']:
         os.environ[constants.DCOS_DEBUG_ENV] = 'true'
 
+    if args['--service-name']:
+        os.environ[constants.DCOS_SERVICE_NAME_ENV] = args['--service-name']
+
     util.configure_process_from_environ()
 
     if args['--version']:

--- a/cli/tests/data/help/marathon.txt
+++ b/cli/tests/data/help/marathon.txt
@@ -1,42 +1,142 @@
 Description:
-    The Mesosphere Datacenter Operating System (DC/OS) spans all of the machines in
-your datacenter or cloud and treats them as a single, shared set of resources.
+    Deploy and manage applications to DC/OS.
 
 Usage:
-    dcos [options] [<command>] [<args>...]
+    dcos marathon --config-schema
+    dcos marathon --help
+    dcos marathon --info
+    dcos marathon about
+    dcos marathon app add [<app-resource>]
+    dcos marathon app list [--json]
+    dcos marathon app remove [--force] <app-id>
+    dcos marathon app restart [--force] <app-id>
+    dcos marathon app show [--app-version=<app-version>] <app-id>
+    dcos marathon app start [--force] <app-id> [<instances>]
+    dcos marathon app stop [--force] <app-id>
+    dcos marathon app kill [--scale] [--host=<host>] <app-id>
+    dcos marathon app update [--force] <app-id> [<properties>...]
+    dcos marathon app version list [--max-count=<max-count>] <app-id>
+    dcos marathon deployment list [--json <app-id>]
+    dcos marathon deployment rollback <deployment-id>
+    dcos marathon deployment stop <deployment-id>
+    dcos marathon deployment watch [--max-count=<max-count>]
+                                   [--interval=<interval>] <deployment-id>
+    dcos marathon group add [<group-resource>]
+    dcos marathon group list [--json]
+    dcos marathon group scale [--force] <group-id> <scale-factor>
+    dcos marathon group show [--group-version=<group-version>] <group-id>
+    dcos marathon group remove [--force] <group-id>
+    dcos marathon group update [--force] <group-id> [<properties>...]
+    dcos marathon task list [--json <app-id>]
+    dcos marathon task stop [--wipe] <task-id>
+    dcos marathon task show <task-id>
+
+Commands:
+    about
+        Print info.json for DC/OS Marathon.
+    app add
+        Add an application.
+    app list
+        List the installed applications.
+    app remove
+        Remove an application.
+    app restart
+        Restart an application.
+    app show
+        Show the `marathon.json` for an  application.
+    app start
+        Start an application.
+    app stop
+        Stop an application.
+    app kill
+        Kill a running application instance.
+    app update
+        Update an application.
+    app version list
+        List the version history of an application.
+    deployment list
+        Print a list of currently deployed applications.
+    deployment rollback
+        Remove a deployed application.
+    deployment stop
+        Cancel the in-progress deployment of an application.
+    deployment watch
+        Monitor deployments.
+    group add
+        Create a new group.
+    group list
+        Print the list of groups.
+    group scale
+        Scale a group.
+    group show
+        Print a detailed list of groups.
+    group remove
+        Remove a group.
+    group update
+        Update a group.
+    task list
+        List all tasks.
+    task stop
+        Stop a task. Wipe persistent data if `--wipe` is set.
+    task show
+        List a specific task.
 
 Options:
-    --debug
-        Enable debug mode.
-    --help
+    --app-version=<app-version>
+        The version of the application to use. It can be specified as an
+        absolute or relative value. Absolute values must be in ISO8601 date
+        format. Relative values must be specified as a negative integer and they
+        represent the version from the currently deployed application definition.
+    --config-schema
+        Show the configuration schema for the Marathon subcommand.
+    --force
+        Disable checks in Marathon during updates.
+    --group-version=<group-version>
+        The group version to use for the command. It can be specified as an
+        absolute or relative value. Absolute values must be in ISO8601 date
+        format. Relative values must be specified as a negative integer and they
+        represent the version from the currently deployed group definition.
+    -h, --help
         Print usage.
-    --log-level=<log-level>
-        Set the logging level. This setting does not affect the output sent to
-        stdout. The severity levels are:
-        The severity level:
-        * debug    Prints all messages.
-        * info     Prints informational, warning, error, and critical messages.
-        * warning  Prints warning, error, and critical messages.
-        * error    Prints error and critical messages.
-        * critical Prints only critical messages to stderr.
+    --host=<host>
+        The hostname that is running app.
+    --info
+        Print a short description of this subcommand.
+    --interval=<interval>
+        Number of seconds to wait between actions.
+    --json
+        Print JSON-formatted list of tasks.
+    --max-count=<max-count>
+        Maximum number of entries to fetch and return.
+    --scale
+        Scale the app down after performing the the operation.
     --version
-        Print version information
-    --service-name=<service-name>
-        Sets the non-default name of the service to invoke request against.
-        For example if marathon is installed to invoke `dcos marathon`
-        commands with the default installation invoke
-        `dcos --service-name=marathon-user marathon`
+        Print version information.
 
-Environment Variables:
-    DCOS_CONFIG
-        Set the path to the DC/OS configuration file. By default, this variable
-        is set to ~/.dcos/dcos.toml.
-    DCOS_DEBUG
-        Indicates whether to print additional debug messages to stdout. By
-        default this is set to false.
-    DCOS_LOG_LEVEL
-        Prints log messages to stderr at or above the level indicated. This is
-        equivalent to the --log-level command-line option.
-    DCOS_SERVICE_NAME
-      Sets the service name to be used for commands that invoked against a
-      service endpoint.  Otherwise it has no effect.
+Positional Arguments:
+    <app-id>
+        The application ID.
+    <app-resource>
+        Path to a file or HTTP(S) URL that contains the app's JSON definition.
+        If omitted, the definition is read from stdin. For a detailed
+        description see
+        https://mesosphere.github.io/marathon/docs/rest-api.html#post-v2-apps.
+    <deployment-id>
+        The deployment ID.
+    <group-id>
+        The group ID.
+    <group-resource>
+        Path to a file or HTTP(S) URL that contains the group's JSON definition.
+        If omitted, the definition is read from stdin. For a detailed
+        description see
+        https://mesosphere.github.io/marathon/docs/rest-api.html#post-v2-groups.
+    <instances>
+        The number of instances.
+    <properties>
+        List of space-separated config.json properties to update.  The list must
+        be formatted as <key>=<value>. For example, `cpus=2.0 mem=308`. If
+        omitted, properties are read from stdin.
+    <task-id>
+        The task ID.
+    <scale-factor>
+        The factor to scale an application group by.

--- a/cli/tests/data/help/marathon.txt
+++ b/cli/tests/data/help/marathon.txt
@@ -1,142 +1,42 @@
 Description:
-    Deploy and manage applications to DC/OS.
+    The Mesosphere Datacenter Operating System (DC/OS) spans all of the machines in
+your datacenter or cloud and treats them as a single, shared set of resources.
 
 Usage:
-    dcos marathon --config-schema
-    dcos marathon --help
-    dcos marathon --info
-    dcos marathon about
-    dcos marathon app add [<app-resource>]
-    dcos marathon app list [--json]
-    dcos marathon app remove [--force] <app-id>
-    dcos marathon app restart [--force] <app-id>
-    dcos marathon app show [--app-version=<app-version>] <app-id>
-    dcos marathon app start [--force] <app-id> [<instances>]
-    dcos marathon app stop [--force] <app-id>
-    dcos marathon app kill [--scale] [--host=<host>] <app-id>
-    dcos marathon app update [--force] <app-id> [<properties>...]
-    dcos marathon app version list [--max-count=<max-count>] <app-id>
-    dcos marathon deployment list [--json <app-id>]
-    dcos marathon deployment rollback <deployment-id>
-    dcos marathon deployment stop <deployment-id>
-    dcos marathon deployment watch [--max-count=<max-count>]
-                                   [--interval=<interval>] <deployment-id>
-    dcos marathon group add [<group-resource>]
-    dcos marathon group list [--json]
-    dcos marathon group scale [--force] <group-id> <scale-factor>
-    dcos marathon group show [--group-version=<group-version>] <group-id>
-    dcos marathon group remove [--force] <group-id>
-    dcos marathon group update [--force] <group-id> [<properties>...]
-    dcos marathon task list [--json <app-id>]
-    dcos marathon task stop [--wipe] <task-id>
-    dcos marathon task show <task-id>
-
-Commands:
-    about
-        Print info.json for DC/OS Marathon.
-    app add
-        Add an application.
-    app list
-        List the installed applications.
-    app remove
-        Remove an application.
-    app restart
-        Restart an application.
-    app show
-        Show the `marathon.json` for an  application.
-    app start
-        Start an application.
-    app stop
-        Stop an application.
-    app kill
-        Kill a running application instance.
-    app update
-        Update an application.
-    app version list
-        List the version history of an application.
-    deployment list
-        Print a list of currently deployed applications.
-    deployment rollback
-        Remove a deployed application.
-    deployment stop
-        Cancel the in-progress deployment of an application.
-    deployment watch
-        Monitor deployments.
-    group add
-        Create a new group.
-    group list
-        Print the list of groups.
-    group scale
-        Scale a group.
-    group show
-        Print a detailed list of groups.
-    group remove
-        Remove a group.
-    group update
-        Update a group.
-    task list
-        List all tasks.
-    task stop
-        Stop a task. Wipe persistent data if `--wipe` is set.
-    task show
-        List a specific task.
+    dcos [options] [<command>] [<args>...]
 
 Options:
-    --app-version=<app-version>
-        The version of the application to use. It can be specified as an
-        absolute or relative value. Absolute values must be in ISO8601 date
-        format. Relative values must be specified as a negative integer and they
-        represent the version from the currently deployed application definition.
-    --config-schema
-        Show the configuration schema for the Marathon subcommand.
-    --force
-        Disable checks in Marathon during updates.
-    --group-version=<group-version>
-        The group version to use for the command. It can be specified as an
-        absolute or relative value. Absolute values must be in ISO8601 date
-        format. Relative values must be specified as a negative integer and they
-        represent the version from the currently deployed group definition.
-    -h, --help
+    --debug
+        Enable debug mode.
+    --help
         Print usage.
-    --host=<host>
-        The hostname that is running app.
-    --info
-        Print a short description of this subcommand.
-    --interval=<interval>
-        Number of seconds to wait between actions.
-    --json
-        Print JSON-formatted list of tasks.
-    --max-count=<max-count>
-        Maximum number of entries to fetch and return.
-    --scale
-        Scale the app down after performing the the operation.
+    --log-level=<log-level>
+        Set the logging level. This setting does not affect the output sent to
+        stdout. The severity levels are:
+        The severity level:
+        * debug    Prints all messages.
+        * info     Prints informational, warning, error, and critical messages.
+        * warning  Prints warning, error, and critical messages.
+        * error    Prints error and critical messages.
+        * critical Prints only critical messages to stderr.
     --version
-        Print version information.
+        Print version information
+    --service-name=<service-name>
+        Sets the non-default name of the service to invoke request against.
+        For example if marathon is installed to invoke `dcos marathon`
+        commands with the default installation invoke
+        `dcos --service-name=marathon-user marathon`
 
-Positional Arguments:
-    <app-id>
-        The application ID.
-    <app-resource>
-        Path to a file or HTTP(S) URL that contains the app's JSON definition.
-        If omitted, the definition is read from stdin. For a detailed
-        description see
-        https://mesosphere.github.io/marathon/docs/rest-api.html#post-v2-apps.
-    <deployment-id>
-        The deployment ID.
-    <group-id>
-        The group ID.
-    <group-resource>
-        Path to a file or HTTP(S) URL that contains the group's JSON definition.
-        If omitted, the definition is read from stdin. For a detailed
-        description see
-        https://mesosphere.github.io/marathon/docs/rest-api.html#post-v2-groups.
-    <instances>
-        The number of instances.
-    <properties>
-        List of space-separated config.json properties to update.  The list must
-        be formatted as <key>=<value>. For example, `cpus=2.0 mem=308`. If
-        omitted, properties are read from stdin.
-    <task-id>
-        The task ID.
-    <scale-factor>
-        The factor to scale an application group by.
+Environment Variables:
+    DCOS_CONFIG
+        Set the path to the DC/OS configuration file. By default, this variable
+        is set to ~/.dcos/dcos.toml.
+    DCOS_DEBUG
+        Indicates whether to print additional debug messages to stdout. By
+        default this is set to false.
+    DCOS_LOG_LEVEL
+        Prints log messages to stderr at or above the level indicated. This is
+        equivalent to the --log-level command-line option.
+    DCOS_SERVICE_NAME
+      Sets the service name to be used for commands that invoked against a
+      service endpoint.  Otherwise it has no effect.

--- a/dcos/constants.py
+++ b/dcos/constants.py
@@ -17,6 +17,10 @@ DCOS_LOG_LEVEL_ENV = 'DCOS_LOG_LEVEL'
 DCOS_DEBUG_ENV = 'DCOS_DEBUG'
 """Name of the environment variable to enable DC/OS debug messages"""
 
+DCOS_SERVICE_NAME_ENV = 'DCOS_SERVICE_NAME'
+"""Name of the environment variable to invocation against a non-default
+DC/OS service"""
+
 DCOS_PAGER_COMMAND_ENV = 'PAGER'
 """Command to use to page long command output (e.g. 'less -R')"""
 

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -34,13 +34,19 @@ def _get_marathon_url(toml_config):
     :returns: marathon base url
     :rtype: str
     """
-
     marathon_url = config.get_config_val('marathon.url', toml_config)
     if marathon_url is None:
         dcos_url = config.get_config_val('core.dcos_url', toml_config)
         if dcos_url is None:
             raise config.missing_config_exception(['core.dcos_url'])
-        marathon_url = urllib.parse.urljoin(dcos_url, 'service/marathon/')
+
+        if util.get_nondefault_service_name() is None:
+            marathon_service_name = "marathon"
+        else:
+            marathon_service_name = util.get_nondefault_service_name()
+
+        marathon_service_url = 'service/{}/'.format(marathon_service_name)
+        marathon_url = urllib.parse.urljoin(dcos_url, marathon_service_url)
 
     return marathon_url
 

--- a/dcos/util.py
+++ b/dcos/util.py
@@ -654,6 +654,19 @@ def validate_png(filename):
         raise DCOSException(
             'Unable to validate [{}] as a PNG file'.format(filename))
 
+def get_nondefault_service_name():
+    """
+
+    :rtype: str or None
+
+    """
+
+    if constants.DCOS_SERVICE_NAME_ENV in os.environ:
+        return os.environ[constants.DCOS_SERVICE_NAME_ENV]
+    else:
+        return None
+
+
 
 def normalize_app_id(app_id):
     """Normalizes the application id.


### PR DESCRIPTION
a solution to using different service names for deployed packages with a solution for marathon

a proposed and working solution for https://github.com/dcos/dcos-cli/issues/396

I was going to just fix marathon, but it was mentioned it was a core issue.  I'm on the fence about using os.env for the value... but we need a way to pass around state without cascading params.  Another option would be adding to a config object.  Looking for feedback:

@jsancio @tamarrow 