### PR TITLE
remove pypi universal config param

### DIFF
--- a/cli/setup.cfg
+++ b/cli/setup.cfg
@@ -1,5 +1,0 @@
-[bdist_wheel]
-# This flag says that the code is written to work on both Python 2 and Python
-# 3. If at all possible, it is good practice to do this. If you cannot, you
-# will need to generate wheels for each Python version that you support.
-universal=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[bdist_wheel]
-# This flag says that the code is written to work on both Python 2 and Python
-# 3. If at all possible, it is good practice to do this. If you cannot, you
-# will need to generate wheels for each Python version that you support.
-universal=1


### PR DESCRIPTION
Changing from using [universal wheels](https://packaging.python.org/distributing/#universal-wheels) to [pure python wheels](https://packaging.python.org/distributing/#pure-python-wheels)