### PR TITLE
Make sure that marathon URL ends with trailing slash

### DIFF
--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -130,6 +130,8 @@ class Client(object):
     """
 
     def __init__(self, marathon_url, timeout=http.DEFAULT_TIMEOUT):
+        if not marathon_url.endswith('/'):
+            marathon_url += '/'
         self._base_url = marathon_url
         self._timeout = timeout
 


### PR DESCRIPTION
This small patch makes sure that marathon urls always end with slash. Otherwise, in some cases urljoin can "eat" the last component of the path.