### PR TITLE
Don't change the case of the username

### DIFF
--- a/dcos/http.py
+++ b/dcos/http.py
@@ -346,7 +346,7 @@ def _get_auth_credentials(username, hostname):
     if username is None:
         sys.stdout.write("{}'s username: ".format(hostname))
         sys.stdout.flush()
-        username = sys.stdin.readline().strip().lower()
+        username = sys.stdin.readline().strip()
 
     password = getpass.getpass("{}@{}'s password: ".format(username, hostname))
 


### PR DESCRIPTION
We should take the username typed by the user as is. No need to lower
the case of the string.