### PR TITLE
Fix command execution

### DIFF
--- a/dcos/subcommand.py
+++ b/dcos/subcommand.py
@@ -6,7 +6,6 @@ import os
 import platform
 import shutil
 import stat
-import subprocess
 import sys
 import zipfile
 from distutils.version import LooseVersion
@@ -578,8 +577,8 @@ def _execute_command(command):
 
     process = Subproc().Popen(
         command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE)
+        stdout=PIPE,
+        stderr=PIPE)
 
     stdout, stderr = process.communicate()
 
@@ -678,7 +677,7 @@ class SubcommandProcess():
         :rtype: int, str | None
         """
 
-        subproc = subprocess.Subproc().Popen(
+        subproc = Subproc().Popen(
             [self._executable,  self._command] + self._args,
             stderr=PIPE)
 


### PR DESCRIPTION
Follows up on 1f7d77ec

Before:

```
$ dcos spark -h
Traceback (most recent call last):
  File "/home/nick/code/dcos-cli/cli/env/bin/dcos", line 9, in <module>
    load_entry_point('dcoscli===SNAPSHOT', 'console_scripts', 'dcos')()
  File "/home/nick/code/dcos-cli/cli/dcoscli/main.py", line 19, in main
    return _main()
  File "/home/nick/code/dcos-cli/cli/dcoscli/main.py", line 86, in _main
    exitcode, _ = sc.run_and_capture()
  File "/home/nick/code/dcos-cli/dcos/subcommand.py", line 681, in run_and_capture
    subproc = subprocess.Subproc().Popen(
AttributeError: 'module' object has no attribute 'Subproc'
```

After:

```
$ dcos spark -h
Usage:
[...]
```