### PR TITLE
when adding new config value, only check that section of config

### DIFF
--- a/cli/tests/data/config/invalid_section.toml
+++ b/cli/tests/data/config/invalid_section.toml
@@ -1,0 +1,2 @@
+[foo]
+bar = "baz"

--- a/cli/tests/integrations/test_config.py
+++ b/cli/tests/integrations/test_config.py
@@ -151,6 +151,25 @@ def test_set_new_output(env):
     config_set('core.dcos_url', 'http://dcos.snakeoil.mesosphere.com', env)
 
 
+def test_set_nonexistent_subcommand(env):
+    assert_command(
+        ['dcos', 'config', 'set', 'foo.bar', 'baz'],
+        stdout=b'',
+        stderr=b"'foo' is not a dcos command.\n",
+        returncode=1,
+        env=env)
+
+
+def test_set_when_extra_section():
+    env = os.environ.copy()
+    path = os.path.join('tests', 'data', 'config', 'invalid_section.toml')
+    env['DCOS_CONFIG'] = path
+    os.chmod(path, 0o600)
+
+    config_set('core.dcos_url', 'http://dcos.snakeoil.mesosphere.com', env)
+    config_unset('core.dcos_url', env)
+
+
 def test_unset_property(env):
     config_unset('core.reporting', env)
     _get_missing_value('core.reporting', env)
@@ -295,6 +314,7 @@ def test_timeout(env):
 def test_parse_error():
     env = os.environ.copy()
     path = os.path.join('tests', 'data', 'config', 'parse_error.toml')
+    os.chmod(path, 0o600)
     env['DCOS_CONFIG'] = path
 
     assert_command(['dcos', 'config', 'show'],

--- a/dcos/config.py
+++ b/dcos/config.py
@@ -132,7 +132,7 @@ def set_val(name, value):
 
     toml_config[name] = new_value
 
-    check_config(toml_config_pre, toml_config)
+    check_config(toml_config_pre, toml_config, section)
 
     save(toml_config)
 
@@ -352,20 +352,22 @@ def get_property_description(section, subkey):
             "No schema found found for {}.{}".format(section, subkey))
 
 
-def check_config(toml_config_pre, toml_config_post):
+def check_config(toml_config_pre, toml_config_post, section):
     """
     :param toml_config_pre: dictionary for the value before change
     :type toml_config_pre: dcos.api.config.Toml
     :param toml_config_post: dictionary for the value with change
     :type toml_config_post: dcos.api.config.Toml
+    :param section: section of the config to check
+    :type section: str
     :returns: process status
     :rtype: int
     """
 
-    errors_pre = util.validate_json(toml_config_pre._dictionary,
-                                    generate_root_schema(toml_config_pre))
-    errors_post = util.validate_json(toml_config_post._dictionary,
-                                     generate_root_schema(toml_config_post))
+    errors_pre = util.validate_json(toml_config_pre._dictionary[section],
+                                    get_config_schema(section))
+    errors_post = util.validate_json(toml_config_post._dictionary[section],
+                                     get_config_schema(section))
 
     logger.info('Comparing changes in the configuration...')
     logger.info('Errors before the config command: %r', errors_pre)


### PR DESCRIPTION
For example, if you have a spark section in the config, and you uninstall the spark subcommand, trying to add anything to the config will result in a 'spark is not a dcos command' error. 

Instead, if the user is not changing the 'spark' section in the toml, we shouldn't be validating it. 