### PR TITLE
Implement `pod add` subcommand

### DIFF
--- a/cli/binary/binary.spec
+++ b/cli/binary/binary.spec
@@ -11,7 +11,8 @@ a = Analysis(['../dcoscli/main.py'],
                      ],
              binaries=None,
             datas=[('../dcoscli/data/help/*', 'dcoscli/data/help'),
-                   ('../../dcos/data/config-schema/*', 'dcos/data/config-schema')
+                   ('../../dcos/data/config-schema/*', 'dcos/data/config-schema'),
+                   ('../../dcos/data/marathon/*', 'dcos/data/marathon')
                   ],
              hiddenimports=[],
              hookspath=[],

--- a/cli/dcoscli/data/help/marathon.txt
+++ b/cli/dcoscli/data/help/marathon.txt
@@ -27,6 +27,7 @@ Usage:
     dcos marathon group show [--group-version=<group-version>] <group-id>
     dcos marathon group remove [--force] <group-id>
     dcos marathon group update [--force] <group-id> [<properties>...]
+    dcos marathon pod add [<pod-resource>]
     dcos marathon task list [--json <app-id>]
     dcos marathon task stop [--wipe] <task-id>
     dcos marathon task show <task-id>
@@ -74,6 +75,8 @@ Commands:
         Remove a group.
     group update
         Update a group.
+    pod add
+        Create a new pod.
     task list
         List all tasks.
     task stop
@@ -132,6 +135,9 @@ Positional Arguments:
         https://mesosphere.github.io/marathon/docs/rest-api.html#post-v2-groups.
     <instances>
         The number of instances.
+    <pod-resource>
+        Path to a file or HTTP(S) URL that contains the pod's JSON definition.
+        If omitted, the definition is read from stdin.
     <properties>
         List of space-separated config.json properties to update.  The list must
         be formatted as <key>=<value>. For example, `cpus=2.0 mem=308`. If

--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -40,6 +40,7 @@ def _cmds():
     :returns: all the supported commands
     :rtype: dcos.cmds.Command
     """
+
     subcommand = MarathonSubcommand()
 
     return [
@@ -251,10 +252,6 @@ def _get_resource(resource):
 
 class MarathonSubcommand(object):
     """Defines a method for each operation of the `dcos marathon` subcommand.
-
-    Having the operations as methods on this class improves modularity and
-    allows common dependencies to be provided to the class constructor. It
-    also makes it much easier to mock dependencies in unit tests.
 
     :param resource_reader: a callable that takes a resource file path as an
                             argument and returns the file contents, as JSON

--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -158,6 +158,11 @@ def _cmds():
             function=_group_scale),
 
         cmds.Command(
+            hierarchy=['marathon', 'pod', 'add'],
+            arg_keys=['<pod-resource>'],
+            function=pod_subcommand.add),
+
+        cmds.Command(
             hierarchy=['marathon', 'about'],
             arg_keys=[],
             function=_about),
@@ -884,3 +889,7 @@ class MarathonPodSubcommand(object):
         pod_json = self._resource_reader(pod_resource_path)
         self._marathon_client.add_pod(pod_json)
         return 0
+
+
+pod_subcommand = MarathonPodSubcommand(
+    resource_reader=_get_resource, marathon_client=marathon.create_client())

--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -877,9 +877,10 @@ def _cli_config_schema():
 class MarathonPodSubcommand(object):
 
     def __init__(self, resource_reader, marathon_client):
+        self._resource_reader = resource_reader
         self._marathon_client = marathon_client
-        pass
 
     def add(self, pod_resource_path):
-        self._marathon_client.add_pod({"arbitrary": "json"})
+        pod_json = self._resource_reader(pod_resource_path)
+        self._marathon_client.add_pod(pod_json)
         return 0

--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -872,3 +872,14 @@ def _cli_config_schema():
         pkg_resources.resource_string(
             'dcos',
             'data/config-schema/marathon.json').decode('utf-8'))
+
+
+class MarathonPodSubcommand(object):
+
+    def __init__(self, resource_reader, marathon_client):
+        self._marathon_client = marathon_client
+        pass
+
+    def add(self, pod_resource_path):
+        self._marathon_client.add_pod({"arbitrary": "json"})
+        return 0

--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -32,146 +32,141 @@ def _main(argv):
         argv=argv,
         version='dcos-marathon version {}'.format(dcoscli.version))
 
-    marathon_client = marathon.create_client()
-    pod_subcommand = MarathonPodSubcommand(resource_reader=_get_resource,
-                                           marathon_client=marathon_client)
-
-    return cmds.execute(_cmds(pod_subcommand), args)
+    return cmds.execute(_cmds(), args)
 
 
-def _cmds(pod_subcommand):
+def _cmds():
     """
-    :param pod_subcommand: object implementing all `marathon pod` subcommands
-    :type pod_subcommand: MarathonPodSubcommand
     :returns: all the supported commands
     :rtype: dcos.cmds.Command
     """
+    subcommand = MarathonSubcommand()
 
     return [
         cmds.Command(
             hierarchy=['marathon', 'version', 'list'],
             arg_keys=['<app-id>', '--max-count'],
-            function=_version_list),
+            function=subcommand.version_list),
 
         cmds.Command(
             hierarchy=['marathon', 'deployment', 'list'],
             arg_keys=['<app-id>', '--json'],
-            function=_deployment_list),
+            function=subcommand.deployment_list),
 
         cmds.Command(
             hierarchy=['marathon', 'deployment', 'rollback'],
             arg_keys=['<deployment-id>'],
-            function=_deployment_rollback),
+            function=subcommand.deployment_rollback),
 
         cmds.Command(
             hierarchy=['marathon', 'deployment', 'stop'],
             arg_keys=['<deployment-id>'],
-            function=_deployment_stop),
+            function=subcommand.deployment_stop),
 
         cmds.Command(
             hierarchy=['marathon', 'deployment', 'watch'],
             arg_keys=['<deployment-id>', '--max-count', '--interval'],
-            function=_deployment_watch),
+            function=subcommand.deployment_watch),
 
         cmds.Command(
             hierarchy=['marathon', 'task', 'list'],
             arg_keys=['<app-id>', '--json'],
-            function=_task_list),
+            function=subcommand.task_list),
 
         cmds.Command(
             hierarchy=['marathon', 'task', 'stop'],
             arg_keys=['<task-id>', '--wipe'],
-            function=_task_stop),
+            function=subcommand.task_stop),
 
         cmds.Command(
             hierarchy=['marathon', 'task', 'show'],
             arg_keys=['<task-id>'],
-            function=_task_show),
+            function=subcommand.task_show),
 
         cmds.Command(
             hierarchy=['marathon', 'app', 'add'],
             arg_keys=['<app-resource>'],
-            function=_add),
+            function=subcommand.add),
 
         cmds.Command(
             hierarchy=['marathon', 'app', 'list'],
             arg_keys=['--json'],
-            function=_list),
+            function=subcommand.list),
 
         cmds.Command(
             hierarchy=['marathon', 'app', 'remove'],
             arg_keys=['<app-id>', '--force'],
-            function=_remove),
+            function=subcommand.remove),
 
         cmds.Command(
             hierarchy=['marathon', 'app', 'show'],
             arg_keys=['<app-id>', '--app-version'],
-            function=_show),
+            function=subcommand.show),
 
         cmds.Command(
             hierarchy=['marathon', 'app', 'start'],
             arg_keys=['<app-id>', '<instances>', '--force'],
-            function=_start),
+            function=subcommand.start),
 
         cmds.Command(
             hierarchy=['marathon', 'app', 'stop'],
             arg_keys=['<app-id>', '--force'],
-            function=_stop),
+            function=subcommand.stop),
 
         cmds.Command(
             hierarchy=['marathon', 'app', 'update'],
             arg_keys=['<app-id>', '<properties>', '--force'],
-            function=_update),
+            function=subcommand.update),
 
         cmds.Command(
             hierarchy=['marathon', 'app', 'restart'],
             arg_keys=['<app-id>', '--force'],
-            function=_restart),
+            function=subcommand.restart),
 
         cmds.Command(
             hierarchy=['marathon', 'app', 'kill'],
             arg_keys=['<app-id>', '--scale', '--host'],
-            function=_kill),
+            function=subcommand.kill),
 
         cmds.Command(
             hierarchy=['marathon', 'group', 'add'],
             arg_keys=['<group-resource>'],
-            function=_group_add),
+            function=subcommand.group_add),
 
         cmds.Command(
             hierarchy=['marathon', 'group', 'list'],
             arg_keys=['--json'],
-            function=_group_list),
+            function=subcommand.group_list),
 
         cmds.Command(
             hierarchy=['marathon', 'group', 'show'],
             arg_keys=['<group-id>', '--group-version'],
-            function=_group_show),
+            function=subcommand.group_show),
 
         cmds.Command(
             hierarchy=['marathon', 'group', 'remove'],
             arg_keys=['<group-id>', '--force'],
-            function=_group_remove),
+            function=subcommand.group_remove),
 
         cmds.Command(
             hierarchy=['marathon', 'group', 'update'],
             arg_keys=['<group-id>', '<properties>', '--force'],
-            function=_group_update),
+            function=subcommand.group_update),
 
         cmds.Command(
             hierarchy=['marathon', 'group', 'scale'],
             arg_keys=['<group-id>', '<scale-factor>', '--force'],
-            function=_group_scale),
+            function=subcommand.group_scale),
 
         cmds.Command(
             hierarchy=['marathon', 'pod', 'add'],
             arg_keys=['<pod-resource>'],
-            function=pod_subcommand.add),
+            function=subcommand.pod_add),
 
         cmds.Command(
             hierarchy=['marathon', 'about'],
             arg_keys=[],
-            function=_about),
+            function=subcommand.about),
 
         cmds.Command(
             hierarchy=['marathon'],
@@ -210,18 +205,6 @@ def _info():
     """
 
     emitter.publish(default_command_info("marathon"))
-    return 0
-
-
-def _about():
-    """
-    :returns: process return code
-    :rtype: int
-    """
-
-    client = marathon.create_client()
-
-    emitter.publish(client.get_about())
     return 0
 
 
@@ -266,312 +249,568 @@ def _get_resource(resource):
     return util.load_json(sys.stdin)
 
 
-def _add(app_resource):
-    """
-    :param app_resource: optional filename for the application resource
-    :type app_resource: str
-    :returns: process return code
-    :rtype: int
-    """
-    application_resource = _get_resource(app_resource)
+class MarathonSubcommand(object):
+    """Defines a method for each operation of the `dcos marathon` subcommand.
 
-    # Add application to marathon
-    client = marathon.create_client()
+    Having the operations as methods on this class improves modularity and
+    allows common dependencies to be provided to the class constructor. It
+    also makes it much easier to mock dependencies in unit tests.
 
-    # Check that the application doesn't exist
-    app_id = client.normalize_app_id(application_resource['id'])
-
-    try:
-        client.get_app(app_id)
-    except DCOSException as e:
-        logger.exception(e)
-    else:
-        raise DCOSException("Application '{}' already exists".format(app_id))
-
-    client.add_app(application_resource)
-
-    return 0
-
-
-def _list(json_):
-    """
-    :param json_: output json if True
-    :type json_: bool
-    :returns: process return code
-    :rtype: int
+    :param resource_reader: a callable that takes a resource file path as an
+                            argument and returns the file contents, as JSON
+    :type resource_reader: collections.abc.Callable
+    :param create_marathon_client: a callable that returns an instance of
+                                   marathon.Client
+    :type create_marathon_client: collections.abc.Callable
     """
 
-    client = marathon.create_client()
-    apps = client.get_apps()
+    def __init__(self,
+                 resource_reader=_get_resource,
+                 create_marathon_client=marathon.create_client):
+        self._resource_reader = resource_reader
+        self._create_marathon_client = create_marathon_client
 
-    if json_:
-        emitter.publish(apps)
-    else:
-        deployments = client.get_deployments()
-        table = tables.app_table(apps, deployments)
-        output = six.text_type(table)
-        if output:
-            emitter.publish(output)
+    def about(self):
+        """
+        :returns: process return code
+        :rtype: int
+        """
 
-    return 0
+        client = self._create_marathon_client()
 
+        emitter.publish(client.get_about())
+        return 0
 
-def _group_list(json_):
-    """
-    :param json_: output json if True
-    :type json_: bool
-    :rtype: int
-    :returns: process return code
-    """
+    def add(self, app_resource):
+        """
+        :param app_resource: optional filename for the application resource
+        :type app_resource: str
+        :returns: process return code
+        :rtype: int
+        """
+        application_resource = self._resource_reader(app_resource)
 
-    client = marathon.create_client()
-    groups = client.get_groups()
+        # Add application to marathon
+        client = self._create_marathon_client()
 
-    emitting.publish_table(emitter, groups, tables.group_table, json_)
-    return 0
+        # Check that the application doesn't exist
+        app_id = client.normalize_app_id(application_resource['id'])
 
+        try:
+            client.get_app(app_id)
+        except DCOSException as e:
+            logger.exception(e)
+        else:
+            message = "Application '{}' already exists".format(app_id)
+            raise DCOSException(message)
 
-def _group_add(group_resource):
-    """
-    :param group_resource: optional filename for the group resource
-    :type group_resource: str
-    :returns: process return code
-    :rtype: int
-    """
+        client.add_app(application_resource)
 
-    group_resource = _get_resource(group_resource)
+        return 0
 
-    client = marathon.create_client()
+    def list(self, json_):
+        """
+        :param json_: output json if True
+        :type json_: bool
+        :returns: process return code
+        :rtype: int
+        """
 
-    # Check that the group doesn't exist
-    group_id = client.normalize_app_id(group_resource['id'])
+        client = self._create_marathon_client()
+        apps = client.get_apps()
 
-    try:
+        if json_:
+            emitter.publish(apps)
+        else:
+            deployments = client.get_deployments()
+            table = tables.app_table(apps, deployments)
+            output = six.text_type(table)
+            if output:
+                emitter.publish(output)
+
+        return 0
+
+    def group_list(self, json_):
+        """
+        :param json_: output json if True
+        :type json_: bool
+        :rtype: int
+        :returns: process return code
+        """
+
+        client = self._create_marathon_client()
+        groups = client.get_groups()
+
+        emitting.publish_table(emitter, groups, tables.group_table, json_)
+        return 0
+
+    def group_add(self, group_resource):
+        """
+        :param group_resource: optional filename for the group resource
+        :type group_resource: str
+        :returns: process return code
+        :rtype: int
+        """
+
+        group_resource = self._resource_reader(group_resource)
+
+        client = self._create_marathon_client()
+
+        # Check that the group doesn't exist
+        group_id = client.normalize_app_id(group_resource['id'])
+
+        try:
+            client.get_group(group_id)
+        except DCOSException as e:
+            logger.exception(e)
+        else:
+            raise DCOSException("Group '{}' already exists".format(group_id))
+
+        client.create_group(group_resource)
+
+        return 0
+
+    def remove(self, app_id, force):
+        """
+        :param app_id: ID of the app to remove
+        :type app_id: str
+        :param force: Whether to override running deployments.
+        :type force: bool
+        :returns: process return code
+        :rtype: int
+        """
+
+        client = self._create_marathon_client()
+        client.remove_app(app_id, force)
+        return 0
+
+    def group_remove(self, group_id, force):
+        """
+        :param group_id: ID of the app to remove
+        :type group_id: str
+        :param force: Whether to override running deployments.
+        :type force: bool
+        :returns: process return code
+        :rtype: int
+        """
+
+        client = self._create_marathon_client()
+        client.remove_group(group_id, force)
+        return 0
+
+    def show(self, app_id, version):
+        """Show details of a Marathon application.
+
+        :param app_id: The id for the application
+        :type app_id: str
+        :param version: The version, either absolute (date-time) or relative
+        :type version: str
+        :returns: process return code
+        :rtype: int
+        """
+
+        client = self._create_marathon_client()
+
+        if version is not None:
+            version = _calculate_version(client, app_id, version)
+
+        app = client.get_app(app_id, version=version)
+
+        emitter.publish(app)
+        return 0
+
+    def group_show(self, group_id, version=None):
+        """Show details of a Marathon application.
+
+        :param group_id: The id for the application
+        :type group_id: str
+        :param version: The version, either absolute (date-time) or relative
+        :type version: str
+        :returns: process return code
+        :rtype: int
+        """
+
+        client = self._create_marathon_client()
+
+        app = client.get_group(group_id, version=version)
+
+        emitter.publish(app)
+        return 0
+
+    def group_update(self, group_id, properties, force):
+        """
+        :param group_id: the id of the group
+        :type group_id: str
+        :param properties: json items used to update group
+        :type properties: [str]
+        :param force: whether to override running deployments
+        :type force: bool
+        :returns: process return code
+        :rtype: int
+        """
+
+        client = self._create_marathon_client()
+
+        # Ensure that the group exists
         client.get_group(group_id)
-    except DCOSException as e:
-        logger.exception(e)
-    else:
-        raise DCOSException("Group '{}' already exists".format(group_id))
 
-    client.create_group(group_resource)
+        properties = _parse_properties(properties)
+        deployment = client.update_group(group_id, properties, force)
 
-    return 0
+        emitter.publish('Created deployment {}'.format(deployment))
+        return 0
 
+    def start(self, app_id, instances, force):
+        """Start a Marathon application.
 
-def _remove(app_id, force):
-    """
-    :param app_id: ID of the app to remove
-    :type app_id: str
-    :param force: Whether to override running deployments.
-    :type force: bool
-    :returns: process return code
-    :rtype: int
-    """
+        :param app_id: the id for the application
+        :type app_id: str
+        :param instances: the number of instances to start
+        :type instances: str
+        :param force: whether to override running deployments
+        :type force: bool
+        :returns: process return code
+        :rtype: int
+        """
 
-    client = marathon.create_client()
-    client.remove_app(app_id, force)
-    return 0
+        # Check that the application exists
+        client = self._create_marathon_client()
 
+        desc = client.get_app(app_id)
 
-def _group_remove(group_id, force):
-    """
-    :param group_id: ID of the app to remove
-    :type group_id: str
-    :param force: Whether to override running deployments.
-    :type force: bool
-    :returns: process return code
-    :rtype: int
-    """
-
-    client = marathon.create_client()
-    client.remove_group(group_id, force)
-    return 0
-
-
-def _show(app_id, version):
-    """Show details of a Marathon application.
-
-    :param app_id: The id for the application
-    :type app_id: str
-    :param version: The version, either absolute (date-time) or relative
-    :type version: str
-    :returns: process return code
-    :rtype: int
-    """
-
-    client = marathon.create_client()
-
-    if version is not None:
-        version = _calculate_version(client, app_id, version)
-
-    app = client.get_app(app_id, version=version)
-
-    emitter.publish(app)
-    return 0
-
-
-def _group_show(group_id, version=None):
-    """Show details of a Marathon application.
-
-    :param group_id: The id for the application
-    :type group_id: str
-    :param version: The version, either absolute (date-time) or relative
-    :type version: str
-    :returns: process return code
-    :rtype: int
-    """
-
-    client = marathon.create_client()
-
-    app = client.get_group(group_id, version=version)
-
-    emitter.publish(app)
-    return 0
-
-
-def _group_update(group_id, properties, force):
-    """
-    :param group_id: the id of the group
-    :type group_id: str
-    :param properties: json items used to update group
-    :type properties: [str]
-    :param force: whether to override running deployments
-    :type force: bool
-    :returns: process return code
-    :rtype: int
-    """
-
-    client = marathon.create_client()
-
-    # Ensure that the group exists
-    client.get_group(group_id)
-
-    properties = _parse_properties(properties)
-    deployment = client.update_group(group_id, properties, force)
-
-    emitter.publish('Created deployment {}'.format(deployment))
-    return 0
-
-
-def _start(app_id, instances, force):
-    """Start a Marathon application.
-
-    :param app_id: the id for the application
-    :type app_id: str
-    :param instances: the number of instances to start
-    :type instances: str
-    :param force: whether to override running deployments
-    :type force: bool
-    :returns: process return code
-    :rtype: int
-    """
-
-    # Check that the application exists
-    client = marathon.create_client()
-
-    desc = client.get_app(app_id)
-
-    if desc['instances'] > 0:
-        emitter.publish(
-            'Application {!r} already started: {!r} instances.'.format(
-                app_id,
-                desc['instances']))
-        return 1
-
-    # Need to add the 'id' because it is required
-    app_json = {'id': app_id}
-
-    # Set instances to 1 if not specified
-    if instances is None:
-        instances = 1
-    else:
-        instances = util.parse_int(instances)
-        if instances <= 0:
+        if desc['instances'] > 0:
             emitter.publish(
-                'The number of instances must be positive: {!r}.'.format(
-                    instances))
+                'Application {!r} already started: {!r} instances.'.format(
+                    app_id,
+                    desc['instances']))
             return 1
 
-    app_json['instances'] = instances
+        # Need to add the 'id' because it is required
+        app_json = {'id': app_id}
 
-    deployment = client.update_app(app_id, app_json, force)
+        # Set instances to 1 if not specified
+        if instances is None:
+            instances = 1
+        else:
+            instances = util.parse_int(instances)
+            if instances <= 0:
+                emitter.publish(
+                    'The number of instances must be positive: {!r}.'.format(
+                        instances))
+                return 1
 
-    emitter.publish('Created deployment {}'.format(deployment))
+        app_json['instances'] = instances
 
-    return 0
+        deployment = client.update_app(app_id, app_json, force)
 
+        emitter.publish('Created deployment {}'.format(deployment))
 
-def _stop(app_id, force):
-    """Stop a Marathon application
+        return 0
 
-    :param app_id: the id of the application
-    :type app_id: str
-    :param force: whether to override running deployments
-    :type force: bool
-    :returns: process return code
-    :rtype: int
-    """
+    def stop(self, app_id, force):
+        """Stop a Marathon application
 
-    # Check that the application exists
-    client = marathon.create_client()
+        :param app_id: the id of the application
+        :type app_id: str
+        :param force: whether to override running deployments
+        :type force: bool
+        :returns: process return code
+        :rtype: int
+        """
 
-    desc = client.get_app(app_id)
+        # Check that the application exists
+        client = self._create_marathon_client()
 
-    if desc['instances'] <= 0:
-        emitter.publish(
-            'Application {!r} already stopped: {!r} instances.'.format(
-                app_id,
-                desc['instances']))
-        return 1
+        desc = client.get_app(app_id)
 
-    app_json = {'instances': 0}
+        if desc['instances'] <= 0:
+            emitter.publish(
+                'Application {!r} already stopped: {!r} instances.'.format(
+                    app_id,
+                    desc['instances']))
+            return 1
 
-    deployment = client.update_app(app_id, app_json, force)
+        app_json = {'instances': 0}
 
-    emitter.publish('Created deployment {}'.format(deployment))
+        deployment = client.update_app(app_id, app_json, force)
 
+        emitter.publish('Created deployment {}'.format(deployment))
 
-def _update(app_id, properties, force):
-    """
-    :param app_id: the id of the application
-    :type app_id: str
-    :param properties: json items used to update resource
-    :type properties: [str]
-    :param force: whether to override running deployments
-    :type force: bool
-    :returns: process return code
-    :rtype: int
-    """
+    def update(self, app_id, properties, force):
+        """
+        :param app_id: the id of the application
+        :type app_id: str
+        :param properties: json items used to update resource
+        :type properties: [str]
+        :param force: whether to override running deployments
+        :type force: bool
+        :returns: process return code
+        :rtype: int
+        """
 
-    client = marathon.create_client()
+        client = self._create_marathon_client()
 
-    # Ensure that the application exists
-    client.get_app(app_id)
+        # Ensure that the application exists
+        client.get_app(app_id)
 
-    properties = _parse_properties(properties)
-    deployment = client.update_app(app_id, properties, force)
+        properties = _parse_properties(properties)
+        deployment = client.update_app(app_id, properties, force)
 
-    emitter.publish('Created deployment {}'.format(deployment))
-    return 0
+        emitter.publish('Created deployment {}'.format(deployment))
+        return 0
 
+    def group_scale(self, group_id, scale_factor, force):
+        """
+        :param group_id: the id of the group
+        :type group_id: str
+        :param scale_factor: scale factor for application group
+        :type scale_factor: str
+        :param force: whether to override running deployments
+        :type force: bool
+        :returns: process return code
+        :rtype: int
+        """
 
-def _group_scale(group_id, scale_factor, force):
-    """
-    :param group_id: the id of the group
-    :type group_id: str
-    :param scale_factor: scale factor for application group
-    :type scale_factor: str
-    :param force: whether to override running deployments
-    :type force: bool
-    :returns: process return code
-    :rtype: int
-    """
+        client = self._create_marathon_client()
+        scale_factor = util.parse_float(scale_factor)
+        deployment = client.scale_group(group_id, scale_factor, force)
+        emitter.publish('Created deployment {}'.format(deployment))
+        return 0
 
-    client = marathon.create_client()
-    scale_factor = util.parse_float(scale_factor)
-    deployment = client.scale_group(group_id, scale_factor, force)
-    emitter.publish('Created deployment {}'.format(deployment))
-    return 0
+    def restart(self, app_id, force):
+        """
+        :param app_id: the id of the application
+        :type app_id: str
+        :param force: whether to override running deployments
+        :type force: bool
+        :returns: process return code
+        :rtype: int
+        """
+
+        client = self._create_marathon_client()
+
+        desc = client.get_app(app_id)
+
+        if desc['instances'] <= 0:
+            app_id = client.normalize_app_id(app_id)
+            emitter.publish(
+                'Unable to perform rolling restart of application {!r} '
+                'because it has no running tasks'.format(
+                    app_id,
+                    desc['instances']))
+            return 1
+
+        payload = client.restart_app(app_id, force)
+
+        message = 'Created deployment {}'.format(payload['deploymentId'])
+        emitter.publish(message)
+        return 0
+
+    def kill(self, app_id, scale, host):
+        """
+        :param app_id: the id of the application
+        :type app_id: str
+        :param scale: Scale the app down
+        :type scale: bool
+        :param host: Kill only those tasks running on host specified
+        :type host: str
+        :returns: process return code
+        :rtype: int
+        """
+        client = self._create_marathon_client()
+
+        payload = client.kill_tasks(app_id, host=host, scale=scale)
+        # If scale is provided, the API return a "deploymentResult"
+        # https://github.com/mesosphere/marathon/blob/50366c8/src/main/scala/mesosphere/marathon/api/RestResource.scala#L34-L36
+        if scale:
+            emitter.publish("Started deployment: {}".format(payload))
+        else:
+            if 'tasks' in payload:
+                emitter.publish('Killed tasks: {}'.format(payload['tasks']))
+                if len(payload['tasks']) == 0:
+                    return 1
+            else:
+                emitter.publish('Killed tasks: []')
+                return 1
+        return 0
+
+    def version_list(self, app_id, max_count):
+        """
+        :param app_id: the id of the application
+        :type app_id: str
+        :param max_count: the maximum number of version to fetch and return
+        :type max_count: str
+        :returns: process return code
+        :rtype: int
+        """
+
+        if max_count is not None:
+            max_count = util.parse_int(max_count)
+
+        client = self._create_marathon_client()
+
+        versions = client.get_app_versions(app_id, max_count)
+
+        emitter.publish(versions)
+        return 0
+
+    def deployment_list(self, app_id, json_):
+        """
+        :param app_id: the application id
+        :type app_id: str
+        :param json_: output json if True
+        :type json_: bool
+        :returns: process return code
+        :rtype: int
+        """
+
+        client = self._create_marathon_client()
+
+        deployments = client.get_deployments(app_id)
+
+        if not deployments and not json_:
+            msg = "There are no deployments"
+            if app_id:
+                msg += " for '{}'".format(app_id)
+            raise DCOSException(msg)
+
+        emitting.publish_table(emitter,
+                               deployments,
+                               tables.deployment_table,
+                               json_)
+        return 0
+
+    def deployment_stop(self, deployment_id):
+        """
+        :param deployment_id: the application id
+        :type deployment_id: str
+        :returns: process return code
+        :rtype: int
+        """
+
+        client = self._create_marathon_client()
+        client.stop_deployment(deployment_id)
+
+        return 0
+
+    def deployment_rollback(self, deployment_id):
+        """
+        :param deployment_id: the application id
+        :type deployment_id: str
+        :returns: process return code
+        :rtype: int
+        """
+
+        client = self._create_marathon_client()
+        deployment = client.rollback_deployment(deployment_id)
+
+        emitter.publish(deployment)
+        return 0
+
+    def deployment_watch(self, deployment_id, max_count, interval):
+        """
+        :param deployment_id: the application id
+        :type deployment_id: str
+        :param max_count: maximum number of polling calls
+        :type max_count: str
+        :param interval: wait interval in seconds between polling calls
+        :type interval: str
+        :returns: process return code
+        :rtype: int
+        """
+
+        if max_count is not None:
+            max_count = util.parse_int(max_count)
+
+        interval = 1 if interval is None else util.parse_int(interval)
+
+        client = self._create_marathon_client()
+
+        count = 0
+        while max_count is None or count < max_count:
+            deployment = client.get_deployment(deployment_id)
+
+            if deployment is None:
+                return 0
+            if util.is_windows_platform():
+                os.system('cls')
+            else:
+                if 'TERM' in os.environ:
+                    os.system('clear')
+            emitter.publish('Deployment update time: '
+                            '{} \n'.format(time.strftime("%Y-%m-%d %H:%M:%S",
+                                                         time.gmtime())))
+            emitter.publish(deployment)
+            time.sleep(interval)
+            count += 1
+
+        return 0
+
+    def task_list(self, app_id, json_):
+        """
+        :param app_id: the id of the application
+        :type app_id: str
+        :param json_: output json if True
+        :type json_: bool
+        :returns: process return code
+        :rtype: int
+        """
+
+        client = self._create_marathon_client()
+        tasks = client.get_tasks(app_id)
+
+        emitting.publish_table(emitter, tasks, tables.app_task_table, json_)
+        return 0
+
+    def task_stop(self, task_id, wipe):
+        """Stop a Marathon task
+
+        :param task_id: the id of the task
+        :type task_id: str
+        :param wipe: whether to wipe persistent data and unreserve resources
+        :type wipe: bool
+        :returns: process return code
+        :rtype: int
+        """
+
+        client = self._create_marathon_client()
+        task = client.stop_task(task_id, wipe)
+
+        if task is None:
+            raise DCOSException("Task '{}' does not exist".format(task_id))
+
+        emitter.publish(task)
+        return 0
+
+    def task_show(self, task_id):
+        """
+        :param task_id: the task id
+        :type task_id: str
+        :returns: process return code
+        :rtype: int
+        """
+
+        client = self._create_marathon_client()
+        task = client.get_task(task_id)
+
+        if task is None:
+            raise DCOSException("Task '{}' does not exist".format(task_id))
+
+        emitter.publish(task)
+        return 0
+
+    def pod_add(self, pod_resource_path):
+        """
+        :param pod_resource_path: optional file path for the pod resource
+        :type pod_resource_path: str
+        :returns: process return code
+        :rtype: int
+        """
+        marathon_client = self._create_marathon_client()
+
+        pod_json = self._resource_reader(pod_resource_path)
+        marathon_client.add_pod(pod_json)
+        return 0
 
 
 def _parse_properties(properties):
@@ -584,12 +823,13 @@ def _parse_properties(properties):
 
     if len(properties) == 0:
         if sys.stdin.isatty():
-            # We don't support TTY right now. In the future we will start an
-            # editor
+            # We don't support TTY right now.
+            # In the future we will start an editor
             raise DCOSException(
                 "We currently don't support reading from the TTY. Please "
                 "specify an application JSON.\n"
-                "E.g. dcos marathon app update your-app-id < app_update.json")
+                "E.g. dcos marathon app update your-app-id "
+                "< app_update.json")
         else:
             return util.load_jsons(sys.stdin.read())
 
@@ -604,237 +844,6 @@ def _parse_properties(properties):
 
         resource_json[key] = value
     return resource_json
-
-
-def _restart(app_id, force):
-    """
-    :param app_id: the id of the application
-    :type app_id: str
-    :param force: whether to override running deployments
-    :type force: bool
-    :returns: process return code
-    :rtype: int
-    """
-
-    client = marathon.create_client()
-
-    desc = client.get_app(app_id)
-
-    if desc['instances'] <= 0:
-        app_id = client.normalize_app_id(app_id)
-        emitter.publish(
-            'Unable to perform rolling restart of application {!r} '
-            'because it has no running tasks'.format(
-                app_id,
-                desc['instances']))
-        return 1
-
-    payload = client.restart_app(app_id, force)
-
-    emitter.publish('Created deployment {}'.format(payload['deploymentId']))
-    return 0
-
-
-def _kill(app_id, scale, host):
-    """
-    :param app_id: the id of the application
-    :type app_id: str
-    :param: scale: Scale the app down
-    :type: scale: bool
-    :param: host: Kill only those tasks running on host specified
-    :type: string
-    :returns: process return code
-    :rtype: int
-    """
-    client = marathon.create_client()
-
-    payload = client.kill_tasks(app_id, host=host, scale=scale)
-    # If scale is provided, the API return a "deploymentResult"
-    # https://github.com/mesosphere/marathon/blob/50366c8/src/main/scala/mesosphere/marathon/api/RestResource.scala#L34-L36
-    if scale:
-        emitter.publish("Started deployment: {}".format(payload))
-    else:
-        if 'tasks' in payload:
-            emitter.publish('Killed tasks: {}'.format(payload['tasks']))
-            if len(payload['tasks']) == 0:
-                return 1
-        else:
-            emitter.publish('Killed tasks: []')
-            return 1
-    return 0
-
-
-def _version_list(app_id, max_count):
-    """
-    :param app_id: the id of the application
-    :type app_id: str
-    :param max_count: the maximum number of version to fetch and return
-    :type max_count: str
-    :returns: process return code
-    :rtype: int
-    """
-
-    if max_count is not None:
-        max_count = util.parse_int(max_count)
-
-    client = marathon.create_client()
-
-    versions = client.get_app_versions(app_id, max_count)
-
-    emitter.publish(versions)
-    return 0
-
-
-def _deployment_list(app_id, json_):
-    """
-    :param app_id: the application id
-    :type app_id: str
-    :param json_: output json if True
-    :type json_: bool
-    :returns: process return code
-    :rtype: int
-    """
-
-    client = marathon.create_client()
-
-    deployments = client.get_deployments(app_id)
-
-    if not deployments and not json_:
-        msg = "There are no deployments"
-        if app_id:
-            msg += " for '{}'".format(app_id)
-        raise DCOSException(msg)
-
-    emitting.publish_table(emitter,
-                           deployments,
-                           tables.deployment_table,
-                           json_)
-    return 0
-
-
-def _deployment_stop(deployment_id):
-    """
-    :param deployment_id: the application id
-    :type deployment_di: str
-    :returns: process return code
-    :rtype: int
-    """
-
-    client = marathon.create_client()
-    client.stop_deployment(deployment_id)
-
-    return 0
-
-
-def _deployment_rollback(deployment_id):
-    """
-    :param deployment_id: the application id
-    :type deployment_di: str
-    :returns: process return code
-    :rtype: int
-    """
-
-    client = marathon.create_client()
-    deployment = client.rollback_deployment(deployment_id)
-
-    emitter.publish(deployment)
-    return 0
-
-
-def _deployment_watch(deployment_id, max_count, interval):
-    """
-    :param deployment_id: the application id
-    :type deployment_di: str
-    :param max_count: maximum number of polling calls
-    :type max_count: str
-    :param interval: wait interval in seconds between polling calls
-    :type interval: str
-    :returns: process return code
-    :rtype: int
-    """
-
-    if max_count is not None:
-        max_count = util.parse_int(max_count)
-
-    interval = 1 if interval is None else util.parse_int(interval)
-
-    client = marathon.create_client()
-
-    count = 0
-    while max_count is None or count < max_count:
-        deployment = client.get_deployment(deployment_id)
-
-        if deployment is None:
-            return 0
-        if util.is_windows_platform():
-            os.system('cls')
-        else:
-            if 'TERM' in os.environ:
-                os.system('clear')
-        emitter.publish('Deployment update time: '
-                        '{} \n'.format(time.strftime("%Y-%m-%d %H:%M:%S",
-                                                     time.gmtime())))
-        emitter.publish(deployment)
-        time.sleep(interval)
-        count += 1
-
-    return 0
-
-
-def _task_list(app_id, json_):
-    """
-    :param app_id: the id of the application
-    :type app_id: str
-    :param json_: output json if True
-    :type json_: bool
-    :returns: process return code
-    :rtype: int
-    """
-
-    client = marathon.create_client()
-    tasks = client.get_tasks(app_id)
-
-    emitting.publish_table(emitter, tasks, tables.app_task_table, json_)
-    return 0
-
-
-def _task_stop(task_id, wipe):
-    """Stop a Marathon task
-
-    :param task_id: the id of the task
-    :type task_id: str
-    :param wipe: whether to wipe persistent data and unreserve resources
-    :type wipe: bool
-    :returns: process return code
-    :rtype: int
-    """
-
-    client = marathon.create_client()
-    task = client.stop_task(task_id, wipe)
-
-    if task is None:
-        raise DCOSException("Task '{}' does not exist".format(task_id))
-
-    emitter.publish(task)
-    return 0
-
-
-def _task_show(task_id):
-    """
-    :param task_id: the task id
-    :type task_id: str
-    :returns: process return code
-    :rtype: int
-    """
-
-    client = marathon.create_client()
-    task = client.get_task(task_id)
-
-    if task is None:
-        raise DCOSException("Task '{}' does not exist".format(task_id))
-
-    emitter.publish(task)
-    return 0
 
 
 def _calculate_version(client, app_id, version):
@@ -883,15 +892,3 @@ def _cli_config_schema():
         pkg_resources.resource_string(
             'dcos',
             'data/config-schema/marathon.json').decode('utf-8'))
-
-
-class MarathonPodSubcommand(object):
-
-    def __init__(self, resource_reader, marathon_client):
-        self._resource_reader = resource_reader
-        self._marathon_client = marathon_client
-
-    def add(self, pod_resource_path):
-        pod_json = self._resource_reader(pod_resource_path)
-        self._marathon_client.add_pod(pod_json)
-        return 0

--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -32,11 +32,17 @@ def _main(argv):
         argv=argv,
         version='dcos-marathon version {}'.format(dcoscli.version))
 
-    return cmds.execute(_cmds(), args)
+    marathon_client = marathon.create_client()
+    pod_subcommand = MarathonPodSubcommand(resource_reader=_get_resource,
+                                           marathon_client=marathon_client)
+
+    return cmds.execute(_cmds(pod_subcommand), args)
 
 
-def _cmds():
+def _cmds(pod_subcommand):
     """
+    :param pod_subcommand: object implementing all `marathon pod` subcommands
+    :type pod_subcommand: MarathonPodSubcommand
     :returns: all the supported commands
     :rtype: dcos.cmds.Command
     """
@@ -889,7 +895,3 @@ class MarathonPodSubcommand(object):
         pod_json = self._resource_reader(pod_resource_path)
         self._marathon_client.add_pod(pod_json)
         return 0
-
-
-pod_subcommand = MarathonPodSubcommand(
-    resource_reader=_get_resource, marathon_client=marathon.create_client())

--- a/cli/dcoscli/subcommand.py
+++ b/cli/dcoscli/subcommand.py
@@ -40,7 +40,7 @@ def default_doc(command):
     :param command: default DC/OS CLI command
     :type command: str
     :returns: config schema of command
-    :rtype: dict
+    :rtype: str
     """
 
     resource = "data/help/{}.txt".format(command)

--- a/cli/tests/data/help/marathon.txt
+++ b/cli/tests/data/help/marathon.txt
@@ -27,6 +27,7 @@ Usage:
     dcos marathon group show [--group-version=<group-version>] <group-id>
     dcos marathon group remove [--force] <group-id>
     dcos marathon group update [--force] <group-id> [<properties>...]
+    dcos marathon pod add [<pod-resource>]
     dcos marathon task list [--json <app-id>]
     dcos marathon task stop [--wipe] <task-id>
     dcos marathon task show <task-id>
@@ -74,6 +75,8 @@ Commands:
         Remove a group.
     group update
         Update a group.
+    pod add
+        Create a new pod.
     task list
         List all tasks.
     task stop
@@ -132,6 +135,9 @@ Positional Arguments:
         https://mesosphere.github.io/marathon/docs/rest-api.html#post-v2-groups.
     <instances>
         The number of instances.
+    <pod-resource>
+        Path to a file or HTTP(S) URL that contains the pod's JSON definition.
+        If omitted, the definition is read from stdin.
     <properties>
         List of space-separated config.json properties to update.  The list must
         be formatted as <key>=<value>. For example, `cpus=2.0 mem=308`. If

--- a/cli/tests/integrations/test_marathon.py
+++ b/cli/tests/integrations/test_marathon.py
@@ -689,11 +689,12 @@ def test_app_locked_error():
     with app('tests/data/marathon/apps/sleep_many_instances.json',
              '/sleep-many-instances',
              wait=False):
+        stderr = (b'App, group, or pod is locked by one or more deployments. '
+                  b'Override with --force.\n')
         assert_command(
             ['dcos', 'marathon', 'app', 'stop', 'sleep-many-instances'],
             returncode=1,
-            stderr=(b'App or group is locked by one or more deployments. '
-                    b'Override with --force.\n'))
+            stderr=stderr)
 
 
 @pytest.mark.skipif(sys.platform == 'win32',

--- a/cli/tests/integrations/test_marathon_pod.py
+++ b/cli/tests/integrations/test_marathon_pod.py
@@ -3,6 +3,8 @@ import json
 import os
 import re
 
+import pytest
+
 from ..common import assert_same_elements
 from .common import assert_command, exec_command, file_bytes, file_json
 
@@ -19,6 +21,7 @@ TRIPLE_POD_ID = 'winston'
 TRIPLE_POD_FILE_PATH = os.path.join(FILE_PATH_BASE, 'doubleplusgood.json')
 
 
+@pytest.mark.skip(reason="Pods support in Marathon not released yet")
 def test_pod_add_from_file_then_remove():
     returncode, stdout, stderr = _pod_add_from_file(GOOD_POD_FILE_PATH)
     assert returncode == 0
@@ -29,12 +32,14 @@ def test_pod_add_from_file_then_remove():
     _assert_pod_remove(GOOD_POD_ID, extra_args=[])
 
 
+@pytest.mark.skip(reason="Pods support in Marathon not released yet")
 def test_pod_add_from_stdin_then_force_remove():
     # Explicitly testing adding from stdin; can't use the context manager
     _assert_pod_add_from_stdin(GOOD_POD_FILE_PATH)
     _assert_pod_remove(GOOD_POD_ID, extra_args=['--force'])
 
 
+@pytest.mark.skip(reason="Pods support in Marathon not released yet")
 def test_pod_list():
     paths = [GOOD_POD_FILE_PATH, DOUBLE_POD_FILE_PATH, TRIPLE_POD_FILE_PATH]
     expected_json = [file_json(path) for path in paths]
@@ -48,6 +53,7 @@ def test_pod_list():
         _assert_pod_list_table(stdout=expected_table)
 
 
+@pytest.mark.skip(reason="Pods support in Marathon not released yet")
 def test_pod_show():
     expected_stdout = file_bytes(GOOD_POD_FILE_PATH)
 
@@ -55,6 +61,7 @@ def test_pod_show():
         _assert_pod_show(GOOD_POD_ID, expected_stdout)
 
 
+@pytest.mark.skip(reason="Pods support in Marathon not released yet")
 def test_pod_update_from_file():
     expected_show_stdout = file_bytes(UPDATED_GOOD_POD_FILE_PATH)
 
@@ -65,6 +72,7 @@ def test_pod_update_from_file():
         _assert_pod_show(GOOD_POD_ID, expected_show_stdout)
 
 
+@pytest.mark.skip(reason="Pods support in Marathon not released yet")
 def test_pod_update_from_stdin_force_true():
     expected_show_stdout = file_bytes(UPDATED_GOOD_POD_FILE_PATH)
 

--- a/cli/tests/unit/test_marathon_pod.py
+++ b/cli/tests/unit/test_marathon_pod.py
@@ -14,8 +14,8 @@ def _assert_add_invoked_successfully(pod_file_json):
     resource_reader = {pod_file_path: pod_file_json}.__getitem__
     marathon_client = create_autospec(marathon.Client)
 
-    pod = main.MarathonPodSubcommand(resource_reader, marathon_client)
-    returncode = pod.add(pod_file_path)
+    subcmd = main.MarathonSubcommand(resource_reader, lambda: marathon_client)
+    returncode = subcmd.pod_add(pod_file_path)
 
     assert returncode == 0
     marathon_client.add_pod.assert_called_with(pod_file_json)

--- a/cli/tests/unit/test_marathon_pod.py
+++ b/cli/tests/unit/test_marathon_pod.py
@@ -1,14 +1,7 @@
-from mock import Mock, create_autospec
-
-from dcos import marathon
 import dcoscli.marathon.main as main
+from dcos import marathon
 
-# Pod add function
-# Arguments: file path of pod JSON
-# Returns: exit code for CLI, or throws exceptions (see what existing code does)
-# Side effects:
-#   - Read contents of pod JSON file
-#   - Send HTTP request with contents of file, and some other stuff
+from mock import create_autospec
 
 
 def test_add_invoked_successfully():
@@ -26,33 +19,3 @@ def _assert_add_invoked_successfully(pod_file_json):
 
     assert returncode == 0
     marathon_client.add_pod.assert_called_with(pod_file_json)
-
-
-def test_add_propagates_file_read_errors():
-    # file_reader throws some exception (check against actual reader code)
-    pod = MarathonPodSubcommand(file_reader, marathon_client)
-
-    try:
-        pod.add(pod_file_path)
-    except SomeException as e:
-        # assert that the exception is as expected
-        pass
-
-    pass
-
-
-def test_add_requires_json_file():
-    # file_reader returns invalid JSON
-    # test that we fail early -- is an exception propagated or do we print?
-    pod = MarathonPodSubcommand(file_reader, marathon_client)
-
-    # catch exception and assert?
-    pod.add(pod_file_path)
-    pass
-
-
-def test_add_propagates_marathon_api_failure():
-    # the marathon_client is configured to throw some exception
-    # test that the error is reported -- an exception or do we print?
-    pod = MarathonPodSubcommand(file_reader, marathon_client)
-    pod.add(pod_file_path)

--- a/cli/tests/unit/test_marathon_pod.py
+++ b/cli/tests/unit/test_marathon_pod.py
@@ -1,0 +1,57 @@
+from mock import Mock, create_autospec
+
+from dcos import marathon
+import dcoscli.marathon.main as main
+
+# Pod add function
+# Arguments: file path of pod JSON
+# Returns: exit code for CLI, or throws exceptions (see what existing code does)
+# Side effects:
+#   - Read contents of pod JSON file
+#   - Send HTTP request with contents of file, and some other stuff
+
+
+# TODO: Another test to ensure data can't be hardcoded
+def test_add_invoked_successfully():
+    pod_file_path = "some/path/to/pod.json"
+    pod_file_json = {"arbitrary": "json"}
+
+    resource_reader = Mock(return_value=pod_file_json)
+    marathon_client = create_autospec(marathon.Client)
+
+    pod = main.MarathonPodSubcommand(resource_reader, marathon_client)
+    exit_code = pod.add(pod_file_path)
+
+    assert exit_code == 0
+    resource_reader.assert_called_with(pod_file_path)
+    marathon_client.add_pod.assert_called_with(pod_file_json)
+
+
+def test_add_propagates_file_read_errors():
+    # file_reader throws some exception (check against actual reader code)
+    pod = MarathonPodSubcommand(file_reader, marathon_client)
+
+    try:
+        pod.add(pod_file_path)
+    except SomeException as e:
+        # assert that the exception is as expected
+        pass
+
+    pass
+
+
+def test_add_requires_json_file():
+    # file_reader returns invalid JSON
+    # test that we fail early -- is an exception propagated or do we print?
+    pod = MarathonPodSubcommand(file_reader, marathon_client)
+
+    # catch exception and assert?
+    pod.add(pod_file_path)
+    pass
+
+
+def test_add_propagates_marathon_api_failure():
+    # the marathon_client is configured to throw some exception
+    # test that the error is reported -- an exception or do we print?
+    pod = MarathonPodSubcommand(file_reader, marathon_client)
+    pod.add(pod_file_path)

--- a/cli/tests/unit/test_marathon_pod.py
+++ b/cli/tests/unit/test_marathon_pod.py
@@ -1,15 +1,22 @@
 import dcoscli.marathon.main as main
 from dcos import marathon
+from dcos.errors import DCOSException
 
+import pytest
 from mock import create_autospec
 
 
-def test_add_invoked_successfully():
-    _assert_add_invoked_successfully(pod_file_json={"arbitrary": "json"})
-    _assert_add_invoked_successfully(pod_file_json=["more", "json"])
+def test_pod_add_invoked_successfully():
+    _assert_pod_add_invoked_successfully(pod_file_json={"arbitrary": "json"})
+    _assert_pod_add_invoked_successfully(pod_file_json=["more", "json"])
 
 
-def _assert_add_invoked_successfully(pod_file_json):
+def test_pod_add_propagates_exceptions_from_add_pod():
+    _assert_pod_add_propagates_exceptions_from_add_pod(DCOSException('BOOM!'))
+    _assert_pod_add_propagates_exceptions_from_add_pod(Exception('Oops!'))
+
+
+def _assert_pod_add_invoked_successfully(pod_file_json):
     pod_file_path = "some/path/to/pod.json"
     resource_reader = {pod_file_path: pod_file_json}.__getitem__
     marathon_client = create_autospec(marathon.Client)
@@ -19,3 +26,17 @@ def _assert_add_invoked_successfully(pod_file_json):
 
     assert returncode == 0
     marathon_client.add_pod.assert_called_with(pod_file_json)
+
+
+def _assert_pod_add_propagates_exceptions_from_add_pod(exception):
+    def resource_reader(path):
+        return {"some": "json"}
+
+    marathon_client = create_autospec(marathon.Client)
+    marathon_client.add_pod.side_effect = exception
+
+    subcmd = main.MarathonSubcommand(resource_reader, lambda: marathon_client)
+    with pytest.raises(exception.__class__) as exception_info:
+        subcmd.pod_add('does/not/matter')
+
+    assert exception_info.value == exception

--- a/cli/tests/unit/test_marathon_pod.py
+++ b/cli/tests/unit/test_marathon_pod.py
@@ -11,19 +11,20 @@ import dcoscli.marathon.main as main
 #   - Send HTTP request with contents of file, and some other stuff
 
 
-# TODO: Another test to ensure data can't be hardcoded
 def test_add_invoked_successfully():
-    pod_file_path = "some/path/to/pod.json"
-    pod_file_json = {"arbitrary": "json"}
+    _assert_add_invoked_successfully(pod_file_json={"arbitrary": "json"})
+    _assert_add_invoked_successfully(pod_file_json=["more", "json"])
 
-    resource_reader = Mock(return_value=pod_file_json)
+
+def _assert_add_invoked_successfully(pod_file_json):
+    pod_file_path = "some/path/to/pod.json"
+    resource_reader = {pod_file_path: pod_file_json}.__getitem__
     marathon_client = create_autospec(marathon.Client)
 
     pod = main.MarathonPodSubcommand(resource_reader, marathon_client)
-    exit_code = pod.add(pod_file_path)
+    returncode = pod.add(pod_file_path)
 
-    assert exit_code == 0
-    resource_reader.assert_called_with(pod_file_path)
+    assert returncode == 0
     marathon_client.add_pod.assert_called_with(pod_file_json)
 
 

--- a/dcos/data/marathon/error.schema.json
+++ b/dcos/data/marathon/error.schema.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "properties": {
+    "errors": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": ["error"]
+      }
+    },
+    "message": {
+      "type": "string"
+    }
+  },
+  "anyOf": [
+    {"required": ["errors"]},
+    {"required": ["message"]}
+  ]
+}

--- a/dcos/jsonitem.py
+++ b/dcos/jsonitem.py
@@ -14,7 +14,7 @@ def parse_json_item(json_item, schema):
     :param json_item: A JSON item in the form 'key=value'
     :type json_item: str
     :param schema: The JSON schema to use for parsing
-    :type schema: dict
+    :type schema: dict | None
     :returns: A tuple for the parsed JSON item
     :rtype: (str, any) where any is one of str, int, float, bool, list or dict
     """

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -143,18 +143,22 @@ class RpcClient(object):
         if 'timeout' not in kwargs:
             kwargs['timeout'] = self._timeout
 
-        return method_fn(url, *args, **kwargs)
+        try:
+            return method_fn(url, *args, **kwargs)
+        except DCOSHTTPException as e:
+            try:
+                json_body = e.response.json()
+            except:
+                json_body = None
 
-        # url = urllib.parse.urljoin(self._base_url, path)
-        #
-        # if 'timeout' not in kwargs:
-        #     kwargs['timeout'] = self._timeout
-        #
-        # try:
-        #     return method_fn(url, *args, **kwargs)
-        # except DCOSHTTPException as e:
-        #     # raise _to_exception(e.response)
-        #     raise e
+            message = response_error_message(
+                status_code=e.response.status_code,
+                reason=e.response.reason,
+                request_method=e.response.request.method,
+                request_url=e.response.request.url,
+                json_body=json_body)
+            raise DCOSException(message)
+
 
 ERROR_JSON_SCHEMA = {
     'type': 'object',

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -707,7 +707,7 @@ class Client(object):
         return response.json()['leader']
 
     def add_pod(self, pod_json):
-        self._rpc.http_req(http.post, 'v2/pods', json={'some': 'json'})
+        return self._rpc.http_req(http.post, 'v2/pods', json=pod_json)
 
 
 def _default_marathon_error(message=""):

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -117,8 +117,9 @@ class RpcClient(object):
     :type timeout: float
     """
 
-    def __init__(self, base_url):
+    def __init__(self, base_url, timeout=http.DEFAULT_TIMEOUT):
         self._base_url = base_url
+        self._timeout = timeout
 
     def http_req(self, method_fn, path, *args, **kwargs):
         """Make an HTTP request, and raise a marathon-specific exception for
@@ -137,7 +138,7 @@ class RpcClient(object):
         """
         url = self._base_url + '/' + path
         if 'timeout' not in kwargs:
-            kwargs['timeout'] = 5
+            kwargs['timeout'] = self._timeout
         return method_fn(url, *args, **kwargs)
 
         # url = urllib.parse.urljoin(self._base_url, path)

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -120,7 +120,7 @@ class RpcClient(object):
     def __init__(self, base_url):
         self._base_url = base_url
 
-    def http_req(self, method_fn, path, *args):
+    def http_req(self, method_fn, path, *args, **kwargs):
         """Make an HTTP request, and raise a marathon-specific exception for
         HTTP error codes.
 
@@ -136,7 +136,7 @@ class RpcClient(object):
         :rtype: requests.Response
         """
         url = self._base_url + '/' + path
-        return method_fn(url, *args, timeout=http.DEFAULT_TIMEOUT)
+        return method_fn(url, *args, timeout=http.DEFAULT_TIMEOUT, **kwargs)
 
         # url = urllib.parse.urljoin(self._base_url, path)
         #

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -51,7 +51,7 @@ class RpcClient(object):
     """Convenience class for making requests against a common RPC API.
 
     For example, it ensures the same base URL is used for all requests. This
-    class is also useful as as target for mocks in unit tests, because it
+    class is also useful as a target for mocks in unit tests, because it
     presents a minimal, application-focused interface.
 
     :param base_url: the URL prefix to use for all requests

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -178,7 +178,9 @@ def convert_exception(dcos_http_exception):
 
         return DCOSException(message)
     else:
-        return dcos_http_exception
+        template = 'Error decoding response from [{}]: HTTP 401: {}'
+        message = template.format(response.request.url, response.reason)
+        return DCOSException(message)
 
 
 def _response_json(response):

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -206,6 +206,10 @@ def response_error_message(
         template = 'Error decoding response from [{}]: HTTP 401: {}'
         return template.format(request_url, reason)
 
+    if status_code == 409:
+        return ('App, group, or pod is locked by one or more deployments. '
+                'Override with --force.')
+
     template = 'Error on request [{} {}]: HTTP 400: {}{}'
     json_suffix = ''
     if json_body is not None:

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -81,8 +81,8 @@ class RpcClient(object):
     ERROR_JSON_VALIDATOR = jsonschema.Draft4Validator(load_error_json_schema())
 
     @classmethod
-    def response_error_message(
-            cls, status_code, reason, request_method, request_url, json_body):
+    def response_error_message(cls, status_code, reason, request_method,
+                               request_url, json_body):
         """Renders a human-readable error message from the given response data.
 
         :param status_code: the integer status code from an HTTP response

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -163,8 +163,11 @@ def response_error_message(
                       failed
     :type json_body: dict | list | str | int | bool | None
     """
-    template = 'Error on request [{} {}]: HTTP 400: {}'
-    return template.format(request_method, request_url, reason)
+    template = 'Error on request [{} {}]: HTTP 400: {}{}'
+    json_suffix = ''
+    if json_body is not None:
+        json_suffix = ':\n' + json.dumps(json_body, indent=2, sort_keys=True)
+    return template.format(request_method, request_url, reason, json_suffix)
 
 
 def convert_exception(dcos_http_exception):

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -143,7 +143,31 @@ class RpcClient(object):
         try:
             return method_fn(url, *args, **kwargs)
         except DCOSHTTPException as e:
-            raise _to_exception(e.response)
+            # raise _to_exception(e.response)
+            raise convert_exception(e)
+
+
+def convert_exception(dcos_http_exception):
+    """Converts the given DCOSHTTPException to a more human-readable
+    DCOSException, to provide better error messages for failed requests to
+    Marathon.
+
+    :param dcos_http_exception: the exception to convert
+    :type dcos_http_exception: DCOSHTTPException
+    :return: the conversion result
+    :rtype: DCOSException
+    """
+    response = dcos_http_exception.response
+
+    if response.status_code == 400:
+        template = 'Error on request [{} {}]: HTTP 400: {}'
+        message = template.format(response.request.method,
+                                  response.request.url,
+                                  response.reason)
+
+        return DCOSException(message)
+    else:
+        return dcos_http_exception
 
 
 class Client(object):

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -136,7 +136,9 @@ class RpcClient(object):
         :rtype: requests.Response
         """
         url = self._base_url + '/' + path
-        return method_fn(url, *args, timeout=http.DEFAULT_TIMEOUT, **kwargs)
+        if 'timeout' not in kwargs:
+            kwargs['timeout'] = 5
+        return method_fn(url, *args, **kwargs)
 
         # url = urllib.parse.urljoin(self._base_url, path)
         #

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -728,6 +728,9 @@ class Client(object):
         response = _http_req(http.get, url, timeout=self._timeout)
         return response.json()['leader']
 
+    def add_pod(self, pod_json):
+        pass
+
 
 def _default_marathon_error(message=""):
     """

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -22,9 +22,10 @@ def create_client(toml_config=None):
 
     marathon_url = _get_marathon_url(toml_config)
     timeout = config.get_config_val('core.timeout') or http.DEFAULT_TIMEOUT
+    rpc_client = RpcClient(marathon_url, timeout)
 
     logger.info('Creating marathon client with: %r', marathon_url)
-    return Client(marathon_url, timeout=timeout)
+    return Client(rpc_client)
 
 
 def _get_marathon_url(toml_config):
@@ -102,48 +103,58 @@ def _to_exception(response):
     return DCOSException('Error: {}'.format(message))
 
 
-def _http_req(fn, *args, **kwargs):
-    """Make an HTTP request, and raise a marathon-specific exception for
-    HTTP error codes.
+class RpcClient(object):
+    """Convenience class for making requests against a common RPC API.
 
-    :param fn: function to call
-    :type fn: function
-    :param args: args to pass to `fn`
-    :type args: [object]
-    :param kwargs: kwargs to pass to `fn`
-    :type kwargs: dict
-    :returns: `fn` return value
-    :rtype: object
+    For example, it ensures the same base URL is used for all requests. This
+    class is also useful as as target for mocks in unit tests, because it
+    presents a minimal, application-focused interface.
 
+    :param base_url: the URL prefix to use for all requests
+    :type base_url: str
+    :param timeout: number of seconds to wait for a response
+    :type timeout: float
     """
-    try:
-        return fn(*args, **kwargs)
-    except DCOSHTTPException as e:
-        raise _to_exception(e.response)
+
+    def __init__(self, base_url, timeout=http.DEFAULT_TIMEOUT):
+        self._base_url = base_url
+        self._timeout = timeout
+
+    def http_req(self, method_fn, path, *args, **kwargs):
+        """Make an HTTP request, and raise a marathon-specific exception for
+        HTTP error codes.
+
+        :param method_fn: function to call that invokes a specific HTTP method
+        :type method_fn: function
+        :param path: the endpoint path to append to this object's base URL
+        :type path: str
+        :param args: additional args to pass to `method_fn`
+        :type args: [object]
+        :param kwargs: kwargs to pass to `method_fn`
+        :type kwargs: dict
+        :returns: `method_fn` return value
+        :rtype: object
+        """
+        url = urllib.parse.urljoin(self._base_url, path)
+
+        if 'timeout' not in kwargs:
+            kwargs['timeout'] = self._timeout
+
+        try:
+            return method_fn(url, *args, **kwargs)
+        except DCOSHTTPException as e:
+            raise _to_exception(e.response)
 
 
 class Client(object):
     """Class for talking to the Marathon server.
 
-    :param marathon_url: the base URL for the Marathon server
-    :type marathon_url: str
+    :param rpc_client: provides a method for making HTTP requests
+    :type rpc_client: _RpcClient
     """
 
-    def __init__(self, marathon_url, timeout=http.DEFAULT_TIMEOUT):
-        if not marathon_url.endswith('/'):
-            marathon_url += '/'
-        self._base_url = marathon_url
-        self._timeout = timeout
-
-    def _create_url(self, path):
-        """Creates the url from the provided path.
-        :param path: url path
-        :type path: str
-        :returns: constructed url
-        :rtype: str
-        """
-
-        return urllib.parse.urljoin(self._base_url, path)
+    def __init__(self, rpc_client):
+        self._rpc = rpc_client
 
     def get_about(self):
         """Returns info about Marathon instance
@@ -152,8 +163,7 @@ class Client(object):
         :rtype: dict
         """
 
-        url = self._create_url('v2/info')
-        response = _http_req(http.get, url, timeout=self._timeout)
+        response = self._rpc.http_req(http.get, 'v2/info')
 
         return response.json()
 
@@ -171,12 +181,11 @@ class Client(object):
 
         app_id = self.normalize_app_id(app_id)
         if version is None:
-            url = self._create_url('v2/apps{}'.format(app_id))
+            path = 'v2/apps{}'.format(app_id)
         else:
-            url = self._create_url(
-                'v2/apps{}/versions/{}'.format(app_id, version))
+            path = 'v2/apps{}/versions/{}'.format(app_id, version)
 
-        response = _http_req(http.get, url, timeout=self._timeout)
+        response = self._rpc.http_req(http.get, path)
 
         # Looks like Marathon return different JSON for versions
         if version is None:
@@ -191,8 +200,7 @@ class Client(object):
         :rtype: list of dict
         """
 
-        url = self._create_url('v2/groups')
-        response = _http_req(http.get, url, timeout=self._timeout)
+        response = self._rpc.http_req(http.get, 'v2/groups')
         return response.json()['groups']
 
     def get_group(self, group_id, version=None):
@@ -209,12 +217,11 @@ class Client(object):
 
         group_id = self.normalize_app_id(group_id)
         if version is None:
-            url = self._create_url('v2/groups{}'.format(group_id))
+            path = 'v2/groups{}'.format(group_id)
         else:
-            url = self._create_url(
-                'v2/groups{}/versions/{}'.format(group_id, version))
+            path = 'v2/groups{}/versions/{}'.format(group_id, version)
 
-        response = _http_req(http.get, url, timeout=self._timeout)
+        response = self._rpc.http_req(http.get, path)
         return response.json()
 
     def get_app_versions(self, app_id, max_count=None):
@@ -222,8 +229,6 @@ class Client(object):
         maximum count.
 
         :param app_id: the ID of the application or group
-        :type app_id: str
-        :param id_type: type of the id ("apps" or "groups")
         :type app_id: str
         :param max_count: the maximum number of version to fetch
         :type max_count: int
@@ -238,9 +243,9 @@ class Client(object):
 
         app_id = self.normalize_app_id(app_id)
 
-        url = self._create_url('v2/apps{}/versions'.format(app_id))
+        path = 'v2/apps{}/versions'.format(app_id)
 
-        response = _http_req(http.get, url, timeout=self._timeout)
+        response = self._rpc.http_req(http.get, path)
 
         if max_count is None:
             return response.json()['versions']
@@ -254,8 +259,7 @@ class Client(object):
         :rtype: [dict]
         """
 
-        url = self._create_url('v2/apps')
-        response = _http_req(http.get, url, timeout=self._timeout)
+        response = self._rpc.http_req(http.get, 'v2/apps')
         return response.json()['apps']
 
     def get_apps_for_framework(self, framework_name):
@@ -279,17 +283,13 @@ class Client(object):
         :rtype: dict
         """
 
-        url = self._create_url('v2/apps')
-
         # The file type exists only in Python 2, preventing type(...) is file.
         if hasattr(app_resource, 'read'):
             app_json = json.load(app_resource)
         else:
             app_json = app_resource
 
-        response = _http_req(http.post, url,
-                             json=app_json,
-                             timeout=self._timeout)
+        response = self._rpc.http_req(http.post, 'v2/apps', json=app_json)
 
         return response.json()
 
@@ -315,12 +315,12 @@ class Client(object):
         else:
             params = {'force': 'true'}
 
-        url = self._create_url('v2/{}{}'.format(url_endpoint, resource_id))
+        path = 'v2/{}{}'.format(url_endpoint, resource_id)
 
-        response = _http_req(http.put, url,
-                             params=params,
-                             json=payload,
-                             timeout=self._timeout)
+        response = self._rpc.http_req(http.put,
+                                      path,
+                                      params=params,
+                                      json=payload)
 
         return response.json().get('deploymentId')
 
@@ -374,13 +374,12 @@ class Client(object):
         else:
             params = {'force': 'true'}
 
-        url = self._create_url('v2/apps{}'.format(app_id))
+        path = 'v2/apps{}'.format(app_id)
 
-        response = _http_req(http.put,
-                             url,
-                             params=params,
-                             json={'instances': int(instances)},
-                             timeout=self._timeout)
+        response = self._rpc.http_req(http.put,
+                                      path,
+                                      params=params,
+                                      json={'instances': int(instances)})
 
         deployment = response.json()['deploymentId']
         return deployment
@@ -404,12 +403,12 @@ class Client(object):
         else:
             params = {'force': 'true'}
 
-        url = self._create_url('v2/groups{}'.format(group_id))
+        path = 'v2/groups{}'.format(group_id)
 
-        response = http.put(url,
-                            params=params,
-                            json={'scaleBy': scale_factor},
-                            timeout=self._timeout)
+        response = self._rpc.http_req(http.put,
+                                      path,
+                                      params=params,
+                                      json={'scaleBy': scale_factor})
 
         deployment = response.json()['deploymentId']
         return deployment
@@ -444,8 +443,8 @@ class Client(object):
         else:
             params = {'force': 'true'}
 
-        url = self._create_url('v2/apps{}'.format(app_id))
-        _http_req(http.delete, url, params=params, timeout=self._timeout)
+        path = 'v2/apps{}'.format(app_id)
+        self._rpc.http_req(http.delete, path, params=params)
 
     def remove_group(self, group_id, force=None):
         """Completely removes the requested application.
@@ -464,9 +463,9 @@ class Client(object):
         else:
             params = {'force': 'true'}
 
-        url = self._create_url('v2/groups{}'.format(group_id))
+        path = 'v2/groups{}'.format(group_id)
 
-        _http_req(http.delete, url, params=params, timeout=self._timeout)
+        self._rpc.http_req(http.delete, path, params=params)
 
     def kill_tasks(self, app_id, scale=None, host=None):
         """Kills the tasks for a given application,
@@ -485,10 +484,8 @@ class Client(object):
             params['host'] = host
         if scale:
             params['scale'] = scale
-        url = self._create_url('v2/apps{}/tasks'.format(app_id))
-        response = _http_req(http.delete, url,
-                             params=params,
-                             timeout=self._timeout)
+        path = 'v2/apps{}/tasks'.format(app_id)
+        response = self._rpc.http_req(http.delete, path, params=params)
         return response.json()
 
     def restart_app(self, app_id, force=None):
@@ -509,11 +506,9 @@ class Client(object):
         else:
             params = {'force': 'true'}
 
-        url = self._create_url('v2/apps{}/restart'.format(app_id))
+        path = 'v2/apps{}/restart'.format(app_id)
 
-        response = _http_req(http.post, url,
-                             params=params,
-                             timeout=self._timeout)
+        response = self._rpc.http_req(http.post, path, params=params)
         return response.json()
 
     def get_deployment(self, deployment_id):
@@ -525,9 +520,7 @@ class Client(object):
         :rtype: dict
         """
 
-        url = self._create_url('v2/deployments')
-
-        response = _http_req(http.get, url, timeout=self._timeout)
+        response = self._rpc.http_req(http.get, 'v2/deployments')
         deployment = next(
             (deployment for deployment in response.json()
              if deployment_id == deployment['id']),
@@ -544,9 +537,7 @@ class Client(object):
         :rtype: list of dict
         """
 
-        url = self._create_url('v2/deployments')
-
-        response = _http_req(http.get, url, timeout=self._timeout)
+        response = self._rpc.http_req(http.get, 'v2/deployments')
 
         if app_id is not None:
             app_id = self.normalize_app_id(app_id)
@@ -578,11 +569,9 @@ class Client(object):
         else:
             params = {'force': 'true'}
 
-        url = self._create_url('v2/deployments/{}'.format(deployment_id))
+        path = 'v2/deployments/{}'.format(deployment_id)
 
-        response = _http_req(http.delete, url,
-                             params=params,
-                             timeout=self._timeout)
+        response = self._rpc.http_req(http.delete, path, params=params)
 
         if force:
             return None
@@ -619,9 +608,7 @@ class Client(object):
         :rtype: [dict]
         """
 
-        url = self._create_url('v2/tasks')
-
-        response = _http_req(http.get, url, timeout=self._timeout)
+        response = self._rpc.http_req(http.get, 'v2/tasks')
 
         if app_id is not None:
             app_id = self.normalize_app_id(app_id)
@@ -643,9 +630,7 @@ class Client(object):
         :rtype: dict
         """
 
-        url = self._create_url('v2/tasks')
-
-        response = _http_req(http.get, url, timeout=self._timeout)
+        response = self._rpc.http_req(http.get, 'v2/tasks')
 
         task = next(
             (task for task in response.json()['tasks']
@@ -670,13 +655,10 @@ class Client(object):
         else:
             params = {'wipe': 'true'}
 
-        url = self._create_url('v2/tasks/delete')
-
-        response = _http_req(http.post,
-                             url,
-                             params=params,
-                             json={'ids': [task_id]},
-                             timeout=self._timeout)
+        response = self._rpc.http_req(http.post,
+                                      'v2/tasks/delete',
+                                      params=params,
+                                      json={'ids': [task_id]})
 
         task = next(
             (task for task in response.json()['tasks']
@@ -704,7 +686,6 @@ class Client(object):
         :returns: the group description
         :rtype: dict
         """
-        url = self._create_url('v2/groups')
 
         # The file type exists only in Python 2, preventing type(...) is file.
         if hasattr(group_resource, 'read'):
@@ -712,9 +693,7 @@ class Client(object):
         else:
             group_json = group_resource
 
-        response = _http_req(http.post, url,
-                             json=group_json,
-                             timeout=self._timeout)
+        response = self._rpc.http_req(http.post, 'v2/groups', json=group_json)
         return response.json()
 
     def get_leader(self):
@@ -724,12 +703,11 @@ class Client(object):
         :rtype: str
         """
 
-        url = self._create_url('v2/leader')
-        response = _http_req(http.get, url, timeout=self._timeout)
+        response = self._rpc.http_req(http.get, 'v2/leader')
         return response.json()['leader']
 
     def add_pod(self, pod_json):
-        pass
+        self._rpc.http_req(http.post, 'v2/pods', json={'some': 'json'})
 
 
 def _default_marathon_error(message=""):

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -133,10 +133,10 @@ class RpcClient(object):
         :param kwargs: kwargs to pass to `method_fn`
         :type kwargs: dict
         :returns: `method_fn` return value
-        :rtype: object
+        :rtype: requests.Response
         """
         url = self._base_url + '/' + path
-        method_fn(url, timeout=http.DEFAULT_TIMEOUT)
+        return method_fn(url, timeout=http.DEFAULT_TIMEOUT)
 
         # url = urllib.parse.urljoin(self._base_url, path)
         #

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -163,6 +163,10 @@ def response_error_message(
                       failed
     :type json_body: dict | list | str | int | bool | None
     """
+    if status_code == 401:
+        template = 'Error decoding response from [{}]: HTTP 401: {}'
+        return template.format(request_url, reason)
+
     template = 'Error on request [{} {}]: HTTP 400: {}{}'
     json_suffix = ''
     if json_body is not None:

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -120,7 +120,7 @@ class RpcClient(object):
     def __init__(self, base_url):
         self._base_url = base_url
 
-    def http_req(self, method_fn, path):
+    def http_req(self, method_fn, path, *args):
         """Make an HTTP request, and raise a marathon-specific exception for
         HTTP error codes.
 
@@ -136,7 +136,7 @@ class RpcClient(object):
         :rtype: requests.Response
         """
         url = self._base_url + '/' + path
-        return method_fn(url, timeout=http.DEFAULT_TIMEOUT)
+        return method_fn(url, *args, timeout=http.DEFAULT_TIMEOUT)
 
         # url = urllib.parse.urljoin(self._base_url, path)
         #

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -169,6 +169,9 @@ def response_error_message(
             if message is not None:
                 return 'Error: {}'.format(message)
 
+            message = '\n'.join(err['error'] for err in json_body['errors'])
+            return _default_marathon_error(message)
+
         template = 'Error decoding response from [{}]: HTTP 401: {}'
         return template.format(request_url, reason)
 

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -164,6 +164,11 @@ def response_error_message(
     :type json_body: dict | list | str | int | bool | None
     """
     if status_code == 401:
+        if json_body is not None:
+            message = json_body.get('message')
+            if message is not None:
+                return 'Error: {}'.format(message)
+
         template = 'Error decoding response from [{}]: HTTP 401: {}'
         return template.format(request_url, reason)
 

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -147,6 +147,26 @@ class RpcClient(object):
             raise convert_exception(e)
 
 
+def response_error_message(
+        status_code, reason, request_method, request_url, json_body):
+    """Renders a human-readable error message from the given response data.
+
+    :param status_code: the integer status code from an HTTP response
+    :type status_code: int
+    :param reason: textual (human-readable) representation of the status code
+    :type reason: str
+    :param request_method: the HTTP method used for the request
+    :type request_method: str
+    :param request_url: the URL the request was sent to
+    :type request_url: str
+    :param json_body: the response body, parsed as JSON, or None if parsing
+                      failed
+    :type json_body: dict | list | str | int | bool | None
+    """
+    template = 'Error on request [{} {}]: HTTP 400: {}'
+    return template.format(request_method, request_url, reason)
+
+
 def convert_exception(dcos_http_exception):
     """Converts the given DCOSHTTPException to a more human-readable
     DCOSException, to provide better error messages for failed requests to

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -118,6 +118,8 @@ class RpcClient(object):
     """
 
     def __init__(self, base_url, timeout=http.DEFAULT_TIMEOUT):
+        if not base_url.endswith('/'):
+            base_url += '/'
         self._base_url = base_url
         self._timeout = timeout
 
@@ -136,9 +138,11 @@ class RpcClient(object):
         :returns: `method_fn` return value
         :rtype: requests.Response
         """
-        url = self._base_url + '/' + path
+        url = self._base_url + path.lstrip('/')
+
         if 'timeout' not in kwargs:
             kwargs['timeout'] = self._timeout
+
         return method_fn(url, *args, **kwargs)
 
         # url = urllib.parse.urljoin(self._base_url, path)

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ setup(
     package_data={
         'dcos': [
             'data/config-schema/*.json',
+            'data/marathon/*.json'
         ],
     },
 )

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -59,6 +59,15 @@ def test_rpc_client_http_req_passes_kwargs_to_method_fn():
                                  timeout=http.DEFAULT_TIMEOUT)
 
 
+def test_rpc_client_http_req_kwarg_timeout_overrides_default():
+    method_fn = mock.Mock()
+
+    rpc_client = marathon.RpcClient('http://base/url')
+    rpc_client.http_req(method_fn, 'some/path', timeout=42)
+
+    method_fn.assert_called_with('http://base/url/some/path', timeout=42)
+
+
 def test_rpc_client_http_req_returns_method_fn_result():
     _assert_rpc_client_http_req_returns_method_fn_result(['the', 'result'])
     _assert_rpc_client_http_req_returns_method_fn_result({'another': 'result'})

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -1,11 +1,8 @@
 import re
 
-import requests
 from dcos import http, marathon
-from dcos.errors import DCOSException, DCOSHTTPException
 
 import mock
-import pytest
 
 
 def test_add_pod_puts_json_in_request_body():
@@ -39,61 +36,14 @@ def test_response_error_message_with_400_status_json():
         _RESPONSE_JSON_2, _PRINTED_JSON_2)
 
 
-def test_rpc_client_http_req_converts_401_status_exception():
-    _assert_rpc_client_http_req_converts_401_status_exception(
-        request_url='http://request/url',
-        status_reason='Something Bad')
+def test_response_error_message_with_401_status_no_json():
+    _assert_response_error_message_with_401_status_no_json(
+        reason=_REASON_1,
+        request_url=_URL_1)
 
-    _assert_rpc_client_http_req_converts_401_status_exception(
-        request_url='https://another/url',
-        status_reason='Another Reason')
-
-
-def _assert_response_error_message_with_400_status_no_json(
-        reason, request_method, request_url):
-    message = marathon.response_error_message(400,
-                                              reason,
-                                              request_method,
-                                              request_url,
-                                              json_body=None)
-
-    pattern = r'Error on request \[(.*) (.*)\]: HTTP 400: (.*)'
-    match = re.fullmatch(pattern, message)
-    assert match
-    assert match.groups() == (request_method, request_url, reason)
-
-
-def _assert_response_error_message_with_400_status_json(
-        response_json, printed_json):
-    message = marathon.response_error_message(status_code=400,
-                                              reason=_REASON_1,
-                                              request_method=_METHOD_1,
-                                              request_url=_URL_1,
-                                              json_body=response_json)
-
-    error_line, json_lines = message.split('\n', 1)
-    pattern = r'Error on request \[(.*) (.*)\]: HTTP 400: (.*):'
-    match = re.fullmatch(pattern, error_line)
-    assert match
-    assert match.groups() == (_METHOD_1, _URL_1, _REASON_1)
-    assert json_lines == printed_json
-
-
-def _assert_rpc_client_http_req_converts_401_status_exception(
-        request_url, status_reason):
-    response = _mock_response(
-        request_method='ANY',
-        request_url=request_url,
-        status_code=401,
-        status_reason=status_reason)
-    response.json.side_effect = ValueError()
-
-    exception = _assert_rpc_client_raises_exception_from_response(response)
-
-    pattern = r'Error decoding response from \[(.*)\]: HTTP 401: (.*)'
-    match = re.fullmatch(pattern, str(exception))
-    assert match
-    assert match.groups() == (request_url, status_reason)
+    _assert_response_error_message_with_401_status_no_json(
+        reason=_REASON_2,
+        request_url=_URL_2)
 
 
 def _assert_add_pod_puts_json_in_request_body(pod_json):
@@ -113,24 +63,54 @@ def _assert_add_pod_returns_parsed_response_body(response_json):
     assert client.add_pod("arbitrary") == response_json
 
 
-def _assert_rpc_client_raises_exception_from_response(response):
-    def bad_method(*args, **kwargs):
-        raise DCOSHTTPException(response)
+def _assert_response_error_message_with_400_status_no_json(
+        reason, request_method, request_url):
+    message = marathon.response_error_message(
+        status_code=400,
+        reason=reason,
+        request_method=request_method,
+        request_url=request_url,
+        json_body=None)
 
-    rpc_client = marathon.RpcClient('http://does/not/matter')
-    with pytest.raises(DCOSException) as exception_info:
-        rpc_client.http_req(method_fn=bad_method, path='arbitrary/path')
-
-    return exception_info.value
+    pattern = r'Error on request \[(.*) (.*)\]: HTTP 400: (.*)'
+    groups = (request_method, request_url, reason)
+    _assert_matches_with_groups(pattern, message, groups)
 
 
-def _mock_response(request_method, request_url, status_code, status_reason):
-    request = requests.Request(request_method, request_url)
-    response = mock.create_autospec(requests.Response)
-    response.request = request.prepare()
-    response.status_code = status_code
-    response.reason = status_reason
-    return response
+def _assert_response_error_message_with_400_status_json(
+        response_json, printed_json):
+    message = marathon.response_error_message(
+        status_code=400,
+        reason=_REASON_1,
+        request_method=_METHOD_1,
+        request_url=_URL_1,
+        json_body=response_json)
+
+    error_line, json_lines = message.split('\n', 1)
+    pattern = r'Error on request \[(.*) (.*)\]: HTTP 400: (.*):'
+    groups = (_METHOD_1, _URL_1, _REASON_1)
+
+    _assert_matches_with_groups(pattern, error_line, groups)
+    assert json_lines == printed_json
+
+
+def _assert_response_error_message_with_401_status_no_json(
+        reason, request_url):
+    message = marathon.response_error_message(
+        status_code=401,
+        reason=reason,
+        request_method='ANY',
+        request_url=request_url,
+        json_body=None)
+
+    pattern = r'Error decoding response from \[(.*)\]: HTTP 401: (.*)'
+    _assert_matches_with_groups(pattern, message, (request_url, reason))
+
+
+def _assert_matches_with_groups(pattern, text, groups):
+    match = re.fullmatch(pattern, text)
+    assert match
+    assert match.groups() == groups
 
 
 _BASE_TEMPLATE_400 = r'Error on request \[(.*) (.*)\]: HTTP 400: (.*)'

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -35,6 +35,11 @@ def test_rpc_client_http_req_calls_method_fn():
         full_url='gopher://different/thing/some/path')
 
 
+def test_rpc_client_http_req_returns_method_fn_result():
+    _assert_rpc_client_http_req_returns_method_fn_result(['the', 'result'])
+    _assert_rpc_client_http_req_returns_method_fn_result({'another': 'result'})
+
+
 def test_error_json_schema_is_valid():
     jsonschema.Draft4Validator.check_schema(marathon.ERROR_JSON_SCHEMA)
 
@@ -193,6 +198,17 @@ def _assert_rpc_client_http_req_calls_method_fn(base_url, path, full_url):
 
     method_fn.assert_called_with(full_url,
                                  timeout=http.DEFAULT_TIMEOUT)
+
+
+def _assert_rpc_client_http_req_returns_method_fn_result(expected):
+
+    def method_fn(*args, **kwargs):
+        return expected
+
+    rpc_client = marathon.RpcClient('http://base/url')
+    actual = rpc_client.http_req(method_fn, 'some/path')
+
+    assert actual == expected
 
 
 def _assert_response_error_message_with_400_status_no_json(

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -54,6 +54,16 @@ def test_response_error_message_with_401_status_json_has_message():
         json_message=_MESSAGE_2)
 
 
+def test_res_err_msg_with_401_status_json_no_message_has_valid_errors():
+    _assert_res_err_msg_with_401_status_json_no_message_has_valid_errors(
+        errors_json=[{'error': 'err1'}, {'error': 'err2'}],
+        errors_str='err1\nerr2')
+
+    _assert_res_err_msg_with_401_status_json_no_message_has_valid_errors(
+        errors_json=[{'error': 'foo'}, {'error': 'bar'}, {'error': 'baz'}],
+        errors_str='foo\nbar\nbaz')
+
+
 def _assert_add_pod_puts_json_in_request_body(pod_json):
     rpc_client = mock.create_autospec(marathon.RpcClient)
 
@@ -128,8 +138,22 @@ def _assert_response_error_message_with_401_status_json_has_message(
     _assert_matches_with_groups(pattern, error_message, (json_message,))
 
 
+def _assert_res_err_msg_with_401_status_json_no_message_has_valid_errors(
+        errors_json, errors_str):
+    message = marathon.response_error_message(
+        status_code=401,
+        reason=_REASON_X,
+        request_method=_METHOD_X,
+        request_url=_URL_X,
+        json_body={'errors': errors_json})
+
+    pattern = (r'Marathon likely misconfigured\. Please check your proxy or '
+               r'Marathon URL settings\. See dcos config --help\. (.*)')
+    _assert_matches_with_groups(pattern, message, (errors_str,))
+
+
 def _assert_matches_with_groups(pattern, text, groups):
-    match = re.fullmatch(pattern, text)
+    match = re.fullmatch(pattern, text, flags=re.DOTALL)
     assert match
     assert match.groups() == groups
 

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -116,7 +116,7 @@ def test_rpc_client_http_req_propagates_method_fn_exception_1():
     with pytest.raises(DCOSException) as e:
         rpc_client.http_req(method_fn, 'some/path')
 
-    expected_message = marathon.response_error_message(
+    expected_message = marathon.RpcClient.response_error_message(
         status_code=403,
         reason='Forbidden',
         request_method='ANY',
@@ -141,7 +141,7 @@ def test_rpc_client_http_req_propagates_method_fn_exception_2():
     with pytest.raises(DCOSException) as e:
         rpc_client.http_req(method_fn, 'some/path')
 
-    expected_message = marathon.response_error_message(
+    expected_message = marathon.RpcClient.response_error_message(
         status_code=422,
         reason='Something Bad',
         request_method='None',
@@ -151,7 +151,8 @@ def test_rpc_client_http_req_propagates_method_fn_exception_2():
 
 
 def test_error_json_schema_is_valid():
-    jsonschema.Draft4Validator.check_schema(marathon.ERROR_JSON_SCHEMA)
+    error_json_schema = marathon.load_error_json_schema()
+    jsonschema.Draft4Validator.check_schema(error_json_schema)
 
 
 def test_response_error_message_with_400_status_no_json():
@@ -175,7 +176,7 @@ def test_response_error_message_with_400_status_json():
 
 
 def test_res_err_msg_with_409_status():
-    actual = marathon.response_error_message(
+    actual = marathon.RpcClient.response_error_message(
         status_code=409,
         reason=_REASON_X,
         request_method=_METHOD_X,
@@ -323,7 +324,7 @@ def _assert_rpc_client_http_req_returns_method_fn_result(expected):
 
 def _assert_response_error_message_with_400_status_no_json(
         reason, request_method, request_url):
-    message = marathon.response_error_message(
+    message = marathon.RpcClient.response_error_message(
         status_code=400,
         reason=reason,
         request_method=request_method,
@@ -337,7 +338,7 @@ def _assert_response_error_message_with_400_status_no_json(
 
 def _assert_response_error_message_with_400_status_json(
         response_json, printed_json):
-    message = marathon.response_error_message(
+    message = marathon.RpcClient.response_error_message(
         status_code=400,
         reason=_REASON_X,
         request_method=_METHOD_X,
@@ -354,7 +355,7 @@ def _assert_response_error_message_with_400_status_json(
 
 def _assert_response_error_message_with_other_status_no_json(
         status_code, reason, request_url):
-    message = marathon.response_error_message(
+    message = marathon.RpcClient.response_error_message(
         status_code=status_code,
         reason=reason,
         request_method=_METHOD_X,
@@ -368,7 +369,7 @@ def _assert_response_error_message_with_other_status_no_json(
 
 def _assert_response_error_message_with_other_status_json_has_message(
         status_code, json_message):
-    error_message = marathon.response_error_message(
+    error_message = marathon.RpcClient.response_error_message(
         status_code=status_code,
         reason=_REASON_X,
         request_method=_METHOD_X,
@@ -381,7 +382,7 @@ def _assert_response_error_message_with_other_status_json_has_message(
 
 def _assert_res_err_msg_with_other_status_json_no_message_has_valid_errors(
         status_code, errors_json, errors_str):
-    message = marathon.response_error_message(
+    message = marathon.RpcClient.response_error_message(
         status_code=status_code,
         reason=_REASON_X,
         request_method=_METHOD_X,
@@ -394,7 +395,7 @@ def _assert_res_err_msg_with_other_status_json_no_message_has_valid_errors(
 
 
 def _assert_res_err_msg_with_other_status_invalid_json(status_code, json_body):
-    actual = marathon.response_error_message(
+    actual = marathon.RpcClient.response_error_message(
         status_code=status_code,
         reason=_REASON_X,
         request_method=_METHOD_X,

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -35,6 +35,18 @@ def test_rpc_client_http_req_calls_method_fn():
         full_url='gopher://different/thing/some/path')
 
 
+def test_rpc_client_http_req_passes_args_to_method_fn():
+    method_fn = mock.Mock()
+
+    rpc_client = marathon.RpcClient('http://base/url')
+    rpc_client.http_req(method_fn, 'some/path', 'foo', 42)
+
+    method_fn.assert_called_with('http://base/url/some/path',
+                                 'foo',
+                                 42,
+                                 timeout=http.DEFAULT_TIMEOUT)
+
+
 def test_rpc_client_http_req_returns_method_fn_result():
     _assert_rpc_client_http_req_returns_method_fn_result(['the', 'result'])
     _assert_rpc_client_http_req_returns_method_fn_result({'another': 'result'})

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -18,6 +18,23 @@ def test_add_pod_returns_parsed_response_body():
     _assert_add_pod_returns_parsed_response_body(["another", "pod", "json"])
 
 
+def test_rpc_client_http_req_calls_method_fn():
+    _assert_rpc_client_http_req_calls_method_fn(
+        base_url='http://base/url',
+        path='some/path',
+        full_url='http://base/url/some/path')
+
+    _assert_rpc_client_http_req_calls_method_fn(
+        base_url='http://base/url',
+        path='different/thing',
+        full_url='http://base/url/different/thing')
+
+    _assert_rpc_client_http_req_calls_method_fn(
+        base_url='gopher://different/thing',
+        path='some/path',
+        full_url='gopher://different/thing/some/path')
+
+
 def test_error_json_schema_is_valid():
     jsonschema.Draft4Validator.check_schema(marathon.ERROR_JSON_SCHEMA)
 
@@ -166,6 +183,16 @@ def _assert_add_pod_returns_parsed_response_body(response_json):
 
     client = marathon.Client(rpc_client)
     assert client.add_pod("arbitrary") == response_json
+
+
+def _assert_rpc_client_http_req_calls_method_fn(base_url, path, full_url):
+    method_fn = mock.Mock()
+
+    rpc_client = marathon.RpcClient(base_url)
+    rpc_client.http_req(method_fn, path)
+
+    method_fn.assert_called_with(full_url,
+                                 timeout=http.DEFAULT_TIMEOUT)
 
 
 def _assert_response_error_message_with_400_status_no_json(

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -47,6 +47,18 @@ def test_rpc_client_http_req_passes_args_to_method_fn():
                                  timeout=http.DEFAULT_TIMEOUT)
 
 
+def test_rpc_client_http_req_passes_kwargs_to_method_fn():
+    method_fn = mock.Mock()
+
+    rpc_client = marathon.RpcClient('http://base/url')
+    rpc_client.http_req(method_fn, 'some/path', foo='bar', baz=42)
+
+    method_fn.assert_called_with('http://base/url/some/path',
+                                 foo='bar',
+                                 baz=42,
+                                 timeout=http.DEFAULT_TIMEOUT)
+
+
 def test_rpc_client_http_req_returns_method_fn_result():
     _assert_rpc_client_http_req_returns_method_fn_result(['the', 'result'])
     _assert_rpc_client_http_req_returns_method_fn_result({'another': 'result'})

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -68,6 +68,15 @@ def test_rpc_client_http_req_kwarg_timeout_overrides_default():
     method_fn.assert_called_with('http://base/url/some/path', timeout=42)
 
 
+def test_rpc_client_http_req_set_timeout_in_constructor():
+    method_fn = mock.Mock()
+
+    rpc_client = marathon.RpcClient('http://base/url', 24)
+    rpc_client.http_req(method_fn, 'some/path')
+
+    method_fn.assert_called_with('http://base/url/some/path', timeout=24)
+
+
 def test_rpc_client_http_req_returns_method_fn_result():
     _assert_rpc_client_http_req_returns_method_fn_result(['the', 'result'])
     _assert_rpc_client_http_req_returns_method_fn_result({'another': 'result'})

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -1,13 +1,13 @@
 import re
-import requests
 
 import jsonschema
-import pytest
+import requests
 
 from dcos import http, marathon
 from dcos.errors import DCOSException, DCOSHTTPException
 
 import mock
+import pytest
 
 
 def test_add_pod_puts_json_in_request_body():

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -21,40 +21,22 @@ def test_add_pod_returns_parsed_response_body():
 
 def test_response_error_message_with_400_status_no_json():
     _assert_response_error_message_with_400_status_no_json(
-        reason='Something Bad',
-        request_method='FOO',
-        request_url='http://request/url')
+        reason=_REASON_1,
+        request_method=_METHOD_1,
+        request_url=_URL_1)
 
     _assert_response_error_message_with_400_status_no_json(
-        reason='Another Reason',
-        request_method='BAR',
-        request_url='https://another/url')
+        reason=_REASON_2,
+        request_method=_METHOD_2,
+        request_url=_URL_2)
 
 
-def test_rpc_client_http_req_converts_exception_for_400_status_with_json():
-    printed_json1 = (
-        '{\n'
-        '  "x": "err",\n'
-        '  "y": 3.14,\n'
-        '  "z": [\n'
-        '    1,\n'
-        '    2,\n'
-        '    3\n'
-        '  ]\n'
-        '}')
-    _assert_rpc_client_http_req_converts_400_status_exception_with_json(
-        response_json={"z": [1, 2, 3], "y": 3.14, "x": "err"},
-        printed_json=printed_json1)
+def test_response_error_message_with_400_status_json():
+    _assert_response_error_message_with_400_status_json(
+        _RESPONSE_JSON_1, _PRINTED_JSON_1)
 
-    printed_json2 = (
-        '[\n'
-        '  "something",\n'
-        '  "completely",\n'
-        '  "different"\n'
-        ']')
-    _assert_rpc_client_http_req_converts_400_status_exception_with_json(
-        response_json=["something", "completely", "different"],
-        printed_json=printed_json2)
+    _assert_response_error_message_with_400_status_json(
+        _RESPONSE_JSON_2, _PRINTED_JSON_2)
 
 
 def test_rpc_client_http_req_converts_401_status_exception():
@@ -81,6 +63,22 @@ def _assert_response_error_message_with_400_status_no_json(
     assert match.groups() == (request_method, request_url, reason)
 
 
+def _assert_response_error_message_with_400_status_json(
+        response_json, printed_json):
+    message = marathon.response_error_message(status_code=400,
+                                              reason=_REASON_1,
+                                              request_method=_METHOD_1,
+                                              request_url=_URL_1,
+                                              json_body=response_json)
+
+    error_line, json_lines = message.split('\n', 1)
+    pattern = r'Error on request \[(.*) (.*)\]: HTTP 400: (.*):'
+    match = re.fullmatch(pattern, error_line)
+    assert match
+    assert match.groups() == (_METHOD_1, _URL_1, _REASON_1)
+    assert json_lines == printed_json
+
+
 def _assert_rpc_client_http_req_converts_401_status_exception(
         request_url, status_reason):
     response = _mock_response(
@@ -96,27 +94,6 @@ def _assert_rpc_client_http_req_converts_401_status_exception(
     match = re.fullmatch(pattern, str(exception))
     assert match
     assert match.groups() == (request_url, status_reason)
-
-
-def _assert_rpc_client_http_req_converts_400_status_exception_with_json(
-        response_json, printed_json):
-    response = _mock_response(
-        request_method='POST',
-        request_url='http://some/url',
-        status_code=400,
-        status_reason='Some Reason')
-    response.json.return_value = response_json
-
-    exception = _assert_rpc_client_raises_exception_from_response(response)
-
-    message = str(exception)
-    error_line, json_lines = message.split('\n', 1)
-
-    pattern = r'Error on request \[(.*) (.*)\]: HTTP 400: (.*):'
-    match = re.fullmatch(pattern, error_line)
-    assert match.groups() == ('POST', 'http://some/url', 'Some Reason')
-
-    assert json_lines == printed_json
 
 
 def _assert_add_pod_puts_json_in_request_body(pod_json):
@@ -154,3 +131,35 @@ def _mock_response(request_method, request_url, status_code, status_reason):
     response.status_code = status_code
     response.reason = status_reason
     return response
+
+
+_BASE_TEMPLATE_400 = r'Error on request \[(.*) (.*)\]: HTTP 400: (.*)'
+
+_REASON_1 = 'Something Bad'
+_REASON_2 = 'Another Reason'
+
+_METHOD_1 = 'FOO'
+_METHOD_2 = 'BAR'
+
+_URL_1 = 'http://request/url'
+_URL_2 = 'https://another/url'
+
+_RESPONSE_JSON_1 = {"z": [1, 2, 3], "y": 3.14, "x": "err"}
+_RESPONSE_JSON_2 = ["something", "completely", "different"]
+
+_PRINTED_JSON_1 = (
+    '{\n'
+    '  "x": "err",\n'
+    '  "y": 3.14,\n'
+    '  "z": [\n'
+    '    1,\n'
+    '    2,\n'
+    '    3\n'
+    '  ]\n'
+    '}')
+_PRINTED_JSON_2 = (
+    '[\n'
+    '  "something",\n'
+    '  "completely",\n'
+    '  "different"\n'
+    ']')

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -77,6 +77,23 @@ def test_rpc_client_http_req_set_timeout_in_constructor():
     method_fn.assert_called_with('http://base/url/some/path', timeout=24)
 
 
+def test_rpc_client_http_req_extra_path_slashes():
+    _assert_rpc_client_http_req_calls_method_fn(
+        base_url='http://base/without/slash',
+        path='/path/with/slash',
+        full_url='http://base/without/slash/path/with/slash')
+
+    _assert_rpc_client_http_req_calls_method_fn(
+        base_url='http://base/with/slash/',
+        path='path/without/slash',
+        full_url='http://base/with/slash/path/without/slash')
+
+    _assert_rpc_client_http_req_calls_method_fn(
+        base_url='http://base/with/slash/',
+        path='/path/with/slash',
+        full_url='http://base/with/slash/path/with/slash')
+
+
 def test_rpc_client_http_req_returns_method_fn_result():
     _assert_rpc_client_http_req_returns_method_fn_result(['the', 'result'])
     _assert_rpc_client_http_req_returns_method_fn_result({'another': 'result'})

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -1,6 +1,9 @@
+import requests
 from dcos import http, marathon
+from dcos.errors import DCOSException, DCOSHTTPException
 
 import mock
+import pytest
 
 
 def test_add_pod_puts_json_in_request_body():
@@ -12,6 +15,24 @@ def test_add_pod_puts_json_in_request_body():
 def test_add_pod_returns_parsed_response_body():
     _assert_add_pod_returns_parsed_response_body({"id": "i-am-a-pod"})
     _assert_add_pod_returns_parsed_response_body(["another", "pod", "json"])
+
+
+def test_rpc_client_http_req_converts_exception_for_400_status():
+    request = requests.Request(method='FOO', url='http://request/url')
+    response = requests.Response()
+    response.request = request.prepare()
+    response.status_code = 400
+    response.reason = 'Something Bad'
+
+    def bad_method(*args, **kwargs):
+        raise DCOSHTTPException(response)
+
+    rpc_client = marathon.RpcClient('http://does/not/matter')
+    with pytest.raises(DCOSException) as exception_info:
+        rpc_client.http_req(method_fn=bad_method, path='arbitrary/path')
+
+    msg = 'Error on request [FOO http://request/url]: HTTP 400: Something Bad'
+    assert str(exception_info.value) == msg
 
 
 def _assert_add_pod_puts_json_in_request_body(pod_json):

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -95,6 +95,19 @@ def test_res_err_msg_with_401_status_invalid_error_json():
         {'errors': [{'error': 'BOOM!'}, {'error': 42}]})
 
 
+def test_res_err_msg_with_409_status():
+    actual = marathon.response_error_message(
+        status_code=409,
+        reason=_REASON_X,
+        request_method=_METHOD_X,
+        request_url=_URL_X,
+        json_body=None)
+
+    expected = ('App, group, or pod is locked by one or more deployments. '
+                'Override with --force.')
+    assert actual == expected
+
+
 def _assert_add_pod_puts_json_in_request_body(pod_json):
     rpc_client = mock.create_autospec(marathon.RpcClient)
 

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -1,0 +1,13 @@
+from dcos import http, marathon
+
+import mock
+
+
+def test_add_pod():
+    pod_json = {"some": "json"}
+    rpc_client = mock.create_autospec(marathon.RpcClient)
+    client = marathon.Client(rpc_client)
+
+    client.add_pod(pod_json)
+
+    rpc_client.http_req.assert_called_with(http.post, 'v2/pods', json=pod_json)

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -3,11 +3,29 @@ from dcos import http, marathon
 import mock
 
 
-def test_add_pod():
-    pod_json = {"some": "json"}
-    rpc_client = mock.create_autospec(marathon.RpcClient)
-    client = marathon.Client(rpc_client)
+def test_add_pod_puts_json_in_request_body():
+    _assert_add_pod_puts_json_in_request_body(pod_json={"some": "json"})
+    _assert_add_pod_puts_json_in_request_body(
+        pod_json=["another", {"json": "value"}])
 
+
+def test_add_pod_returns_parsed_response_body():
+    _assert_add_pod_returns_parsed_response_body({"id": "i-am-a-pod"})
+    _assert_add_pod_returns_parsed_response_body(["another", "pod", "json"])
+
+
+def _assert_add_pod_puts_json_in_request_body(pod_json):
+    rpc_client = mock.create_autospec(marathon.RpcClient)
+
+    client = marathon.Client(rpc_client)
     client.add_pod(pod_json)
 
     rpc_client.http_req.assert_called_with(http.post, 'v2/pods', json=pod_json)
+
+
+def _assert_add_pod_returns_parsed_response_body(response_json):
+    rpc_client = mock.create_autospec(marathon.RpcClient)
+    rpc_client.http_req.return_value = response_json
+
+    client = marathon.Client(rpc_client)
+    assert client.add_pod("arbitrary") == response_json

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py34-syntax, py34-unit
 
 [testenv]
 deps =
+  mock
   pytest
   pytest-cov
 passenv = DCOS_* CI_FLAGS CLI_TEST_SSH_KEY_PATH
@@ -18,4 +19,4 @@ commands =
 
 [testenv:py34-unit]
 commands =
-  py.test -p no:cacheprovider -vv {env:CI_FLAGS:} --cov {envsitepackagesdir}/dcos tests
+  py.test -p no:cacheprovider -vv {env:CI_FLAGS:} --cov {envsitepackagesdir}/dcos tests{posargs}


### PR DESCRIPTION
Did some refactoring to support unit tests of Marathon interfaces. This especially helped for tests of error responses.

This PR is mostly infrastructure. The remaining pod subcommands will take much less time to implement with this foundation.