### PR TITLE
Implement `pod update`

### DIFF
--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -927,14 +927,11 @@ class MarathonSubcommand(object):
         marathon_client.show_pod(pod_id)
 
         resource = self._resource_reader.from_properties_or_stdin(properties)
-        try:
-            deployment_id = marathon_client.update_pod(
-                pod_id, pod_json=resource, force=force)
+        deployment_id = marathon_client.update_pod(
+            pod_id, pod_json=resource, force=force)
 
-            emitter.publish('Created deployment {}'.format(deployment_id))
-            return 0
-        except:
-            pass
+        emitter.publish('Created deployment {}'.format(deployment_id))
+        return 0
 
 
 def _calculate_version(client, app_id, version):

--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -882,6 +882,11 @@ class MarathonSubcommand(object):
         :rtype: int
         """
 
+        marathon_client = self._create_marathon_client()
+
+        # Ensure that the pod exists
+        marathon_client.show_pod(pod_id)
+
         return 0
 
 

--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -926,8 +926,8 @@ class MarathonSubcommand(object):
         # Ensure that the pod exists
         marathon_client.show_pod(pod_id)
 
-        self._resource_reader.from_properties_or_stdin(properties)
-
+        resource = self._resource_reader.from_properties_or_stdin(properties)
+        marathon_client.update_pod(pod_id, pod_json=resource, force=force)
         return 0
 
 

--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -926,7 +926,7 @@ class MarathonSubcommand(object):
         # Ensure that the pod exists
         marathon_client.show_pod(pod_id)
 
-        self._resource_reader.from_properties_or_stdin([])
+        self._resource_reader.from_properties_or_stdin(properties)
 
         return 0
 

--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -927,7 +927,10 @@ class MarathonSubcommand(object):
         marathon_client.show_pod(pod_id)
 
         resource = self._resource_reader.from_properties_or_stdin(properties)
-        marathon_client.update_pod(pod_id, pod_json=resource, force=force)
+        deployment_id = marathon_client.update_pod(
+            pod_id, pod_json=resource, force=force)
+
+        emitter.publish('Created deployment {}'.format(deployment_id))
         return 0
 
 

--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -927,11 +927,14 @@ class MarathonSubcommand(object):
         marathon_client.show_pod(pod_id)
 
         resource = self._resource_reader.from_properties_or_stdin(properties)
-        deployment_id = marathon_client.update_pod(
-            pod_id, pod_json=resource, force=force)
+        try:
+            deployment_id = marathon_client.update_pod(
+                pod_id, pod_json=resource, force=force)
 
-        emitter.publish('Created deployment {}'.format(deployment_id))
-        return 0
+            emitter.publish('Created deployment {}'.format(deployment_id))
+            return 0
+        except:
+            pass
 
 
 def _calculate_version(client, app_id, version):

--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -882,7 +882,7 @@ class MarathonSubcommand(object):
         :rtype: int
         """
 
-        raise DCOSException('Not implemented')
+        return 0
 
 
 def _parse_properties(properties):

--- a/cli/tests/integrations/test_marathon_pod.py
+++ b/cli/tests/integrations/test_marathon_pod.py
@@ -2,8 +2,6 @@ import contextlib
 import json
 import re
 
-from dcos import util
-
 import pytest
 
 from ..common import file_bytes
@@ -11,7 +9,7 @@ from ..fixtures.marathon import (DOUBLE_POD_FILE_PATH, DOUBLE_POD_ID,
                                  GOOD_POD_FILE_PATH, GOOD_POD_ID,
                                  TRIPLE_POD_FILE_PATH, TRIPLE_POD_ID,
                                  UPDATED_GOOD_POD_FILE_PATH, pod_fixture)
-from .common import assert_command, exec_command
+from .common import assert_command, exec_command, file_json_ast
 
 _POD_BASE_CMD = ['dcos', 'marathon', 'pod']
 _POD_ADD_CMD = _POD_BASE_CMD + ['add']
@@ -54,30 +52,34 @@ def test_pod_list():
 
 @pytest.mark.skip(reason="Pods support in Marathon not released yet")
 def test_pod_show():
+    expected_json = file_json_ast(GOOD_POD_FILE_PATH)
+
     with _pod(GOOD_POD_ID, GOOD_POD_FILE_PATH):
-        _assert_pod_show(GOOD_POD_ID)
+        _assert_pod_show(GOOD_POD_ID, expected_json)
 
 
 @pytest.mark.skip(reason="Pods support in Marathon not released yet")
-def test_pod_update_from_file():
-    expected_show_stdout = file_bytes(UPDATED_GOOD_POD_FILE_PATH)
+def test_pod_update_from_properties():
+    expected_json = file_json_ast(UPDATED_GOOD_POD_FILE_PATH)
+    properties = ['id=/' + GOOD_POD_ID,
+                  'containers=' + json.dumps(expected_json['containers'])]
 
     with _pod(GOOD_POD_ID, GOOD_POD_FILE_PATH):
-        _assert_pod_update_from_file(GOOD_POD_ID,
-                                     UPDATED_GOOD_POD_FILE_PATH,
-                                     extra_args=[])
-        _assert_pod_show(GOOD_POD_ID, expected_show_stdout)
+        _assert_pod_update_from_properties(GOOD_POD_ID,
+                                           properties,
+                                           extra_args=[])
+        _assert_pod_show(GOOD_POD_ID, expected_json)
 
 
 @pytest.mark.skip(reason="Pods support in Marathon not released yet")
 def test_pod_update_from_stdin_force_true():
-    expected_show_stdout = file_bytes(UPDATED_GOOD_POD_FILE_PATH)
+    expected_json = file_json_ast(UPDATED_GOOD_POD_FILE_PATH)
 
     with _pod(GOOD_POD_ID, GOOD_POD_FILE_PATH):
         _assert_pod_update_from_stdin(GOOD_POD_ID,
                                       UPDATED_GOOD_POD_FILE_PATH,
                                       extra_args=['--force'])
-        _assert_pod_show(GOOD_POD_ID, expected_show_stdout)
+        _assert_pod_show(GOOD_POD_ID, expected_json)
 
 
 def _pod_add_from_file(file_path):
@@ -107,21 +109,24 @@ def _assert_pod_list_json_subset(expected_json, actual_json):
     for expected_pod in expected_json:
         pod_id = expected_pod['id']
         actual_pod = actual_pods_by_id[pod_id]
-
-        expected_containers = expected_pod['containers']
-        actual_containers = actual_pod['containers']
-        actual_containers_by_name = {c['name']: c for c in actual_containers}
-
-        for expected_container in expected_containers:
-            container_name = expected_container['name']
-            actual_container = actual_containers_by_name[container_name]
-
-            for k, v in expected_container['resources'].items():
-                assert actual_container['resources'][k] == v
-
-        assert len(actual_containers) == len(expected_containers)
+        _assert_pod_json_subset(expected_pod, actual_pod)
 
     assert len(actual_json) == len(expected_json)
+
+
+def _assert_pod_json_subset(expected_pod, actual_pod):
+    expected_containers = expected_pod['containers']
+    actual_containers = actual_pod['containers']
+    actual_containers_by_name = {c['name']: c for c in actual_containers}
+
+    for expected_container in expected_containers:
+        container_name = expected_container['name']
+        actual_container = actual_containers_by_name[container_name]
+
+        for k, v in expected_container['resources'].items():
+            assert actual_container['resources'][k] == v
+
+    assert len(actual_containers) == len(expected_containers)
 
 
 def _assert_pod_list_table(stdout):
@@ -133,7 +138,7 @@ def _assert_pod_remove(pod_id, extra_args):
     assert_command(cmd, returncode=0, stdout=b'', stderr=b'')
 
 
-def _assert_pod_show(pod_id):
+def _assert_pod_show(pod_id, expected_json):
     cmd = _POD_SHOW_CMD + [pod_id]
     returncode, stdout, stderr = exec_command(cmd)
 
@@ -141,11 +146,11 @@ def _assert_pod_show(pod_id):
     assert stderr == b''
 
     pod_json = json.loads(stdout.decode('utf-8'))
-    assert pod_json['id'] == util.normalize_marathon_id_path(pod_id)
+    _assert_pod_json_subset(expected_json, pod_json)
 
 
-def _assert_pod_update_from_file(pod_id, file_path, extra_args):
-    cmd = _POD_UPDATE_CMD + [pod_id, file_path] + extra_args
+def _assert_pod_update_from_properties(pod_id, properties, extra_args):
+    cmd = _POD_UPDATE_CMD + [pod_id] + properties + extra_args
     returncode, stdout, stderr = exec_command(cmd)
 
     assert returncode == 0
@@ -154,7 +159,7 @@ def _assert_pod_update_from_file(pod_id, file_path, extra_args):
 
 
 def _assert_pod_update_from_stdin(pod_id, file_path, extra_args):
-    cmd = _POD_UPDATE_CMD + [pod_id, file_path] + extra_args
+    cmd = _POD_UPDATE_CMD + [pod_id] + extra_args
     with open(file_path) as fd:
         returncode, stdout, stderr = exec_command(cmd, stdin=fd)
 

--- a/cli/tests/integrations/test_marathon_pod.py
+++ b/cli/tests/integrations/test_marathon_pod.py
@@ -61,8 +61,9 @@ def test_pod_show():
 @pytest.mark.skip(reason="Pods support in Marathon not released yet")
 def test_pod_update_from_properties():
     expected_json = file_json_ast(UPDATED_GOOD_POD_FILE_PATH)
-    properties = ['id=/' + GOOD_POD_ID,
-                  'containers=' + json.dumps(expected_json['containers'])]
+    containers_json_str = json.dumps(expected_json['containers'])
+    properties = ['id=/{}'.format(GOOD_POD_ID),
+                  'containers={}'.format(containers_json_str)]
 
     with _pod(GOOD_POD_ID, GOOD_POD_FILE_PATH):
         _assert_pod_update_from_properties(GOOD_POD_ID,
@@ -109,12 +110,24 @@ def _assert_pod_list_json_subset(expected_json, actual_json):
     for expected_pod in expected_json:
         pod_id = expected_pod['id']
         actual_pod = actual_pods_by_id[pod_id]
-        _assert_pod_json_subset(expected_pod, actual_pod)
+        _assert_pod_json(expected_pod, actual_pod)
 
     assert len(actual_json) == len(expected_json)
 
 
-def _assert_pod_json_subset(expected_pod, actual_pod):
+def _assert_pod_json(expected_pod, actual_pod):
+    """Checks that the "actual" pod JSON matches the "expected" pod JSON.
+
+    The comparison only looks at specific fields that are present in the
+    test data used by this module.
+
+    :param expected_pod: contains the baseline values for the comparison
+    :type expected_pod: {}
+    :param actual_pod: has its fields checked against the expected fields
+    :type actual_pod: {}
+    :rtype: None
+    """
+
     expected_containers = expected_pod['containers']
     actual_containers = actual_pod['containers']
     actual_containers_by_name = {c['name']: c for c in actual_containers}
@@ -146,7 +159,7 @@ def _assert_pod_show(pod_id, expected_json):
     assert stderr == b''
 
     pod_json = json.loads(stdout.decode('utf-8'))
-    _assert_pod_json_subset(expected_json, pod_json)
+    _assert_pod_json(expected_json, pod_json)
 
 
 def _assert_pod_update_from_properties(pod_id, properties, extra_args):

--- a/cli/tests/unit/test_marathon_pod.py
+++ b/cli/tests/unit/test_marathon_pod.py
@@ -69,8 +69,10 @@ def test_pod_list_propagates_exceptions_from_list_pod():
 
 
 def test_pod_update_invoked_successfully():
-    _assert_pod_update_invoked_successfully(pod_id='foo')
-    _assert_pod_update_invoked_successfully(pod_id='bar')
+    _assert_pod_update_invoked_successfully(pod_id='foo', properties=[])
+    _assert_pod_update_invoked_successfully(pod_id='bar', properties=[])
+    _assert_pod_update_invoked_successfully(pod_id='foo',
+                                            properties=['bar=baz'])
 
 
 def _assert_pod_add_invoked_successfully(pod_file_json):
@@ -164,16 +166,16 @@ def _assert_pod_list_propagates_exceptions_from_list_pod(exception):
     assert exception_info.value == exception
 
 
-def _assert_pod_update_invoked_successfully(pod_id):
+def _assert_pod_update_invoked_successfully(pod_id, properties):
     resource_reader = create_autospec(main.ResourceReader)
     marathon_client = create_autospec(marathon.Client)
     subcmd = main.MarathonSubcommand(resource_reader, lambda: marathon_client)
 
-    returncode = subcmd.pod_update(pod_id, properties=[], force=False)
+    returncode = subcmd.pod_update(pod_id, properties, force=False)
 
     assert returncode == 0
     marathon_client.show_pod.assert_called_with(pod_id)
-    resource_reader.from_properties_or_stdin.assert_called_with([])
+    resource_reader.from_properties_or_stdin.assert_called_with(properties)
 
 
 def _unused_reader_fixture():

--- a/cli/tests/unit/test_marathon_pod.py
+++ b/cli/tests/unit/test_marathon_pod.py
@@ -69,11 +69,8 @@ def test_pod_list_propagates_exceptions_from_list_pod():
 
 
 def test_pod_update_invoked_successfully():
-    subcmd, marathon_client = _unused_reader_fixture()
-
-    returncode = subcmd.pod_update(pod_id='foo', properties=[], force=False)
-
-    assert returncode == 0
+    _assert_pod_update_invoked_successfully(pod_id='foo')
+    _assert_pod_update_invoked_successfully(pod_id='bar')
 
 
 def _assert_pod_add_invoked_successfully(pod_file_json):
@@ -161,6 +158,15 @@ def _assert_pod_list_propagates_exceptions_from_list_pod(exception):
         subcmd.pod_list(json_=False)
 
     assert exception_info.value == exception
+
+
+def _assert_pod_update_invoked_successfully(pod_id):
+    subcmd, marathon_client = _unused_reader_fixture()
+
+    returncode = subcmd.pod_update(pod_id, properties=[], force=False)
+
+    assert returncode == 0
+    marathon_client.show_pod.assert_called_with(pod_id)
 
 
 def _unused_reader_fixture():

--- a/cli/tests/unit/test_marathon_pod.py
+++ b/cli/tests/unit/test_marathon_pod.py
@@ -112,6 +112,19 @@ def test_pod_update_propagates_exceptions_from_show_pod():
     assert str(exception_info.value) == 'show error'
 
 
+def test_pod_update_propagates_dcos_exception_from_resource_reader():
+    resource_reader = create_autospec(main.ResourceReader)
+    resource_reader.from_properties_or_stdin.side_effect = \
+        DCOSException('properties error')
+    marathon_client = create_autospec(marathon.Client)
+    subcmd = main.MarathonSubcommand(resource_reader, lambda: marathon_client)
+
+    with pytest.raises(DCOSException) as exception_info:
+        subcmd.pod_update(pod_id='foo', properties=[], force=False)
+
+    assert str(exception_info.value) == 'properties error'
+
+
 def _assert_pod_add_invoked_successfully(pod_file_json):
     pod_file_path = "some/path/to/pod.json"
     resource_reader = create_autospec(main.ResourceReader)

--- a/cli/tests/unit/test_marathon_pod.py
+++ b/cli/tests/unit/test_marathon_pod.py
@@ -68,6 +68,14 @@ def test_pod_list_propagates_exceptions_from_list_pod():
         Exception('Oops!'))
 
 
+def test_pod_update_invoked_successfully():
+    subcmd, marathon_client = _unused_reader_fixture()
+
+    returncode = subcmd.pod_update(pod_id='foo', properties=[], force=False)
+
+    assert returncode == 0
+
+
 def _assert_pod_add_invoked_successfully(pod_file_json):
     pod_file_path = "some/path/to/pod.json"
     resource_reader = {pod_file_path: pod_file_json}.__getitem__

--- a/cli/tests/unit/test_marathon_pod.py
+++ b/cli/tests/unit/test_marathon_pod.py
@@ -50,7 +50,7 @@ def test_pod_list_with_json():
 
 @patch('dcoscli.marathon.main.emitter', autospec=True)
 def test_pod_list_table(emitter):
-    subcmd, marathon_client = _unused_reader_fixture()
+    subcmd, marathon_client = _failing_reader_fixture()
     marathon_client.list_pod.return_value = marathon_fixtures.pod_fixture()
 
     returncode = subcmd.pod_list(json_=False)
@@ -157,7 +157,7 @@ def _assert_pod_add_propagates_exceptions_from_add_pod(exception):
 
 
 def _assert_pod_remove_invoked_successfully(pod_id, force):
-    subcmd, marathon_client = _unused_reader_fixture()
+    subcmd, marathon_client = _failing_reader_fixture()
 
     returncode = subcmd.pod_remove(pod_id, force)
 
@@ -166,7 +166,7 @@ def _assert_pod_remove_invoked_successfully(pod_id, force):
 
 
 def _assert_pod_remove_propagates_exceptions_from_remove_pod(exception):
-    subcmd, marathon_client = _unused_reader_fixture()
+    subcmd, marathon_client = _failing_reader_fixture()
     marathon_client.remove_pod.side_effect = exception
 
     with pytest.raises(exception.__class__) as exception_info:
@@ -177,7 +177,7 @@ def _assert_pod_remove_propagates_exceptions_from_remove_pod(exception):
 
 @patch('dcoscli.marathon.main.emitter', autospec=True)
 def _assert_pod_show_invoked_successfully(emitter, pod_json):
-    subcmd, marathon_client = _unused_reader_fixture()
+    subcmd, marathon_client = _failing_reader_fixture()
     marathon_client.show_pod.return_value = pod_json
 
     returncode = subcmd.pod_show(pod_json['id'])
@@ -188,7 +188,7 @@ def _assert_pod_show_invoked_successfully(emitter, pod_json):
 
 
 def _assert_pod_show_propagates_exceptions_from_show_pod(exception):
-    subcmd, marathon_client = _unused_reader_fixture()
+    subcmd, marathon_client = _failing_reader_fixture()
     marathon_client.show_pod.side_effect = exception
 
     with pytest.raises(exception.__class__) as exception_info:
@@ -199,7 +199,7 @@ def _assert_pod_show_propagates_exceptions_from_show_pod(exception):
 
 @patch('dcoscli.marathon.main.emitter', autospec=True)
 def _assert_pod_list_with_json(emitter, pod_list_json):
-    subcmd, marathon_client = _unused_reader_fixture()
+    subcmd, marathon_client = _failing_reader_fixture()
     marathon_client.list_pod.return_value = pod_list_json
 
     subcmd.pod_list(json_=True)
@@ -208,7 +208,7 @@ def _assert_pod_list_with_json(emitter, pod_list_json):
 
 
 def _assert_pod_list_propagates_exceptions_from_list_pod(exception):
-    subcmd, marathon_client = _unused_reader_fixture()
+    subcmd, marathon_client = _failing_reader_fixture()
     marathon_client.list_pod.side_effect = exception
 
     with pytest.raises(exception.__class__) as exception_info:
@@ -247,15 +247,15 @@ def _assert_pod_update_propagates_exception(
     assert str(exception_info.value) == error_message
 
 
-def _unused_reader_fixture():
+def _failing_reader_fixture():
     marathon_client = create_autospec(marathon.Client)
-    subcmd = main.MarathonSubcommand(_unused_resource_reader(),
+    subcmd = main.MarathonSubcommand(_failing_resource_reader(),
                                      lambda: marathon_client)
 
     return subcmd, marathon_client
 
 
-def _unused_resource_reader():
+def _failing_resource_reader():
     resource_reader = create_autospec(main.ResourceReader)
     error = AssertionError("should not be called")
     resource_reader.get_resource.side_effect = error

--- a/cli/tests/unit/test_marathon_pod.py
+++ b/cli/tests/unit/test_marathon_pod.py
@@ -125,6 +125,18 @@ def test_pod_update_propagates_dcos_exception_from_resource_reader():
     assert str(exception_info.value) == 'properties error'
 
 
+def test_pod_update_propagates_dcos_exception_from_update_pod():
+    resource_reader = create_autospec(main.ResourceReader)
+    marathon_client = create_autospec(marathon.Client)
+    marathon_client.update_pod.side_effect = DCOSException('update error')
+    subcmd = main.MarathonSubcommand(resource_reader, lambda: marathon_client)
+
+    with pytest.raises(DCOSException) as exception_info:
+        subcmd.pod_update(pod_id='foo', properties=[], force=False)
+
+    assert str(exception_info.value) == 'update error'
+
+
 def _assert_pod_add_invoked_successfully(pod_file_json):
     pod_file_path = "some/path/to/pod.json"
     resource_reader = create_autospec(main.ResourceReader)

--- a/cli/tests/unit/test_marathon_pod.py
+++ b/cli/tests/unit/test_marathon_pod.py
@@ -99,6 +99,19 @@ def test_pod_update_invoked_successfully():
         emitted='Created deployment some-arbitrary-value')
 
 
+def test_pod_update_propagates_exceptions_from_show_pod():
+    resource_reader = create_autospec(main.ResourceReader)
+    marathon_client = create_autospec(marathon.Client)
+    marathon_client.show_pod.side_effect = DCOSException('show error')
+    marathon_client.update_pod.side_effect = DCOSException('update error')
+    subcmd = main.MarathonSubcommand(resource_reader, lambda: marathon_client)
+
+    with pytest.raises(DCOSException) as exception_info:
+        subcmd.pod_update(pod_id='foo', properties=[], force=False)
+
+    assert str(exception_info.value) == 'show error'
+
+
 def _assert_pod_add_invoked_successfully(pod_file_json):
     pod_file_path = "some/path/to/pod.json"
     resource_reader = create_autospec(main.ResourceReader)

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -768,6 +768,16 @@ class Client(object):
         response = self._rpc.http_req(http.get, 'v2/pods')
         return response.json()
 
+    def update_pod(self, pod_id):
+        """Update a pod.
+
+        :param pod_id: the pod ID
+        :type pod_id: str
+        :rtype: None
+        """
+
+        self._rpc.http_req(http.put, 'v2/pods/{}'.format(pod_id))
+
     @staticmethod
     def _marathon_id_path_join(url_path, id_path):
         """Concatenates a URL path with a Marathon "ID path", ensuring the

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -748,7 +748,9 @@ class Client(object):
 
         path = self._marathon_id_path_join('v2/pods', pod_id)
         params = self._force_params(force)
-        self._rpc.http_req(http.put, path, params=params, json=pod_json)
+        response = self._rpc.http_req(
+            http.put, path, params=params, json=pod_json)
+        return response.json()['deploymentId']
 
     @staticmethod
     def _marathon_id_path_join(url_path, id_path):

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -319,7 +319,7 @@ class Client(object):
 
         return response.json()
 
-    def _update(self, resource_id, payload, force=None, url_endpoint="apps"):
+    def _update(self, resource_id, payload, force=False, url_endpoint="apps"):
         """Update an application or group.
 
         :param resource_id: the app or group id
@@ -335,12 +335,7 @@ class Client(object):
         """
 
         resource_id = util.normalize_marathon_id_path(resource_id)
-
-        if not force:
-            params = None
-        else:
-            params = {'force': 'true'}
-
+        params = self._force_params(force)
         path = 'v2/{}{}'.format(url_endpoint, resource_id)
 
         response = self._rpc.http_req(http.put,
@@ -350,7 +345,7 @@ class Client(object):
 
         return response.json().get('deploymentId')
 
-    def update_app(self, app_id, payload, force=None):
+    def update_app(self, app_id, payload, force=False):
         """Update an application.
 
         :param app_id: the application id
@@ -365,7 +360,7 @@ class Client(object):
 
         return self._update(app_id, payload, force)
 
-    def update_group(self, group_id, payload, force=None):
+    def update_group(self, group_id, payload, force=False):
         """Update a group.
 
         :param group_id: the group id
@@ -380,7 +375,7 @@ class Client(object):
 
         return self._update(group_id, payload, force, "groups")
 
-    def scale_app(self, app_id, instances, force=None):
+    def scale_app(self, app_id, instances, force=False):
         """Scales an application to the requested number of instances.
 
         :param app_id: the ID of the application to scale
@@ -394,12 +389,7 @@ class Client(object):
         """
 
         app_id = util.normalize_marathon_id_path(app_id)
-
-        if not force:
-            params = None
-        else:
-            params = {'force': 'true'}
-
+        params = self._force_params(force)
         path = 'v2/apps{}'.format(app_id)
 
         response = self._rpc.http_req(http.put,
@@ -410,7 +400,7 @@ class Client(object):
         deployment = response.json()['deploymentId']
         return deployment
 
-    def scale_group(self, group_id, scale_factor, force=None):
+    def scale_group(self, group_id, scale_factor, force=False):
         """Scales a group with the requested scale-factor.
         :param group_id: the ID of the group to scale
         :type group_id: str
@@ -423,12 +413,7 @@ class Client(object):
         """
 
         group_id = util.normalize_marathon_id_path(group_id)
-
-        if not force:
-            params = None
-        else:
-            params = {'force': 'true'}
-
+        params = self._force_params(force)
         path = 'v2/groups{}'.format(group_id)
 
         response = self._rpc.http_req(http.put,
@@ -439,7 +424,7 @@ class Client(object):
         deployment = response.json()['deploymentId']
         return deployment
 
-    def stop_app(self, app_id, force=None):
+    def stop_app(self, app_id, force=False):
         """Scales an application to zero instances.
 
         :param app_id: the ID of the application to stop
@@ -452,7 +437,7 @@ class Client(object):
 
         return self.scale_app(app_id, 0, force)
 
-    def remove_app(self, app_id, force=None):
+    def remove_app(self, app_id, force=False):
         """Completely removes the requested application.
 
         :param app_id: the ID of the application to remove
@@ -463,16 +448,11 @@ class Client(object):
         """
 
         app_id = util.normalize_marathon_id_path(app_id)
-
-        if not force:
-            params = None
-        else:
-            params = {'force': 'true'}
-
+        params = self._force_params(force)
         path = 'v2/apps{}'.format(app_id)
         self._rpc.http_req(http.delete, path, params=params)
 
-    def remove_group(self, group_id, force=None):
+    def remove_group(self, group_id, force=False):
         """Completely removes the requested application.
 
         :param group_id: the ID of the application to remove
@@ -483,12 +463,7 @@ class Client(object):
         """
 
         group_id = util.normalize_marathon_id_path(group_id)
-
-        if not force:
-            params = None
-        else:
-            params = {'force': 'true'}
-
+        params = self._force_params(force)
         path = 'v2/groups{}'.format(group_id)
 
         self._rpc.http_req(http.delete, path, params=params)
@@ -514,7 +489,7 @@ class Client(object):
         response = self._rpc.http_req(http.delete, path, params=params)
         return response.json()
 
-    def restart_app(self, app_id, force=None):
+    def restart_app(self, app_id, force=False):
         """Performs a rolling restart of all of the tasks.
 
         :param app_id: the id of the application to restart
@@ -526,12 +501,7 @@ class Client(object):
         """
 
         app_id = util.normalize_marathon_id_path(app_id)
-
-        if not force:
-            params = None
-        else:
-            params = {'force': 'true'}
-
+        params = self._force_params(force)
         path = 'v2/apps{}/restart'.format(app_id)
 
         response = self._rpc.http_req(http.post, path, params=params)
@@ -590,11 +560,7 @@ class Client(object):
         :rtype: dict
         """
 
-        if not force:
-            params = None
-        else:
-            params = {'force': 'true'}
-
+        params = self._force_params(force)
         path = 'v2/deployments/{}'.format(deployment_id)
 
         response = self._rpc.http_req(http.delete, path, params=params)
@@ -742,7 +708,7 @@ class Client(object):
         """
 
         path = self._marathon_id_path_join('v2/pods', pod_id)
-        params = {'force': 'true'} if force else None
+        params = self._force_params(force)
         self._rpc.http_req(http.delete, path, params=params)
 
     def show_pod(self, pod_id):
@@ -779,7 +745,8 @@ class Client(object):
         """
 
         path = self._marathon_id_path_join('v2/pods', pod_id)
-        self._rpc.http_req(http.put, path, params=None)
+        params = self._force_params(force)
+        self._rpc.http_req(http.put, path, params=params)
 
     @staticmethod
     def _marathon_id_path_join(url_path, id_path):
@@ -800,6 +767,17 @@ class Client(object):
 
         normalized_id_path = urllib.parse.quote(id_path.strip('/'))
         return url_path.rstrip('/') + '/' + normalized_id_path
+
+    @staticmethod
+    def _force_params(force):
+        """Returns the query parameters that signify the provided force value.
+
+        :param force: whether to override running deployments
+        :type force: bool
+        :rtype: {} | None
+        """
+
+        return {'force': 'true'} if force else None
 
 
 def _default_marathon_error(message=""):

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -695,7 +695,9 @@ class Client(object):
         :returns: description of created pod
         :rtype: dict
         """
-        return self._rpc.http_req(http.post, 'v2/pods', json=pod_json)
+
+        response = self._rpc.http_req(http.post, 'v2/pods', json=pod_json)
+        return response.json()
 
     def remove_pod(self, pod_id, force=False):
         """Completely removes the requested pod.

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -345,7 +345,7 @@ class Client(object):
             return body_json['deploymentId']
         except KeyError:
             template = ('Error: missing "deploymentId" field in the following '
-                        'JSON response from\nMarathon:\n{}')
+                        'JSON response from Marathon:\n{}')
             rendered_json = json.dumps(body_json, indent=2, sort_keys=True)
             raise DCOSException(template.format(rendered_json))
 
@@ -800,8 +800,8 @@ class Client(object):
         try:
             return response.json()
         except:
-            template = ('Error: the following response from Marathon was not '
-                        'in JSON format:\n{}')
+            template = ('Error: Response from Marathon was not in expected '
+                        'JSON format:\n{}')
             raise DCOSException(template.format(response.text))
 
 

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -776,7 +776,8 @@ class Client(object):
         :rtype: None
         """
 
-        self._rpc.http_req(http.put, 'v2/pods/{}'.format(pod_id))
+        path = self._marathon_id_path_join('v2/pods', pod_id)
+        self._rpc.http_req(http.put, path)
 
     @staticmethod
     def _marathon_id_path_join(url_path, id_path):

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -750,7 +750,10 @@ class Client(object):
         params = self._force_params(force)
         response = self._rpc.http_req(
             http.put, path, params=params, json=pod_json)
-        return response.json()['deploymentId']
+        try:
+            return response.json()['deploymentId']
+        except:
+            pass
 
     @staticmethod
     def _marathon_id_path_join(url_path, id_path):

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -734,11 +734,13 @@ class Client(object):
         response = self._rpc.http_req(http.get, 'v2/pods')
         return response.json()
 
-    def update_pod(self, pod_id, force=False):
+    def update_pod(self, pod_id, pod_json, force=False):
         """Update a pod.
 
         :param pod_id: the pod ID
         :type pod_id: str
+        :param pod_json: JSON pod definition
+        :type pod_json: {}
         :param force: whether to override running deployments
         :type force: bool
         :rtype: None
@@ -746,7 +748,7 @@ class Client(object):
 
         path = self._marathon_id_path_join('v2/pods', pod_id)
         params = self._force_params(force)
-        self._rpc.http_req(http.put, path, params=params)
+        self._rpc.http_req(http.put, path, params=params, json=pod_json)
 
     @staticmethod
     def _marathon_id_path_join(url_path, id_path):

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -768,16 +768,18 @@ class Client(object):
         response = self._rpc.http_req(http.get, 'v2/pods')
         return response.json()
 
-    def update_pod(self, pod_id):
+    def update_pod(self, pod_id, force=False):
         """Update a pod.
 
         :param pod_id: the pod ID
         :type pod_id: str
+        :param force: whether to override running deployments
+        :type force: bool
         :rtype: None
         """
 
         path = self._marathon_id_path_join('v2/pods', pod_id)
-        self._rpc.http_req(http.put, path)
+        self._rpc.http_req(http.put, path, params=None)
 
     @staticmethod
     def _marathon_id_path_join(url_path, id_path):

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -750,12 +750,21 @@ class Client(object):
         params = self._force_params(force)
         response = self._rpc.http_req(
             http.put, path, params=params, json=pod_json)
+
         try:
-            return response.json()['deploymentId']
+            body_json = response.json()
         except:
             template = ('Error: the following response from Marathon was not '
                         'in JSON format:\n{}')
             raise DCOSException(template.format(response.text))
+
+        try:
+            return body_json['deploymentId']
+        except KeyError:
+            template = ('Error: missing "deploymentId" field in the following '
+                        'JSON response from\nMarathon:\n{}')
+            rendered_json = json.dumps(body_json, indent=2, sort_keys=True)
+            raise DCOSException(template.format(rendered_json))
 
     @staticmethod
     def _marathon_id_path_join(url_path, id_path):

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -753,7 +753,9 @@ class Client(object):
         try:
             return response.json()['deploymentId']
         except:
-            pass
+            template = ('Error: the following response from Marathon was not '
+                        'in JSON format:\n{}')
+            raise DCOSException(template.format(response.text))
 
     @staticmethod
     def _marathon_id_path_join(url_path, id_path):

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -121,18 +121,36 @@ def test_list_pod_propagates_json_parsing_exception():
 
 def test_update_pod_builds_rpc_correctly():
     _assert_update_pod_builds_rpc_correctly(
-        pod_id='foo', force=False, path='v2/pods/foo', params=None)
+        pod_id='foo',
+        pod_json={'some': 'json'},
+        force=False,
+        path='v2/pods/foo',
+        params=None)
     _assert_update_pod_builds_rpc_correctly(
-        pod_id='/foo bar/', force=False, path='v2/pods/foo%20bar', params=None)
+        pod_id='/foo bar/',
+        pod_json={'some': 'json'},
+        force=False,
+        path='v2/pods/foo%20bar',
+        params=None)
     _assert_update_pod_builds_rpc_correctly(
-        pod_id='foo', force=True, path='v2/pods/foo', params={'force': 'true'})
+        pod_id='foo',
+        pod_json={'some': 'json'},
+        force=True,
+        path='v2/pods/foo',
+        params={'force': 'true'})
+    _assert_update_pod_builds_rpc_correctly(
+        pod_id='foo',
+        pod_json={'something': 'different'},
+        force=False,
+        path='v2/pods/foo',
+        params=None)
 
 
 def test_update_pod_has_default_force_value():
     marathon_client, rpc_client = _create_fixtures()
-    marathon_client.update_pod('foo')
+    marathon_client.update_pod('foo', {'some': 'json'})
     rpc_client.http_req.assert_called_with(
-        http.put, 'v2/pods/foo', params=None)
+        http.put, 'v2/pods/foo', params=None, json={'some': 'json'})
 
 
 def test_rpc_client_http_req_calls_method_fn():
@@ -457,10 +475,12 @@ def _assert_list_pod_returns_success_response_json(body_json):
     assert marathon_client.list_pod() == body_json
 
 
-def _assert_update_pod_builds_rpc_correctly(pod_id, force, path, params):
+def _assert_update_pod_builds_rpc_correctly(
+        pod_id, pod_json, force, path, params):
     marathon_client, rpc_client = _create_fixtures()
-    marathon_client.update_pod(pod_id, force)
-    rpc_client.http_req.assert_called_with(http.put, path, params=params)
+    marathon_client.update_pod(pod_id, pod_json, force)
+    rpc_client.http_req.assert_called_with(
+        http.put, path, params=params, json=pod_json)
 
 
 def _assert_method_propagates_rpc_dcos_exception(invoke_method):

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -119,15 +119,18 @@ def test_list_pod_propagates_json_parsing_exception():
         lambda marathon_client: marathon_client.list_pod())
 
 
-def test_update_pod_includes_id_in_path_correctly():
-    _assert_update_pod_includes_id_in_path_correctly('foo', 'v2/pods/foo')
-    _assert_update_pod_includes_id_in_path_correctly('/foo bar/',
-                                                     'v2/pods/foo%20bar')
+def test_update_pod_builds_rpc_correctly():
+    _assert_update_pod_builds_rpc_correctly(
+        pod_id='foo', force=False, path='v2/pods/foo', params=None)
+    _assert_update_pod_builds_rpc_correctly(
+        pod_id='/foo bar/', force=False, path='v2/pods/foo%20bar', params=None)
+    _assert_update_pod_builds_rpc_correctly(
+        pod_id='foo', force=True, path='v2/pods/foo', params={'force': 'true'})
 
 
-def test_update_pod_handles_force_argument_correctly():
+def test_update_pod_has_default_force_value():
     marathon_client, rpc_client = _create_fixtures()
-    marathon_client.update_pod('foo', force=False)
+    marathon_client.update_pod('foo')
     rpc_client.http_req.assert_called_with(
         http.put, 'v2/pods/foo', params=None)
 
@@ -454,10 +457,10 @@ def _assert_list_pod_returns_success_response_json(body_json):
     assert marathon_client.list_pod() == body_json
 
 
-def _assert_update_pod_includes_id_in_path_correctly(pod_id, path):
+def _assert_update_pod_builds_rpc_correctly(pod_id, force, path, params):
     marathon_client, rpc_client = _create_fixtures()
-    marathon_client.update_pod(pod_id)
-    rpc_client.http_req.assert_called_with(http.put, path, params=None)
+    marathon_client.update_pod(pod_id, force)
+    rpc_client.http_req.assert_called_with(http.put, path, params=params)
 
 
 def _assert_method_propagates_rpc_dcos_exception(invoke_method):

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -119,6 +119,11 @@ def test_list_pod_propagates_json_parsing_exception():
         lambda marathon_client: marathon_client.list_pod())
 
 
+def test_update_pod_includes_id_in_path_correctly():
+    _assert_update_pod_includes_id_in_path_correctly('foo', 'v2/pods/foo')
+    _assert_update_pod_includes_id_in_path_correctly('bar', 'v2/pods/bar')
+
+
 def test_rpc_client_http_req_calls_method_fn():
     _assert_rpc_client_http_req_calls_method_fn(
         base_url='http://base/url',
@@ -439,6 +444,12 @@ def _assert_list_pod_returns_success_response_json(body_json):
     rpc_client.http_req.return_value = mock_response
 
     assert marathon_client.list_pod() == body_json
+
+
+def _assert_update_pod_includes_id_in_path_correctly(pod_id, path):
+    marathon_client, rpc_client = _create_fixtures()
+    marathon_client.update_pod(pod_id)
+    rpc_client.http_req.assert_called_with(http.put, path)
 
 
 def _assert_method_propagates_rpc_dcos_exception(invoke_method):

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -125,15 +125,45 @@ def test_list_pod_raises_dcos_exception_for_json_parse_errors():
 
 
 def test_update_pod_executes_successfully():
-    _assert_update_pod_executes_successfully()
     _assert_update_pod_executes_successfully(
-        pod_id='/foo bar/', path='v2/pods/foo%20bar')
+        pod_id='foo',
+        pod_json={'some', 'json'},
+        force=False,
+        response_body={'deploymentId': 'pod-deployment-id'},
+        path='v2/pods/foo',
+        params=None,
+        expected_return='pod-deployment-id')
     _assert_update_pod_executes_successfully(
-        force=True, params={'force': 'true'})
+        pod_id='/foo bar/',
+        pod_json={'some', 'json'},
+        force=False,
+        response_body={'deploymentId': 'pod-deployment-id'},
+        path='v2/pods/foo%20bar',
+        params=None,
+        expected_return='pod-deployment-id')
     _assert_update_pod_executes_successfully(
-        pod_json={'something': 'different'})
+        pod_id='foo',
+        pod_json={'some', 'json'},
+        force=True,
+        response_body={'deploymentId': 'pod-deployment-id'},
+        path='v2/pods/foo',
+        params={'force': 'true'},
+        expected_return='pod-deployment-id')
     _assert_update_pod_executes_successfully(
+        pod_id='foo',
+        pod_json={'something', 'different'},
+        force=False,
+        response_body={'deploymentId': 'pod-deployment-id'},
+        path='v2/pods/foo',
+        params=None,
+        expected_return='pod-deployment-id')
+    _assert_update_pod_executes_successfully(
+        pod_id='foo',
+        pod_json={'some', 'json'},
+        force=False,
         response_body={'deploymentId': 'an-arbitrary-value'},
+        path='v2/pods/foo',
+        params=None,
         expected_return='an-arbitrary-value')
 
 
@@ -492,12 +522,7 @@ def _assert_list_pod_returns_success_response_json(body_json):
 
 
 def _assert_update_pod_executes_successfully(
-        pod_id='foo', pod_json=None, force=False, response_body=None,
-        path='v2/pods/foo', params=None, expected_return='pod-deployment-id'):
-    pod_json = _default_if_none(pod_json, {'some': 'json'})
-    response_body = _default_if_none(
-        response_body, {'deploymentId': expected_return})
-
+        pod_id, pod_json, force, response_body, path, params, expected_return):
     marathon_client, rpc_client = _create_fixtures()
     mock_response = mock.create_autospec(requests.Response)
     mock_response.json.return_value = response_body
@@ -675,10 +700,6 @@ def _create_fixtures():
     marathon_client = marathon.Client(rpc_client)
 
     return marathon_client, rpc_client
-
-
-def _default_if_none(value, default):
-    return value if value is not None else default
 
 
 _MESSAGE_1 = 'Oops!'

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -450,11 +450,13 @@ def _assert_add_pod_puts_json_in_request_body(pod_json):
 
 
 def _assert_add_pod_returns_parsed_response_body(response_json):
-    rpc_client = mock.create_autospec(marathon.RpcClient)
-    rpc_client.http_req.return_value = response_json
+    mock_response = mock.create_autospec(requests.Response)
+    mock_response.json.return_value = response_json
 
-    client = marathon.Client(rpc_client)
-    assert client.add_pod("arbitrary") == response_json
+    marathon_client, rpc_client = _create_fixtures()
+    rpc_client.http_req.return_value = mock_response
+
+    assert marathon_client.add_pod({'some': 'json'}) == response_json
 
 
 def _assert_show_pod_builds_rpc_correctly(pod_id, path):

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -109,7 +109,7 @@ def test_list_pod_returns_success_response_json():
     _assert_list_pod_returns_success_response_json(body_json=['a', 'b', 'c'])
 
 
-def test_list_pod_propagates_dcos_exception():
+def test_list_pod_propagates_rpc_dcos_exception():
     _assert_method_propagates_rpc_dcos_exception(
         lambda marathon_client: marathon_client.list_pod())
 
@@ -137,6 +137,12 @@ def test_update_pod_has_default_force_value():
     marathon_client.update_pod('foo', {'some': 'json'})
     rpc_client.http_req.assert_called_with(
         http.put, 'v2/pods/foo', params=None, json={'some': 'json'})
+
+
+def test_update_pod_propagates_rpc_dcos_exception():
+    _assert_method_propagates_rpc_dcos_exception(
+        lambda marathon_client:
+            marathon_client.update_pod('foo', {'some': 'json'}))
 
 
 def test_rpc_client_http_req_calls_method_fn():

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -125,6 +125,13 @@ def test_update_pod_includes_id_in_path_correctly():
                                                      'v2/pods/foo%20bar')
 
 
+def test_update_pod_handles_force_argument_correctly():
+    marathon_client, rpc_client = _create_fixtures()
+    marathon_client.update_pod('foo', force=False)
+    rpc_client.http_req.assert_called_with(
+        http.put, 'v2/pods/foo', params=None)
+
+
 def test_rpc_client_http_req_calls_method_fn():
     _assert_rpc_client_http_req_calls_method_fn(
         base_url='http://base/url',
@@ -450,7 +457,7 @@ def _assert_list_pod_returns_success_response_json(body_json):
 def _assert_update_pod_includes_id_in_path_correctly(pod_id, path):
     marathon_client, rpc_client = _create_fixtures()
     marathon_client.update_pod(pod_id)
-    rpc_client.http_req.assert_called_with(http.put, path)
+    rpc_client.http_req.assert_called_with(http.put, path, params=None)
 
 
 def _assert_method_propagates_rpc_dcos_exception(invoke_method):

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -522,8 +522,8 @@ def _assert_method_raises_dcos_exception_for_json_parse_errors(invoke_method):
         with pytest.raises(DCOSException) as exception_info:
             invoke_method(marathon_client)
 
-        pattern = ('Error: the following response from Marathon was not in '
-                   'JSON format:\n(.*)')
+        pattern = ('Error: Response from Marathon was not in expected JSON '
+                   'format:\n(.*)')
         actual_error = str(exception_info.value)
         _assert_matches_with_groups(pattern, actual_error, (non_json,))
 
@@ -543,7 +543,7 @@ def _assert_update_pod_raises_dcos_exception_if_deployment_id_missing(
         marathon_client.update_pod('foo', {'some': 'json'})
 
     pattern = ('Error: missing "deploymentId" field in the following JSON '
-               'response from\nMarathon:\n(.*)')
+               'response from Marathon:\n(.*)')
     actual_error = str(exception_info.value)
     _assert_matches_with_groups(pattern, actual_error, (rendered_bad_json,))
 

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -121,7 +121,8 @@ def test_list_pod_propagates_json_parsing_exception():
 
 def test_update_pod_includes_id_in_path_correctly():
     _assert_update_pod_includes_id_in_path_correctly('foo', 'v2/pods/foo')
-    _assert_update_pod_includes_id_in_path_correctly('bar', 'v2/pods/bar')
+    _assert_update_pod_includes_id_in_path_correctly('/foo bar/',
+                                                     'v2/pods/foo%20bar')
 
 
 def test_rpc_client_http_req_calls_method_fn():


### PR DESCRIPTION
The integration tests for `pod update` against the `feature/pods` branch of Marathon still fail, because there's a discrepancy between what the RAML spec says vs. what the endpoint returns in the response. I'm assuming we can address that during the end-to-end test phase.