### PR TITLE
All pod subcommands check for Marathon support

### DIFF
--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -861,6 +861,8 @@ class MarathonSubcommand(object):
         """
 
         marathon_client = self._create_marathon_client()
+        if not marathon_client.pod_feature_supported():
+            raise DCOSException('This command is not supported by Marathon')
         pod_json = self._resource_reader.get_resource(pod_resource_path)
         marathon_client.add_pod(pod_json)
         return 0

--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -860,9 +860,7 @@ class MarathonSubcommand(object):
         :rtype: int
         """
 
-        marathon_client = self._create_marathon_client()
-        if not marathon_client.pod_feature_supported():
-            raise DCOSException('This command is not supported by Marathon')
+        marathon_client = self._marathon_client_with_pods()
         pod_json = self._resource_reader.get_resource(pod_resource_path)
         marathon_client.add_pod(pod_json)
         return 0
@@ -877,7 +875,7 @@ class MarathonSubcommand(object):
         :rtype: int
         """
 
-        marathon_client = self._create_marathon_client()
+        marathon_client = self._marathon_client_with_pods()
         marathon_client.remove_pod(pod_id, force)
         return 0
 
@@ -889,7 +887,7 @@ class MarathonSubcommand(object):
         :rtype: int
         """
 
-        marathon_client = self._create_marathon_client()
+        marathon_client = self._marathon_client_with_pods()
         pods = marathon_client.list_pod()
         emitting.publish_table(emitter, pods, tables.pod_table, json_)
         return 0
@@ -903,7 +901,7 @@ class MarathonSubcommand(object):
         :rtype: int
         """
 
-        marathon_client = self._create_marathon_client()
+        marathon_client = self._marathon_client_with_pods()
         pod_json = marathon_client.show_pod(pod_id)
         emitter.publish(pod_json)
         return 0
@@ -920,7 +918,7 @@ class MarathonSubcommand(object):
         :rtype: int
         """
 
-        marathon_client = self._create_marathon_client()
+        marathon_client = self._marathon_client_with_pods()
 
         # Ensure that the pod exists
         marathon_client.show_pod(pod_id)
@@ -932,6 +930,20 @@ class MarathonSubcommand(object):
 
         emitter.publish('Created deployment {}'.format(deployment_id))
         return 0
+
+    def _marathon_client_with_pods(self):
+        """Creates and returns a Marathon client, but raises an exception if
+        it does not support the pod API.
+
+        :rtype: dcos.marathon.Client
+        """
+
+        marathon_client = self._create_marathon_client()
+
+        if not marathon_client.pod_feature_supported():
+            raise DCOSException('This command is not supported by Marathon')
+
+        return marathon_client
 
 
 def _calculate_version(client, app_id, version):

--- a/cli/tests/unit/test_marathon_pod.py
+++ b/cli/tests/unit/test_marathon_pod.py
@@ -101,7 +101,7 @@ def test_pod_update_invoked_successfully():
 
 def test_pod_update_propagates_exceptions_from_show_pod():
     resource_reader = create_autospec(main.ResourceReader)
-    marathon_client = create_autospec(marathon.Client)
+    marathon_client = _marathon_client_fixture()
     marathon_client.show_pod.side_effect = DCOSException('show error')
     marathon_client.update_pod.side_effect = DCOSException('update error')
 
@@ -113,7 +113,7 @@ def test_pod_update_propagates_dcos_exception_from_resource_reader():
     resource_reader = create_autospec(main.ResourceReader)
     resource_reader.get_resource_from_properties.side_effect = \
         DCOSException('properties error')
-    marathon_client = create_autospec(marathon.Client)
+    marathon_client = _marathon_client_fixture()
 
     _assert_pod_update_propagates_exception(
         resource_reader, marathon_client, 'properties error')
@@ -121,7 +121,7 @@ def test_pod_update_propagates_dcos_exception_from_resource_reader():
 
 def test_pod_update_propagates_dcos_exception_from_update_pod():
     resource_reader = create_autospec(main.ResourceReader)
-    marathon_client = create_autospec(marathon.Client)
+    marathon_client = _marathon_client_fixture()
     marathon_client.update_pod.side_effect = DCOSException('update error')
 
     _assert_pod_update_propagates_exception(
@@ -167,7 +167,7 @@ def _assert_pod_add_invoked_successfully(pod_file_json):
     pod_file_path = "some/path/to/pod.json"
     resource_reader = create_autospec(main.ResourceReader)
     resource_reader.get_resource.return_value = pod_file_json
-    marathon_client = create_autospec(marathon.Client)
+    marathon_client = _marathon_client_fixture()
 
     subcmd = main.MarathonSubcommand(resource_reader, lambda: marathon_client)
     returncode = subcmd.pod_add(pod_file_path)
@@ -181,7 +181,7 @@ def _assert_pod_add_propagates_exceptions_from_add_pod(exception):
     resource_reader = create_autospec(main.ResourceReader)
     resource_reader.get_resource.return_value = {'some': 'json'}
 
-    marathon_client = create_autospec(marathon.Client)
+    marathon_client = _marathon_client_fixture()
     marathon_client.add_pod.side_effect = exception
 
     subcmd = main.MarathonSubcommand(resource_reader, lambda: marathon_client)
@@ -258,7 +258,7 @@ def _assert_pod_update_invoked_successfully(
     resource_reader = create_autospec(main.ResourceReader)
     resource_reader.get_resource_from_properties.return_value = resource
 
-    marathon_client = create_autospec(marathon.Client)
+    marathon_client = _marathon_client_fixture()
     marathon_client.update_pod.return_value = deployment_id
 
     subcmd = main.MarathonSubcommand(resource_reader, lambda: marathon_client)
@@ -282,8 +282,14 @@ def _assert_pod_update_propagates_exception(
     assert str(exception_info.value) == error_message
 
 
-def _failing_reader_fixture():
+def _marathon_client_fixture():
     marathon_client = create_autospec(marathon.Client)
+    marathon_client.pod_feature_supported.return_value = True
+    return marathon_client
+
+
+def _failing_reader_fixture():
+    marathon_client = _marathon_client_fixture()
     subcmd = main.MarathonSubcommand(_failing_resource_reader(),
                                      lambda: marathon_client)
 

--- a/cli/tests/unit/test_marathon_pod.py
+++ b/cli/tests/unit/test_marathon_pod.py
@@ -18,6 +18,17 @@ def test_pod_add_propagates_exceptions_from_add_pod():
     _assert_pod_add_propagates_exceptions_from_add_pod(Exception('Oops!'))
 
 
+def test_pod_add_fails_if_not_supported():
+    subcmd, marathon_client = _failing_reader_fixture()
+    marathon_client.pod_feature_supported.return_value = False
+
+    with pytest.raises(DCOSException) as exception_info:
+        subcmd.pod_add('not/used')
+
+    message = 'This command is not supported by Marathon'
+    assert str(exception_info.value) == message
+
+
 def test_pod_remove_invoked_successfully():
     _assert_pod_remove_invoked_successfully(pod_id='a-pod', force=False)
     _assert_pod_remove_invoked_successfully(pod_id='a-pod', force=True)

--- a/cli/tests/unit/test_marathon_pod.py
+++ b/cli/tests/unit/test_marathon_pod.py
@@ -136,7 +136,7 @@ def test_pod_command_fails_if_not_supported():
         with pytest.raises(DCOSException) as exception_info:
             invoke_command(subcmd)
 
-        message = 'This command is not supported by Marathon'
+        message = 'This command is not supported by your version of Marathon'
         assert str(exception_info.value) == message
 
     test_case(_default_pod_add)

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -762,7 +762,7 @@ class Client(object):
         """
 
         response = http.head('whatever')
-        return response.status_code == 200
+        return response.status_code // 100 == 2
 
     @staticmethod
     def _marathon_id_path_join(url_path, id_path):

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -761,7 +761,8 @@ class Client(object):
         :rtype: bool
         """
 
-        return True
+        response = http.head('whatever')
+        return response.status_code == 200
 
     @staticmethod
     def _marathon_id_path_join(url_path, id_path):

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -754,6 +754,15 @@ class Client(object):
 
         return self._update('pods', pod_id, pod_json, force)
 
+    def pod_feature_supported(self):
+        """Return whether or not this client is communicating with a server
+        that supports pod operations.
+
+        :rtype: bool
+        """
+
+        return True
+
     @staticmethod
     def _marathon_id_path_join(url_path, id_path):
         """Concatenates a URL path with a Marathon "ID path", ensuring the

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -780,8 +780,13 @@ class Client(object):
         :rtype: bool
         """
 
-        response = self._rpc.raw_http_req(http.head, 'v2/pods')
-        return response.status_code // 100 == 2
+        try:
+            response = self._rpc.raw_http_req(http.head, 'v2/pods')
+            return response.status_code // 100 == 2
+        except DCOSHTTPException as e:
+            if e.response.status_code == 404:
+                return False
+            raise
 
     @staticmethod
     def _marathon_id_path_join(url_path, id_path):

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -129,9 +129,9 @@ class RpcClient(object):
 
         return 'Error: {}'.format(message)
 
-    def raw_http_req(self, method_fn, path, *args, **kwargs):
-        """Make an HTTP request, letting any exceptions generated propagate to
-        the caller.
+    def http_req(self, method_fn, path, *args, **kwargs):
+        """Make an HTTP request, and raise a marathon-specific exception for
+        HTTP error codes.
 
         :param method_fn: function to call that invokes a specific HTTP method
         :type method_fn: function
@@ -150,26 +150,8 @@ class RpcClient(object):
         if 'timeout' not in kwargs:
             kwargs['timeout'] = self._timeout
 
-        return method_fn(url, *args, **kwargs)
-
-    def http_req(self, method_fn, path, *args, **kwargs):
-        """Make an HTTP request, and raise a marathon-specific exception for
-        HTTP error codes.
-
-        :param method_fn: function to call that invokes a specific HTTP method
-        :type method_fn: function
-        :param path: the endpoint path to append to this object's base URL
-        :type path: str
-        :param args: additional args to pass to `method_fn`
-        :type args: [object]
-        :param kwargs: kwargs to pass to `method_fn`
-        :type kwargs: dict
-        :returns: `method_fn` return value
-        :rtype: requests.Response
-        """
-
         try:
-            return self.raw_http_req(method_fn, path, *args, **kwargs)
+            return method_fn(url, *args, **kwargs)
         except DCOSHTTPException as e:
             # Marathon is buggy and sometimes returns JSON, sometimes returns
             # HTML. We only include the body in the error message if it's JSON.

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -756,15 +756,15 @@ class Client(object):
         return self._update('pods', pod_id, pod_json, force)
 
     def pod_feature_supported(self):
-        """Return whether or not this client is communicating with a server
-        that supports pod operations.
+        """Return whether or not this client is communicating with a version
+        of Marathon that supports pod operations.
 
         :rtype: bool
         """
 
         # Allow response objects to be returned from `http_req` on status 404,
         # while handling all other exceptions as usual
-        def head_404(url, **kwargs):
+        def test_for_pods(url, **kwargs):
             try:
                 return http.head(url, **kwargs)
             except DCOSHTTPException as e:
@@ -772,7 +772,7 @@ class Client(object):
                     return e.response
                 raise
 
-        response = self._rpc.http_req(head_404, 'v2/pods')
+        response = self._rpc.http_req(test_for_pods, 'v2/pods')
         return response.status_code // 100 == 2
 
     @staticmethod

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -164,6 +164,16 @@ def test_update_pod_raises_dcos_exception_if_deployment_id_missing():
                            '}'))
 
 
+@mock.patch('dcos.http.head')
+def test_pod_feature_supported_returns_true(head_fn):
+    mock_response = mock.create_autospec(requests.Response)
+    mock_response.status_code = 200
+    head_fn.return_value = mock_response
+
+    marathon_client, rpc_client = _create_fixtures()
+    assert marathon_client.pod_feature_supported()
+
+
 def test_rpc_client_http_req_calls_method_fn():
     _assert_rpc_client_http_req_calls_method_fn(
         base_url='http://base/url',

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -26,53 +26,20 @@ def test_add_pod_raises_dcos_exception_for_json_parse_errors():
         lambda marathon_client: marathon_client.add_pod({'some': 'json'}))
 
 
-def test_remove_pod_builds_rpc_correctly_1():
+def test_remove_pod_has_default_force_value():
     marathon_client, rpc_client = _create_fixtures()
     marathon_client.remove_pod('foo')
     rpc_client.http_req.assert_called_with(
         http.delete, 'v2/pods/foo', params=None)
 
 
-def test_remove_pod_builds_rpc_correctly_2():
-    marathon_client, rpc_client = _create_fixtures()
-    marathon_client.remove_pod('foo', force=False)
-    rpc_client.http_req.assert_called_with(
-        http.delete, 'v2/pods/foo', params=None)
-
-
-def test_remove_pod_builds_rpc_correctly_3():
-    marathon_client, rpc_client = _create_fixtures()
-    marathon_client.remove_pod('foo', force=True)
-    rpc_client.http_req.assert_called_with(
-        http.delete, 'v2/pods/foo', params={'force': 'true'})
-
-
-def test_remove_pod_builds_rpc_correctly_4():
-    marathon_client, rpc_client = _create_fixtures()
-    marathon_client.remove_pod('bar')
-    rpc_client.http_req.assert_called_with(
-        http.delete, 'v2/pods/bar', params=None)
-
-
-def test_remove_pod_builds_rpc_correctly_5():
-    marathon_client, rpc_client = _create_fixtures()
-    marathon_client.remove_pod('/bar')
-    rpc_client.http_req.assert_called_with(
-        http.delete, 'v2/pods/bar', params=None)
-
-
-def test_remove_pod_builds_rpc_correctly_6():
-    marathon_client, rpc_client = _create_fixtures()
-    marathon_client.remove_pod('bar/')
-    rpc_client.http_req.assert_called_with(
-        http.delete, 'v2/pods/bar', params=None)
-
-
-def test_remove_pod_builds_rpc_correctly_7():
-    marathon_client, rpc_client = _create_fixtures()
-    marathon_client.remove_pod('foo bar')
-    rpc_client.http_req.assert_called_with(
-        http.delete, 'v2/pods/foo%20bar', params=None)
+def test_remove_pod_builds_rpc_correctly():
+    _assert_remove_pod_builds_rpc_correctly(
+        pod_id='foo', force=False, path='v2/pods/foo', params=None)
+    _assert_remove_pod_builds_rpc_correctly(
+        pod_id='foo', force=True, path='v2/pods/foo', params={'force': 'true'})
+    _assert_remove_pod_builds_rpc_correctly(
+        pod_id='/foo bar/', force=False, path='v2/pods/foo%20bar', params=None)
 
 
 def test_remove_pod_propagates_dcos_exception():
@@ -493,6 +460,12 @@ def _assert_add_pod_returns_parsed_response_body(response_json):
     rpc_client.http_req.return_value = mock_response
 
     assert marathon_client.add_pod({'some': 'json'}) == response_json
+
+
+def _assert_remove_pod_builds_rpc_correctly(pod_id, force, path, params):
+    marathon_client, rpc_client = _create_fixtures()
+    marathon_client.remove_pod(pod_id, force)
+    rpc_client.http_req.assert_called_with(http.delete, path, params=params)
 
 
 def _assert_show_pod_builds_rpc_correctly(pod_id, path):

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -166,6 +166,8 @@ def test_update_pod_raises_dcos_exception_if_deployment_id_missing():
 
 def test_pod_feature_supported():
     assert _invoke_pod_feature_supported(status_code=200)
+    assert _invoke_pod_feature_supported(status_code=204)
+
     assert not _invoke_pod_feature_supported(status_code=404)
 
 

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -164,14 +164,9 @@ def test_update_pod_raises_dcos_exception_if_deployment_id_missing():
                            '}'))
 
 
-@mock.patch('dcos.http.head')
-def test_pod_feature_supported_returns_true(head_fn):
-    mock_response = mock.create_autospec(requests.Response)
-    mock_response.status_code = 200
-    head_fn.return_value = mock_response
-
-    marathon_client, rpc_client = _create_fixtures()
-    assert marathon_client.pod_feature_supported()
+def test_pod_feature_supported():
+    assert _invoke_pod_feature_supported(status_code=200)
+    assert not _invoke_pod_feature_supported(status_code=404)
 
 
 def test_rpc_client_http_req_calls_method_fn():
@@ -564,6 +559,16 @@ def _assert_method_propagates_rpc_dcos_exception(invoke_method):
         invoke_method(marathon_client)
 
     assert str(exception_info.value) == 'BOOM!'
+
+
+@mock.patch('dcos.http.head')
+def _invoke_pod_feature_supported(head_fn, status_code):
+    mock_response = mock.create_autospec(requests.Response)
+    mock_response.status_code = status_code
+    head_fn.return_value = mock_response
+
+    marathon_client, rpc_client = _create_fixtures()
+    return marathon_client.pod_feature_supported()
 
 
 def _assert_rpc_client_http_req_calls_method_fn(base_url, path, full_url):


### PR DESCRIPTION
Fixes #759.

~~**MERGE #768 BEFORE REVIEWING**~~

This PR updates all `dcos marathon pod` subcommands to check if the Marathon instance supports the pods HTTP API. This is accomplished by making a `HEAD /v2/pods` request and checking if the response's status code is in the 2xx range. If the status code is 404, we know pods are not supported. And if the status code is anything else, we default to the existing error handling for HTTP requests to Marathon.

The console output when a command is not supported is as follows:

```
$ dcos marathon pod list
This command is not supported by Marathon
```