### PR TITLE
Improving tox config: TeamCity test output, flake8-import-sort, pep8-naming

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,0 @@
-[settings]
-not_skip = __init__.py

--- a/cli/dcoscli/auth/main.py
+++ b/cli/dcoscli/auth/main.py
@@ -1,11 +1,12 @@
-import dcoscli
 import docopt
+from six.moves import urllib
+
+import dcoscli
 from dcos import cmds, config, emitting, http, util
 from dcos.errors import DCOSAuthorizationException, DCOSException
 from dcoscli.subcommand import default_command_info, default_doc
 from dcoscli.util import decorate_docopt_usage
 
-from six.moves import urllib
 
 emitter = emitting.FlatEmitter()
 logger = util.get_logger(__name__)

--- a/cli/dcoscli/config/main.py
+++ b/cli/dcoscli/config/main.py
@@ -1,7 +1,8 @@
 import collections
 
-import dcoscli
 import docopt
+
+import dcoscli
 from dcos import cmds, config, emitting, http, util
 from dcos.errors import DCOSException, DefaultError
 from dcoscli.subcommand import default_command_info, default_doc

--- a/cli/dcoscli/help/main.py
+++ b/cli/dcoscli/help/main.py
@@ -1,7 +1,8 @@
 from concurrent.futures import ThreadPoolExecutor
 
-import dcoscli
 import docopt
+
+import dcoscli
 from dcos import cmds, emitting, options, subcommand, subprocess, util
 from dcos.errors import DCOSException
 from dcoscli.subcommand import (default_command_documentation,

--- a/cli/dcoscli/job/main.py
+++ b/cli/dcoscli/job/main.py
@@ -2,10 +2,12 @@ import json
 import os
 import sys
 
-import dcoscli
 import docopt
 import pkg_resources
 import six
+from six.moves import urllib
+
+import dcoscli
 from dcos import cmds, config, cosmospackage, emitting, http, options, util
 from dcos.errors import DCOSException, DCOSHTTPException
 from dcoscli import tables
@@ -13,7 +15,6 @@ from dcoscli.package.main import get_cosmos_url
 from dcoscli.subcommand import default_command_info, default_doc
 from dcoscli.util import decorate_docopt_usage
 
-from six.moves import urllib
 
 logger = util.get_logger(__name__)
 emitter = emitting.FlatEmitter()

--- a/cli/dcoscli/main.py
+++ b/cli/dcoscli/main.py
@@ -2,13 +2,14 @@ import os
 import signal
 import sys
 
-import dcoscli
 import docopt
+from six.moves import urllib
+
+import dcoscli
 from dcos import config, constants, emitting, errors, http, subcommand, util
 from dcos.errors import DCOSException
-from dcoscli.subcommand import SubcommandMain, default_doc
+from dcoscli.subcommand import default_doc, SubcommandMain
 
-from six.moves import urllib
 
 logger = util.get_logger(__name__)
 emitter = emitting.FlatEmitter()

--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -3,10 +3,11 @@ import os
 import sys
 import time
 
-import dcoscli
 import docopt
 import pkg_resources
 import six
+
+import dcoscli
 from dcos import cmds, emitting, http, jsonitem, marathon, options, util
 from dcos.errors import DCOSException
 from dcoscli import tables

--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -1,9 +1,11 @@
 import functools
 import os
 
-import dcoscli
 import docopt
 import six
+from six.moves import urllib
+
+import dcoscli
 from dcos import (cmds, config, cosmospackage, emitting, errors, http, mesos,
                   subprocess, util)
 from dcos.errors import DCOSException, DefaultError
@@ -12,7 +14,6 @@ from dcoscli.package.main import confirm, get_cosmos_url
 from dcoscli.subcommand import default_command_info, default_doc
 from dcoscli.util import decorate_docopt_usage
 
-from six.moves import urllib
 
 logger = util.get_logger(__name__)
 emitter = emitting.FlatEmitter()

--- a/cli/dcoscli/package/main.py
+++ b/cli/dcoscli/package/main.py
@@ -2,9 +2,10 @@ import json
 import os
 import sys
 
-import dcoscli
 import docopt
 import pkg_resources
+
+import dcoscli
 from dcos import (cmds, config, cosmospackage, emitting, http, options,
                   package, subcommand, util)
 from dcos.errors import DCOSException

--- a/cli/dcoscli/service/main.py
+++ b/cli/dcoscli/service/main.py
@@ -1,6 +1,7 @@
-import dcoscli
 import docopt
 import six
+
+import dcoscli
 from dcos import cmds, emitting, marathon, mesos, subprocess, util
 from dcos.errors import DCOSException, DefaultError
 from dcoscli import log, tables

--- a/cli/dcoscli/task/main.py
+++ b/cli/dcoscli/task/main.py
@@ -1,8 +1,9 @@
 import posixpath
 
-import dcoscli
 import docopt
 import six
+
+import dcoscli
 from dcos import cmds, emitting, mesos, util
 from dcos.errors import DCOSException, DCOSHTTPException, DefaultError
 from dcoscli import log, tables

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -2,4 +2,5 @@ sphinx>=1.3.1, <2.0
 tox>=2.2, <3.0
 wheel>=0.24.0, <1.0
 pytest>=2.9.1
+teamcity-messages>=1.20
 -e .. # Install the DC/OS package

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -1,8 +1,9 @@
 from codecs import open
 from os import path
 
-import dcoscli
 from setuptools import find_packages, setup
+
+import dcoscli
 
 here = path.abspath(path.dirname(__file__))
 

--- a/cli/tests/integrations/common.py
+++ b/cli/tests/integrations/common.py
@@ -7,9 +7,9 @@ import subprocess
 import time
 
 import six
-from dcos import config, http
-
 from six.moves import urllib
+
+from dcos import config, http
 
 
 def exec_command(cmd, env=None, stdin=None):

--- a/cli/tests/integrations/test_auth.py
+++ b/cli/tests/integrations/test_auth.py
@@ -1,8 +1,8 @@
 import os
 
-from dcos import constants
-
 import pytest
+
+from dcos import constants
 
 from .common import assert_command, exec_command, update_config
 

--- a/cli/tests/integrations/test_config.py
+++ b/cli/tests/integrations/test_config.py
@@ -1,10 +1,10 @@
 import json
 import os
 
-import six
-from dcos import constants
-
 import pytest
+import six
+
+from dcos import constants
 
 from .common import (assert_command, config_set, config_unset,
                      exec_command, update_config)

--- a/cli/tests/integrations/test_job.py
+++ b/cli/tests/integrations/test_job.py
@@ -2,9 +2,9 @@ import contextlib
 import json
 import os
 
-from dcos import constants
-
 import pytest
+
+from dcos import constants
 
 from .common import (assert_command, exec_command, job, show_job,
                      show_job_schedule, update_config)

--- a/cli/tests/integrations/test_marathon.py
+++ b/cli/tests/integrations/test_marathon.py
@@ -5,10 +5,10 @@ import re
 import sys
 import threading
 
-from dcos import constants
-
 import pytest
 from six.moves.BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+
+from dcos import constants
 
 from .common import (app, assert_command, assert_lines,
                      exec_command, list_deployments, popen_tty,

--- a/cli/tests/integrations/test_marathon.py
+++ b/cli/tests/integrations/test_marathon.py
@@ -829,7 +829,7 @@ def _zero_instance_app():
 def _zero_instance_app_through_http():
     class JSONRequestHandler (BaseHTTPRequestHandler):
 
-        def do_GET(self):
+        def do_GET(self):  # noqa: N802
             self.send_response(200)
             self.send_header("Content-type", "application/json")
             self.end_headers()

--- a/cli/tests/integrations/test_marathon_pod.py
+++ b/cli/tests/integrations/test_marathon_pod.py
@@ -5,13 +5,13 @@ import re
 
 import pytest
 
+from .common import (assert_command, exec_command, file_json_ast,
+                     watch_all_deployments)
 from ..common import file_bytes
 from ..fixtures.marathon import (DOUBLE_POD_FILE_PATH, DOUBLE_POD_ID,
                                  GOOD_POD_FILE_PATH, GOOD_POD_ID,
-                                 TRIPLE_POD_FILE_PATH, TRIPLE_POD_ID,
-                                 UPDATED_GOOD_POD_FILE_PATH, pod_fixture)
-from .common import (assert_command, exec_command, file_json_ast,
-                     watch_all_deployments)
+                                 pod_fixture, TRIPLE_POD_FILE_PATH,
+                                 TRIPLE_POD_ID, UPDATED_GOOD_POD_FILE_PATH)
 
 _PODS_ENABLED = 'PODS_ENABLED' in os.environ
 

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -3,15 +3,15 @@ import os
 import re
 import sys
 
-import dcos.util as util
+import pytest
 import six
+
+import dcos.util as util
 from dcos import mesos
 from dcos.util import create_schema
 
-import pytest
-
-from ..fixtures.node import slave_fixture
 from .common import assert_command, assert_lines, exec_command, ssh_output
+from ..fixtures.node import slave_fixture
 
 
 def test_help():

--- a/cli/tests/integrations/test_package.py
+++ b/cli/tests/integrations/test_package.py
@@ -876,10 +876,10 @@ def _install_bad_chronos(args=['--yes'],
     returncode_, stdout_, stderr_ = exec_command(cmd)
     assert returncode_ == 1
     assert stderr in stderr_.decode('utf-8')
-    preInstallNotes = (b'We recommend a minimum of one node with at least 1 '
-                       b'CPU and 2GB of RAM available for the Chronos '
-                       b'Service.\n')
-    assert stdout_ == preInstallNotes
+    pre_install_notes = (b'We recommend a minimum of one node with at least 1 '
+                         b'CPU and 2GB of RAM available for the Chronos '
+                         b'Service.\n')
+    assert stdout_ == pre_install_notes
 
 
 def _install_chronos(
@@ -888,11 +888,11 @@ def _install_chronos(
         stdout=b'Installing Marathon app for package [chronos] '
                b'version [2.4.0]\n',
         stderr=b'',
-        preInstallNotes=b'We recommend a minimum of one node with at least 1 '
-                        b'CPU and 2GB of RAM available for the Chronos '
-                        b'Service.\n',
-        postInstallNotes=b'Chronos DCOS Service has been successfully '
-                         b'''installed!
+        pre_install_notes=b'We recommend a minimum of one node with at least '
+                          b'1 CPU and 2GB of RAM available for the Chronos '
+                          b'Service.\n',
+        post_install_notes=b'Chronos DCOS Service has been successfully '
+                           b'''installed!
 
 \tDocumentation: http://mesos.github.io/chronos
 \tIssues: https://github.com/mesos/chronos/issues\n''',
@@ -902,7 +902,7 @@ def _install_chronos(
     assert_command(
         cmd,
         returncode,
-        preInstallNotes + stdout + postInstallNotes,
+        pre_install_notes + stdout + post_install_notes,
         stderr,
         stdin=stdin)
 
@@ -914,11 +914,11 @@ def _chronos_package(
         stdout=b'Installing Marathon app for package [chronos] '
                b'version [2.4.0]\n',
         stderr=b'',
-        preInstallNotes=b'We recommend a minimum of one node with at least 1 '
-                        b'CPU and 2GB of RAM available for the Chronos '
-                        b'Service.\n',
-        postInstallNotes=b'Chronos DCOS Service has been successfully '
-                         b'''installed!
+        pre_install_notes=b'We recommend a minimum of one node with at least '
+                          b'1 CPU and 2GB of RAM available for the Chronos '
+                          b'Service.\n',
+        post_install_notes=b'Chronos DCOS Service has been successfully '
+                           b'''installed!
 
 \tDocumentation: http://mesos.github.io/chronos
 \tIssues: https://github.com/mesos/chronos/issues\n''',
@@ -929,8 +929,8 @@ def _chronos_package(
         returncode,
         stdout,
         stderr,
-        preInstallNotes,
-        postInstallNotes,
+        pre_install_notes,
+        post_install_notes,
         stdin)
     try:
         yield

--- a/cli/tests/integrations/test_package.py
+++ b/cli/tests/integrations/test_package.py
@@ -3,18 +3,18 @@ import contextlib
 import json
 import sys
 
+import pytest
 import six
+
 from dcos import subcommand
 
-import pytest
-
-from ..common import file_bytes
 from .common import (assert_command, assert_lines, base64_to_dict,
                      delete_zk_node, delete_zk_nodes, exec_command,
                      file_json,
                      get_services, package_install,
                      package_uninstall, service_shutdown,
                      wait_for_service, watch_all_deployments)
+from ..common import file_bytes
 
 
 def setup_module(module):

--- a/cli/tests/integrations/test_service.py
+++ b/cli/tests/integrations/test_service.py
@@ -4,16 +4,16 @@ import subprocess
 import sys
 import time
 
+import pytest
+
 import dcos.util as util
 from dcos.util import create_schema
 
-import pytest
-
-from ..fixtures.service import framework_fixture
 from .common import (assert_command, assert_lines, delete_zk_node,
                      delete_zk_nodes, exec_command, get_services,
                      package_install, remove_app, service_shutdown,
                      ssh_output, wait_for_service)
+from ..fixtures.service import framework_fixture
 
 
 def setup_module(module):

--- a/cli/tests/integrations/test_ssl.py
+++ b/cli/tests/integrations/test_ssl.py
@@ -1,8 +1,8 @@
 import os
 
-from dcos import constants
-
 import pytest
+
+from dcos import constants
 
 from .common import config_set, exec_command, update_config
 

--- a/cli/tests/integrations/test_task.py
+++ b/cli/tests/integrations/test_task.py
@@ -6,14 +6,14 @@ import subprocess
 import sys
 import time
 
+import pytest
+
 import dcos.util as util
 from dcos.util import create_schema
 
-import pytest
-
-from ..fixtures.task import task_fixture
 from .common import (add_app, app, assert_command, assert_lines, exec_command,
                      remove_app, watch_all_deployments)
+from ..fixtures.task import task_fixture
 
 SLEEP_COMPLETED = 'tests/data/marathon/apps/sleep-completed.json'
 SLEEP_COMPLETED1 = 'tests/data/marathon/apps/sleep-completed1.json'

--- a/cli/tests/unit/common.py
+++ b/cli/tests/unit/common.py
@@ -1,9 +1,8 @@
 import contextlib
 import sys
 
-import six
-
 import mock
+import six
 
 
 @contextlib.contextmanager

--- a/cli/tests/unit/test_http_auth.py
+++ b/cli/tests/unit/test_http_auth.py
@@ -1,12 +1,12 @@
 import copy
 
-from dcos import http
-from dcos.errors import DCOSException
-from requests.auth import HTTPBasicAuth
-
 import pytest
 from mock import Mock, patch
+from requests.auth import HTTPBasicAuth
 from six.moves.urllib.parse import urlparse
+
+from dcos import http
+from dcos.errors import DCOSException
 
 
 def test_get_auth_scheme_basic():

--- a/cli/tests/unit/test_marathon_pod.py
+++ b/cli/tests/unit/test_marathon_pod.py
@@ -1,9 +1,10 @@
+import pytest
+from mock import create_autospec, patch
+
 import dcoscli.marathon.main as main
 from dcos import marathon
 from dcos.errors import DCOSException, DCOSHTTPException
 
-import pytest
-from mock import create_autospec, patch
 from ..common import file_bytes
 from ..fixtures import marathon as marathon_fixtures
 

--- a/cli/tests/unit/test_node.py
+++ b/cli/tests/unit/test_node.py
@@ -1,8 +1,8 @@
-import dcoscli.node.main as main
-from dcos.errors import DCOSException
-
 import mock
 import pytest
+
+import dcoscli.node.main as main
+from dcos.errors import DCOSException
 
 
 @mock.patch('dcos.cosmospackage.Cosmos')

--- a/cli/tests/unit/test_tables.py
+++ b/cli/tests/unit/test_tables.py
@@ -1,10 +1,10 @@
 import datetime
 
-from dcos.mesos import Slave
-from dcoscli import tables
-
 import mock
 import pytz
+
+from dcos.mesos import Slave
+from dcoscli import tables
 
 from ..fixtures.marathon import (app_fixture, app_task_fixture,
                                  deployment_fixture_app_post_pods,

--- a/cli/tests/unit/test_task.py
+++ b/cli/tests/unit/test_task.py
@@ -1,10 +1,10 @@
+import pytest
+from mock import MagicMock, patch
+
 from dcos import mesos
 from dcos.errors import DCOSException
 from dcoscli.log import log_files
 from dcoscli.task.main import main
-
-import pytest
-from mock import MagicMock, patch
 
 from .common import assert_mock
 

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -1,24 +1,34 @@
 [tox]
 envlist = py34-syntax, py34-unit, py34-integration
 
+[flake8]
+application-import-names=dcos,dcoscli
+import-order-style=smarkets
+
 [testenv]
 deps =
   mock
   pytest
   pytest-cov
   pytz
+  teamcity-messages
   -e..
-passenv = DCOS_* CI_FLAGS CLI_TEST_SSH_KEY_PATH CLI_TEST_MASTER_PROXY
+
+passenv =
+  DCOS_*
+  CI_FLAGS
+  CLI_TEST_SSH_KEY_PATH
+  CLI_TEST_MASTER_PROXY
+  TEAMCITY_VERSION
 
 [testenv:py34-syntax]
 deps =
   flake8
-  isort
+  flake8-import-order
   ..
 
 commands =
   flake8 --verbose {env:CI_FLAGS:} dcoscli tests setup.py
-  isort --recursive --check-only --diff --verbose dcoscli tests setup.py
 
 [testenv:py34-integration]
 commands =

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -25,6 +25,7 @@ passenv =
 deps =
   flake8
   flake8-import-order
+  pep8-naming
   ..
 
 commands =

--- a/cli/tox.win.ini
+++ b/cli/tox.win.ini
@@ -4,23 +4,27 @@ envlist = py34-unit, py34-integration
 [testenv]
 setenv =
   DCOS_CONFIG = {env:DCOS_CONFIG}
+
+passenv =
+  TEAMCITY_MESSAGES
+
 deps =
   pytest
   pytest-cov
   mock
   pypiwin32
   pytz
+  teamcity-messages
   -e..
 
 [testenv:syntax]
 deps =
   flake8
-  isort
+  flake8-import-order
   ..
 
 commands =
   flake8 --verbose {env:CI_FLAGS:} dcoscli tests setup.py
-  isort --recursive --check-only --diff --verbose dcoscli tests setup.py
 
 [testenv:py34-integration]
 commands =

--- a/cli/tox.win.ini
+++ b/cli/tox.win.ini
@@ -21,6 +21,7 @@ deps =
 deps =
   flake8
   flake8-import-order
+  pep8-naming
   ..
 
 commands =

--- a/dcos/cosmospackage.py
+++ b/dcos/cosmospackage.py
@@ -3,12 +3,13 @@ import collections
 import functools
 
 import six
+from six.moves import urllib
+
 from dcos import emitting, http, util
 from dcos.errors import (DCOSAuthenticationException,
                          DCOSAuthorizationException, DCOSBadRequest,
                          DCOSException, DCOSHTTPException, DefaultError)
 
-from six.moves import urllib
 
 logger = util.get_logger(__name__)
 

--- a/dcos/emitting.py
+++ b/dcos/emitting.py
@@ -12,9 +12,10 @@ from distutils import spawn
 import pager
 import pygments
 import six
-from dcos import config, constants, errors, util
 from pygments.formatters import Terminal256Formatter
 from pygments.lexers import JsonLexer
+
+from dcos import config, constants, errors, util
 
 logger = util.get_logger(__name__)
 

--- a/dcos/http.py
+++ b/dcos/http.py
@@ -3,14 +3,14 @@ import sys
 import threading
 
 import requests
+from requests.auth import AuthBase, HTTPBasicAuth
+from six.moves import urllib
+from six.moves.urllib.parse import urlparse
+
 from dcos import config, util
 from dcos.errors import (DCOSAuthenticationException,
                          DCOSAuthorizationException, DCOSBadRequest,
                          DCOSException, DCOSHTTPException)
-from requests.auth import AuthBase, HTTPBasicAuth
-
-from six.moves import urllib
-from six.moves.urllib.parse import urlparse
 
 logger = util.get_logger(__name__)
 lock = threading.Lock()

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -2,10 +2,10 @@ import json
 import jsonschema
 import pkg_resources
 
+from six.moves import urllib
+
 from dcos import config, http, util
 from dcos.errors import DCOSException, DCOSHTTPException
-
-from six.moves import urllib
 
 logger = util.get_logger(__name__)
 

--- a/dcos/mesos.py
+++ b/dcos/mesos.py
@@ -2,10 +2,10 @@ import fnmatch
 import itertools
 import os
 
+from six.moves import urllib
+
 from dcos import config, http, util
 from dcos.errors import DCOSException, DCOSHTTPException
-
-from six.moves import urllib
 
 logger = util.get_logger(__name__)
 

--- a/dcos/subcommand.py
+++ b/dcos/subcommand.py
@@ -575,7 +575,7 @@ def _execute_command(command):
 
     logger.info('Calling: %r', command)
 
-    process = Subproc().Popen(
+    process = Subproc().popen(
         command,
         stdout=PIPE,
         stderr=PIPE)
@@ -677,7 +677,7 @@ class SubcommandProcess():
         :rtype: int, str | None
         """
 
-        subproc = Subproc().Popen(
+        subproc = Subproc().popen(
             [self._executable,  self._command] + self._args,
             stderr=PIPE)
 

--- a/dcos/subprocess.py
+++ b/dcos/subprocess.py
@@ -37,7 +37,7 @@ class Subproc():
             shell=shell,
             env=self._env)
 
-    def Popen(self, args, stdin=None, stdout=None, stderr=None, shell=False):
+    def popen(self, args, stdin=None, stdout=None, stderr=None, shell=False):
         """
         call subprocess.Popen with modified environment
         """

--- a/dcos/util.py
+++ b/dcos/util.py
@@ -14,10 +14,10 @@ import time
 
 import jsonschema
 import six
+from six.moves import urllib
+
 from dcos import constants
 from dcos.errors import DCOSException
-
-from six.moves import urllib
 
 
 def get_logger(name):

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 from codecs import open
 from os import path
+from setuptools import find_packages, setup
 
 import dcos
-from setuptools import find_packages, setup
 
 here = path.abspath(path.dirname(__file__))
 

--- a/tests/test_cmds.py
+++ b/tests/test_cmds.py
@@ -1,6 +1,6 @@
-from dcos import cmds
-
 import pytest
+
+from dcos import cmds
 
 
 @pytest.fixture

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
-from dcos import config
-
 import pytest
+
+from dcos import config
 
 
 @pytest.fixture

--- a/tests/test_jsonitem.py
+++ b/tests/test_jsonitem.py
@@ -1,7 +1,7 @@
+import pytest
+
 from dcos import jsonitem
 from dcos.errors import DCOSException
-
-import pytest
 
 
 @pytest.fixture(params=range(6))

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -1,13 +1,13 @@
 import re
 
 import jsonschema
-import requests
-from dcos import http, marathon
-from dcos.errors import DCOSException, DCOSHTTPException
-from requests.structures import CaseInsensitiveDict
-
 import mock
 import pytest
+import requests
+from requests.structures import CaseInsensitiveDict
+
+from dcos import http, marathon
+from dcos.errors import DCOSException, DCOSHTTPException
 
 
 def test_add_pod_puts_json_in_request_body():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,7 @@
+import pytest
+
 from dcos import util
 from dcos.errors import DCOSException
-
-import pytest
 
 
 def test_open_file():

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,30 @@
 [tox]
 envlist = py34-syntax, py34-unit
 
+[flake8]
+application-import-names=dcos
+import-order-style=smarkets
+
 [testenv]
 deps =
   mock
   pytest
   pytest-cov
-passenv = DCOS_* CI_FLAGS CLI_TEST_SSH_KEY_PATH
+  teamcity-messages
+
+passenv =
+  DCOS_*
+  CI_FLAGS
+  CLI_TEST_SSH_KEY_PATH
+  TEAMCITY_VERSION
 
 [testenv:py34-syntax]
 deps =
   flake8
-  isort
+  flake8-import-order
 
 commands =
   flake8 --verbose {env:CI_FLAGS:} dcos tests setup.py
-  isort --recursive --check-only --diff --verbose dcos tests setup.py
 
 [testenv:py34-unit]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ passenv =
 deps =
   flake8
   flake8-import-order
+  pep8-naming
 
 commands =
   flake8 --verbose {env:CI_FLAGS:} dcos tests setup.py

--- a/tox.win.ini
+++ b/tox.win.ini
@@ -18,6 +18,7 @@ deps =
 deps =
   flake8
   flake8-import-order
+  pep8-naming
 
 commands =
   flake8 --verbose {env:CI_FLAGS:} dcos tests setup.py

--- a/tox.win.ini
+++ b/tox.win.ini
@@ -4,19 +4,23 @@ envlist = py34-unit
 [testenv]
 setenv =
   DCOS_CONFIG = {env:DCOS_CONFIG}
+
+passenv =
+  TEAMCITY_VERSION
+
 deps =
   pytest
   pytest-cov
   pypiwin32
+  teamcity-messages
 
 [testenv:syntax]
 deps =
   flake8
-  isort
+  flake8-import-order
 
 commands =
   flake8 --verbose {env:CI_FLAGS:} dcos tests setup.py
-  isort --recursive --check-only --diff --verbose dcos tests setup.py
 
 [testenv:py34-unit]
 commands =


### PR DESCRIPTION
Rolls what was #781, #782 into one big PR since otherwise they all conflict slightly with oneanother when merging.

This adds the teamcity-messages packages which extends py.test and flake8 in
order to make it so messages from the tools will be picked up by the CI system
directly.

This also passes TEAMCITY_VERSION through the tox.ini environment variables. The
teamcity-messages automatically enables / starts itself when TEAMCITY_VERSION is
in the environment, which is only set on TeamCity build agents, making for
minimal CI changes being necessary, while leaving it compatible with other CI
system message formatting plugins.

This moves environment variables to one per line which makes them easier to work with.

Switch to using flake8-import-sort from isort
     - Does a better job sorting
     - Requires less configuration
     - Makes structured error messages CI can see / pop up rather than digging into logs

All the existing files are updated / adjusted to fit the new style rules.



Iterating on re-building this PR until the messages are all nicely structured.