### PR TITLE
Switch to using flake8-import-sort from isort

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,0 @@
-[settings]
-not_skip = __init__.py

--- a/dcos/cosmospackage.py
+++ b/dcos/cosmospackage.py
@@ -3,12 +3,13 @@ import collections
 import functools
 
 import six
+from six.moves import urllib
+
 from dcos import emitting, http, util
 from dcos.errors import (DCOSAuthenticationException,
                          DCOSAuthorizationException, DCOSBadRequest,
                          DCOSException, DCOSHTTPException, DefaultError)
 
-from six.moves import urllib
 
 logger = util.get_logger(__name__)
 

--- a/dcos/emitting.py
+++ b/dcos/emitting.py
@@ -12,9 +12,10 @@ from distutils import spawn
 import pager
 import pygments
 import six
-from dcos import config, constants, errors, util
 from pygments.formatters import Terminal256Formatter
 from pygments.lexers import JsonLexer
+
+from dcos import config, constants, errors, util
 
 logger = util.get_logger(__name__)
 

--- a/dcos/http.py
+++ b/dcos/http.py
@@ -3,14 +3,14 @@ import sys
 import threading
 
 import requests
+from requests.auth import AuthBase, HTTPBasicAuth
+from six.moves import urllib
+from six.moves.urllib.parse import urlparse
+
 from dcos import config, util
 from dcos.errors import (DCOSAuthenticationException,
                          DCOSAuthorizationException, DCOSBadRequest,
                          DCOSException, DCOSHTTPException)
-from requests.auth import AuthBase, HTTPBasicAuth
-
-from six.moves import urllib
-from six.moves.urllib.parse import urlparse
 
 logger = util.get_logger(__name__)
 lock = threading.Lock()

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -1,9 +1,9 @@
 import json
 
+from six.moves import urllib
+
 from dcos import config, http, util
 from dcos.errors import DCOSException, DCOSHTTPException
-
-from six.moves import urllib
 
 logger = util.get_logger(__name__)
 

--- a/dcos/mesos.py
+++ b/dcos/mesos.py
@@ -2,10 +2,10 @@ import fnmatch
 import itertools
 import os
 
+from six.moves import urllib
+
 from dcos import config, http, util
 from dcos.errors import DCOSException, DCOSHTTPException
-
-from six.moves import urllib
 
 logger = util.get_logger(__name__)
 

--- a/dcos/util.py
+++ b/dcos/util.py
@@ -14,10 +14,10 @@ import time
 
 import jsonschema
 import six
+from six.moves import urllib
+
 from dcos import constants
 from dcos.errors import DCOSException
-
-from six.moves import urllib
 
 
 def get_logger(name):

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 from codecs import open
 from os import path
+from setuptools import find_packages, setup
 
 import dcos
-from setuptools import find_packages, setup
 
 here = path.abspath(path.dirname(__file__))
 

--- a/tests/test_cmds.py
+++ b/tests/test_cmds.py
@@ -1,6 +1,6 @@
-from dcos import cmds
-
 import pytest
+
+from dcos import cmds
 
 
 @pytest.fixture

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
-from dcos import config
-
 import pytest
+
+from dcos import config
 
 
 @pytest.fixture

--- a/tests/test_jsonitem.py
+++ b/tests/test_jsonitem.py
@@ -1,7 +1,7 @@
+import pytest
+
 from dcos import jsonitem
 from dcos.errors import DCOSException
-
-import pytest
 
 
 @pytest.fixture(params=range(6))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,7 @@
+import pytest
+
 from dcos import util
 from dcos.errors import DCOSException
-
-import pytest
 
 
 def test_open_file():

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,10 @@
 [tox]
 envlist = py34-syntax, py34-unit
 
+[flake8]
+application-import-names=dcos
+import-order-style=smarkets
+
 [testenv]
 deps =
   pytest
@@ -10,11 +14,10 @@ passenv = DCOS_* CI_FLAGS CLI_TEST_SSH_KEY_PATH
 [testenv:py34-syntax]
 deps =
   flake8
-  isort
+  flake8-import-order
 
 commands =
   flake8 --verbose {env:CI_FLAGS:} dcos tests setup.py
-  isort --recursive --check-only --diff --verbose dcos tests setup.py
 
 [testenv:py34-unit]
 commands =


### PR DESCRIPTION
First commit does the swap, second commit fixes all the newly found problems so it's easy to see what the tooling change is vs. the import reordering.

 - Does a better job sorting
 - Requires less configuration
 - Makes structured error messages CI can see / pop up rather than digging into logs