### PR TITLE
Add pep8 naming

### DIFF
--- a/dcos/cosmospackage.py
+++ b/dcos/cosmospackage.py
@@ -15,6 +15,38 @@ logger = util.get_logger(__name__)
 emitter = emitting.FlatEmitter()
 
 
+def cosmos_error(fn):
+    """Decorator for errors returned from cosmos
+
+    :param fn: function to check for errors from cosmos
+    :type fn: function
+    :rtype: Response
+    :returns: Response
+    """
+
+    @functools.wraps(fn)
+    def check_for_cosmos_error(*args, **kwargs):
+        """Returns response from cosmos or raises exception
+
+        :param response: response from cosmos
+        :type response: Response
+        :returns: Response or raises Exception
+        :rtype: valid response
+        """
+
+        response = fn(*args, **kwargs)
+        content_type = response.headers.get('Content-Type')
+        if content_type is None:
+            raise DCOSHTTPException(response)
+        elif _get_header("error", "v1") in content_type:
+            logger.debug("Error: {}".format(response.json()))
+            error_msg = _format_error_message(response.json())
+            raise DCOSException(error_msg)
+        return response
+
+    return check_for_cosmos_error
+
+
 class Cosmos():
     """Implementation of Package Manager using Cosmos"""
 
@@ -262,37 +294,6 @@ class Cosmos():
         params = {"name": name}
         response = self.cosmos_post("repository/delete", params=params)
         return response.json()
-
-    def cosmos_error(fn):
-        """Decorator for errors returned from cosmos
-
-        :param fn: function to check for errors from cosmos
-        :type fn: function
-        :rtype: Response
-        :returns: Response
-        """
-
-        @functools.wraps(fn)
-        def check_for_cosmos_error(*args, **kwargs):
-            """Returns response from cosmos or raises exception
-
-            :param response: response from cosmos
-            :type response: Response
-            :returns: Response or raises Exception
-            :rtype: valid response
-            """
-
-            response = fn(*args, **kwargs)
-            content_type = response.headers.get('Content-Type')
-            if content_type is None:
-                raise DCOSHTTPException(response)
-            elif _get_header("error", "v1") in content_type:
-                logger.debug("Error: {}".format(response.json()))
-                error_msg = _format_error_message(response.json())
-                raise DCOSException(error_msg)
-            return response
-
-        return check_for_cosmos_error
 
     @cosmos_error
     def _post(self, request, params, headers=None):

--- a/dcos/subcommand.py
+++ b/dcos/subcommand.py
@@ -575,7 +575,7 @@ def _execute_command(command):
 
     logger.info('Calling: %r', command)
 
-    process = Subproc().Popen(
+    process = Subproc().popen(
         command,
         stdout=PIPE,
         stderr=PIPE)

--- a/dcos/subprocess.py
+++ b/dcos/subprocess.py
@@ -37,7 +37,7 @@ class Subproc():
             shell=shell,
             env=self._env)
 
-    def Popen(self, args, stdin=None, stdout=None, stderr=None, shell=False):
+    def popen(self, args, stdin=None, stdout=None, stderr=None, shell=False):
         """
         call subprocess.Popen with modified environment
         """

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ passenv = DCOS_* CI_FLAGS CLI_TEST_SSH_KEY_PATH
 [testenv:py34-syntax]
 deps =
   flake8
+  pep8-naming
   isort
 
 commands =


### PR DESCRIPTION
 - Subprocess().Popen() -> Subprocess().popen() per PEP-8 conventions (member function names should be all lower case)
 - Move cosmos_error out of class because it isn't a member function per PEP-8
 - Add pep8-naming plugin to flake8 so PEP-8 errors are caught during syntax checks