### PR TITLE
Make Marathon 409 response status error message less confusing

### DIFF
--- a/cli/tests/integrations/test_marathon.py
+++ b/cli/tests/integrations/test_marathon.py
@@ -699,10 +699,11 @@ def test_app_locked_error():
     with app('tests/data/marathon/apps/sleep_many_instances.json',
              '/sleep-many-instances',
              wait=False):
+        stderr = b'Changes blocked: deployment already in progress for app.\n'
         assert_command(
             ['dcos', 'marathon', 'app', 'stop', 'sleep-many-instances'],
             returncode=1,
-            stderr=b'App already exists.\n')
+            stderr=stderr)
 
 
 @pytest.mark.skipif(sys.platform == 'win32',

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -114,7 +114,9 @@ class RpcClient(object):
             path_name = (name for name in cls.RESOURCE_TYPES if name in path)
             resource_name = next(path_name, 'resource')
 
-            return '{} already exists.'.format(resource_name.capitalize())
+            template = ('Changes blocked: '
+                        'deployment already in progress for {}.')
+            return template.format(resource_name)
 
         if json_body is None:
             template = 'Error decoding response from [{}]: HTTP {}: {}'

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -399,15 +399,15 @@ def test_res_err_msg_with_409_status():
             request_url=request_url,
             json_body=None)
 
-        pattern = r'(.*) already exists\.'
+        pattern = r'Changes blocked: deployment already in progress for (.*)\.'
         _assert_matches_with_groups(pattern, actual, (expected_resource,))
 
-    test_case('http://marathon/v2/apps', 'App')
-    test_case('http://marathon/v2/groups/group-id', 'Group')
-    test_case('http://marathon/v2/pods/', 'Pod')
-    test_case('http://marathon/v2/thingies/foo', 'Resource')
-    test_case('http://dcos/service/marathon/v2/apps/bar', 'App')
-    test_case('http://pods-app.com/service/marathon/v2/groups/baz', 'Group')
+    test_case('http://marathon/v2/apps', 'app')
+    test_case('http://marathon/v2/groups/group-id', 'group')
+    test_case('http://marathon/v2/pods/', 'pod')
+    test_case('http://marathon/v2/thingies/foo', 'resource')
+    test_case('http://dcos/service/marathon/v2/apps/bar', 'app')
+    test_case('http://pods-app.com/service/marathon/v2/groups/baz', 'group')
 
 
 def test_response_error_message_with_other_status_no_json():


### PR DESCRIPTION
- State that changes cannot be made
- Refer to an existing deployment as the reason