### PR TITLE
Remove `<properties>` arguments from `marathon pod update`

### DIFF
--- a/cli/dcoscli/data/help/marathon.txt
+++ b/cli/dcoscli/data/help/marathon.txt
@@ -31,7 +31,7 @@ Usage:
     dcos marathon pod list [--json]
     dcos marathon pod remove [--force] <pod-id>
     dcos marathon pod show <pod-id>
-    dcos marathon pod update [--force] <pod-id> [<properties>...]
+    dcos marathon pod update [--force] <pod-id>
     dcos marathon task list [--json <app-id>]
     dcos marathon task stop [--wipe] <task-id>
     dcos marathon task show <task-id>
@@ -155,7 +155,7 @@ Positional Arguments:
     <properties>
         List of space-separated JSON object properties to update.  The list
         must be formatted as <key>=<value>. For example, `cpus=2.0 mem=308`.
-        If omitted, properties are read from stdin.
+        If omitted, properties are read from a JSON object provided on stdin.
     <task-id>
         The task ID.
     <scale-factor>

--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -181,7 +181,7 @@ def _cmds():
 
         cmds.Command(
             hierarchy=['marathon', 'pod', 'update'],
-            arg_keys=['<pod-id>', '<properties>', '--force'],
+            arg_keys=['<pod-id>', '--force'],
             function=subcommand.pod_update),
 
         cmds.Command(
@@ -237,7 +237,7 @@ class ResourceReader(object):
         """
         :param name: optional filename or http(s) url
         for the application or group resource
-        :type name: str
+        :type name: str | None
         :returns: resource
         :rtype: dict
         """
@@ -914,12 +914,10 @@ class MarathonSubcommand(object):
         emitter.publish(pod_json)
         return 0
 
-    def pod_update(self, pod_id, properties, force):
+    def pod_update(self, pod_id, force):
         """
         :param pod_id: the Marathon ID of the pod to update
         :type pod_id: str
-        :param properties: JSON items to update in pod definition
-        :type properties: [str]
         :param force: whether to override running deployments
         :type force: bool
         :returns: process return code
@@ -932,8 +930,7 @@ class MarathonSubcommand(object):
         # Ensure that the pod exists
         marathon_client.show_pod(pod_id)
 
-        resource = self._resource_reader.\
-            get_resource_from_properties(properties)
+        resource = self._resource_reader.get_resource(name=None)
         deployment_id = marathon_client.update_pod(
             pod_id, pod_json=resource, force=force)
 

--- a/cli/tests/data/help/marathon.txt
+++ b/cli/tests/data/help/marathon.txt
@@ -31,7 +31,7 @@ Usage:
     dcos marathon pod list [--json]
     dcos marathon pod remove [--force] <pod-id>
     dcos marathon pod show <pod-id>
-    dcos marathon pod update [--force] <pod-id> [<properties>...]
+    dcos marathon pod update [--force] <pod-id>
     dcos marathon task list [--json <app-id>]
     dcos marathon task stop [--wipe] <task-id>
     dcos marathon task show <task-id>
@@ -155,7 +155,7 @@ Positional Arguments:
     <properties>
         List of space-separated JSON object properties to update.  The list
         must be formatted as <key>=<value>. For example, `cpus=2.0 mem=308`.
-        If omitted, properties are read from stdin.
+        If omitted, properties are read from a JSON object provided on stdin.
     <task-id>
         The task ID.
     <scale-factor>


### PR DESCRIPTION
Pod descriptor JSONs have too many important nested fields, making
command-line properties awkward to specify. Removal improves the
user experience of the command.

Fixes #779.