### PR TITLE
Fix accidental skipping of pods integration tests in CI builds

### DIFF
--- a/cli/tests/integrations/test_marathon.py
+++ b/cli/tests/integrations/test_marathon.py
@@ -656,6 +656,7 @@ def test_stop_task():
         _stop_task(task_id)
 
 
+@pytest.mark.skip(reason="https://mesosphere.atlassian.net/browse/DCOS-10325")
 def test_stop_task_wipe():
     with _zero_instance_app():
         _start_app('zero-instance-app', 1)

--- a/cli/tests/integrations/test_marathon_pod.py
+++ b/cli/tests/integrations/test_marathon_pod.py
@@ -13,7 +13,7 @@ from ..fixtures.marathon import (DOUBLE_POD_FILE_PATH, DOUBLE_POD_ID,
 from .common import (assert_command, exec_command, file_json_ast,
                      watch_all_deployments)
 
-_PODS_ENABLED = 'PODS_ENABLED' in os.environ
+_PODS_ENABLED = 'DCOS_PODS_ENABLED' in os.environ
 
 _POD_BASE_CMD = ['dcos', 'marathon', 'pod']
 _POD_ADD_CMD = _POD_BASE_CMD + ['add']

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -8,7 +8,7 @@ deps =
   pytest-cov
   pytz
   -e..
-passenv = DCOS_* CI_FLAGS CLI_TEST_SSH_KEY_PATH CLI_TEST_MASTER_PROXY
+passenv = DCOS_* CI_FLAGS CLI_TEST_SSH_KEY_PATH CLI_TEST_MASTER_PROXY PODS_ENABLED
 
 [testenv:py34-syntax]
 deps =

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -8,7 +8,7 @@ deps =
   pytest-cov
   pytz
   -e..
-passenv = DCOS_* CI_FLAGS CLI_TEST_SSH_KEY_PATH CLI_TEST_MASTER_PROXY PODS_ENABLED
+passenv = DCOS_* CI_FLAGS CLI_TEST_SSH_KEY_PATH CLI_TEST_MASTER_PROXY
 
 [testenv:py34-syntax]
 deps =


### PR DESCRIPTION
Add PODS_ENABLED to Tox env var whitelist

You'll be happy/relieved to know that all tests still pass! I also updated #783 so that we remember to undo this change as well.