### PR TITLE
Update `marathon pod list` to use `GET /v2/pods/::status`

### DIFF
--- a/cli/dcoscli/tables.py
+++ b/cli/dcoscli/tables.py
@@ -443,8 +443,8 @@ def pod_table(pods):
 
     fields = OrderedDict([
         ('ID+CONTAINERS', id_and_containers),
-        ('INSTANCES', lambda pod: len(pod['instances'])),
-        ('VERSION', lambda pod: pod['spec']['version']),
+        ('INSTANCES', lambda pod: len(pod.get('instances', []))),
+        ('VERSION', lambda pod: pod['spec'].get('version', '-')),
         ('STATUS', lambda pod: pod['status']),
         ('STATUS SINCE', lambda pod: pod['statusSince'])
     ])

--- a/cli/dcoscli/tables.py
+++ b/cli/dcoscli/tables.py
@@ -425,13 +425,35 @@ def pod_table(pods):
     :rtype: PrettyTable
     """
 
+    def id_and_containers(pod):
+        """Extract the pod ID and container names from the given pod JSON.
+
+        :param pod: the pod JSON to read
+        :type pod: {}
+        :returns: the entry for the ID+CONTAINER column of the pod table
+        :rtype: str
+        """
+
+        pod_id = pod['id']
+        container_names = sorted(container['name'] for container
+                                 in pod['spec']['containers'])
+
+        container_lines = ('\n |-{}'.format(name) for name in container_names)
+        return pod_id + ''.join(container_lines)
+
     fields = OrderedDict([
-        ('ID', lambda pod: pod['id']),
-        ('CONTAINERS', lambda pod: len(pod['containers'])),
+        ('ID+CONTAINERS', id_and_containers),
+        ('INSTANCES', lambda pod: len(pod['instances'])),
+        ('VERSION', lambda pod: pod['spec']['version']),
+        ('STATUS', lambda pod: pod['status']),
+        ('STATUS SINCE', lambda pod: pod['statusSince'])
     ])
 
-    tb = table(fields, pods, sortby='ID')
-    tb.align['ID'] = 'l'
+    tb = table(fields, pods, sortby='ID+CONTAINERS')
+    tb.align['ID+CONTAINERS'] = 'l'
+    tb.align['VERSION'] = 'l'
+    tb.align['STATUS'] = 'l'
+    tb.align['STATUS SINCE'] = 'l'
 
     return tb
 

--- a/cli/tests/data/marathon/pods/double.json
+++ b/cli/tests/data/marathon/pods/double.json
@@ -3,6 +3,11 @@
   "containers": [
     {
       "name": "thing-1",
+      "exec": {
+        "command": {
+          "shell": "sleep 1000"
+        }
+      },
       "resources": {
         "cpus": 0.1,
         "mem": 16.0
@@ -20,5 +25,9 @@
     {
       "mode": "host"
     }
-  ]
+  ],
+  "scaling": {
+    "kind": "fixed",
+    "instances": 2
+  }
 }

--- a/cli/tests/data/marathon/pods/doubleplusgood.json
+++ b/cli/tests/data/marathon/pods/doubleplusgood.json
@@ -17,6 +17,11 @@
     },
     {
       "name": "the-cat",
+      "exec": {
+        "command": {
+          "shell": "sleep 1000"
+        }
+      },
       "resources": {
         "cpus": 0.2,
         "mem": 32.0

--- a/cli/tests/data/marathon/pods/good.json
+++ b/cli/tests/data/marathon/pods/good.json
@@ -3,6 +3,11 @@
   "containers": [
     {
       "name": "good-container",
+      "exec": {
+        "command": {
+          "shell": "sleep 1000"
+        }
+      },
       "resources": {
         "cpus": 0.1,
         "mem": 16.0
@@ -13,5 +18,9 @@
     {
       "mode": "host"
     }
-  ]
+  ],
+  "scaling": {
+    "kind": "fixed",
+    "instances": 3
+  }
 }

--- a/cli/tests/fixtures/marathon.py
+++ b/cli/tests/fixtures/marathon.py
@@ -294,3 +294,75 @@ def pod_list_fixture():
     }
 
     return [good_pod_status, double_pod_status, triple_pod_status]
+
+
+def pod_list_without_instances_fixture():
+    """Marathon pod without an "instances" field.
+
+    :rtype: {}
+    """
+
+    return {
+        "id": "/pod-without-instances",
+        "spec": {
+            "id": "/pod-without-instances",
+            "containers": [
+                {
+                    "name": "no-instances",
+                    "exec": {
+                        "command": {
+                            "shell": "sleep 1000"
+                        }
+                    },
+                    "resources": {
+                        "cpus": 0.1,
+                        "mem": 16.0
+                    }
+                }
+            ],
+            "networks": [
+                {
+                    "mode": "host"
+                }
+            ],
+            "version": "2016-10-05T16:18:03.399Z"
+        },
+        "status": "stable",
+        "statusSince": "2016-10-05T15:36:54.123Z"
+    }
+
+
+def pod_list_without_spec_version_fixture():
+    """Marathon pod without a "spec"."version" field.
+
+    :rtype: {}
+    """
+
+    return {
+        "id": "/pod-without-spec-version",
+        "instances": [{}],
+        "spec": {
+            "id": "/pod-without-spec-version",
+            "containers": [
+                {
+                    "name": "no-spec-version",
+                    "exec": {
+                        "command": {
+                            "shell": "sleep 1000"
+                        }
+                    },
+                    "resources": {
+                        "cpus": 0.1,
+                        "mem": 16.0
+                    }
+                }
+            ],
+            "networks": [
+                {
+                    "mode": "host"
+                }
+            ]
+        },
+        "status": "stable",
+        "statusSince": "2016-10-05T15:36:54.123Z"
+    }

--- a/cli/tests/fixtures/marathon.py
+++ b/cli/tests/fixtures/marathon.py
@@ -255,11 +255,42 @@ def group_fixture():
     }
 
 
-def pod_fixture():
-    """Marathon pod fixture.
+def pod_list_fixture():
+    """"Marathon pod list fixture.
 
     :rtype: [{}]
     """
 
-    paths = [GOOD_POD_FILE_PATH, DOUBLE_POD_FILE_PATH, TRIPLE_POD_FILE_PATH]
-    return [file_json_ast(path) for path in paths]
+    good_pod_spec = file_json_ast(GOOD_POD_FILE_PATH)
+    double_pod_spec = file_json_ast(DOUBLE_POD_FILE_PATH)
+    triple_pod_spec = file_json_ast(TRIPLE_POD_FILE_PATH)
+
+    good_pod_spec["version"] = "2016-10-05T16:18:03.399Z"
+    double_pod_spec["version"] = "2016-10-04T27:18:28.183Z"
+    triple_pod_spec["version"] = "2016-09-01T31:41:59.265Z"
+
+    good_pod_status = {
+        "id": good_pod_spec["id"],
+        "instances": [{}, {}, {}],
+        "spec": good_pod_spec,
+        "status": "stable",
+        "statusSince": "2016-10-05T15:36:54.123Z"
+    }
+
+    double_pod_status = {
+        "id": double_pod_spec["id"],
+        "instances": [{}, {}],
+        "spec": double_pod_spec,
+        "status": "terminal",
+        "statusSince": "2016-10-04T03:13:37.101Z"
+    }
+
+    triple_pod_status = {
+        "id": triple_pod_spec["id"],
+        "instances": [{}],
+        "spec": triple_pod_spec,
+        "status": "degraded",
+        "statusSince": "2016-09-30T22:28:09.201Z"
+    }
+
+    return [good_pod_status, double_pod_status, triple_pod_status]

--- a/cli/tests/integrations/test_marathon_pod.py
+++ b/cli/tests/integrations/test_marathon_pod.py
@@ -10,8 +10,8 @@ from .common import (assert_command, exec_command, file_json_ast,
                      watch_all_deployments)
 from ..fixtures.marathon import (DOUBLE_POD_FILE_PATH, DOUBLE_POD_ID,
                                  GOOD_POD_FILE_PATH, GOOD_POD_ID,
-                                 TRIPLE_POD_FILE_PATH, TRIPLE_POD_ID,
-                                 UPDATED_GOOD_POD_FILE_PATH, pod_list_fixture)
+                                 pod_list_fixture, TRIPLE_POD_FILE_PATH,
+                                 TRIPLE_POD_ID, UPDATED_GOOD_POD_FILE_PATH)
 
 _PODS_ENABLED = 'DCOS_PODS_ENABLED' in os.environ
 

--- a/cli/tests/unit/data/pod.txt
+++ b/cli/tests/unit/data/pod.txt
@@ -1,4 +1,10 @@
-ID           CONTAINERS  
-/double-pod      2       
-/good-pod        1       
-/winston         3       
+ID+CONTAINERS      INSTANCES  VERSION                   STATUS    STATUS SINCE              
+/double-pod            2      2016-10-04T27:18:28.183Z  terminal  2016-10-04T03:13:37.101Z  
+ |-thing-1                                                                                  
+ |-thing-2                                                                                  
+/good-pod              3      2016-10-05T16:18:03.399Z  stable    2016-10-05T15:36:54.123Z  
+ |-good-container                                                                           
+/winston               1      2016-09-01T31:41:59.265Z  degraded  2016-09-30T22:28:09.201Z  
+ |-the-cat                                                                                  
+ |-thing-1                                                                                  
+ |-thing-2                                                                                  

--- a/cli/tests/unit/data/pod_without_instances.txt
+++ b/cli/tests/unit/data/pod_without_instances.txt
@@ -1,0 +1,3 @@
+ID+CONTAINERS           INSTANCES  VERSION                   STATUS  STATUS SINCE              
+/pod-without-instances      0      2016-10-05T16:18:03.399Z  stable  2016-10-05T15:36:54.123Z  
+ |-no-instances                                                                                

--- a/cli/tests/unit/data/pod_without_spec_version.txt
+++ b/cli/tests/unit/data/pod_without_spec_version.txt
@@ -1,0 +1,3 @@
+ID+CONTAINERS              INSTANCES  VERSION  STATUS  STATUS SINCE              
+/pod-without-spec-version      1      -        stable  2016-10-05T15:36:54.123Z  
+ |-no-spec-version                                                               

--- a/cli/tests/unit/test_marathon_pod.py
+++ b/cli/tests/unit/test_marathon_pod.py
@@ -6,7 +6,7 @@ from dcos import marathon
 from dcos.errors import DCOSException, DCOSHTTPException
 
 from ..common import file_bytes
-from ..fixtures import marathon as marathon_fixtures
+from ..fixtures.marathon import pod_list_fixture
 
 
 def test_pod_add_invoked_successfully():
@@ -52,7 +52,7 @@ def test_pod_list_with_json():
 @patch('dcoscli.marathon.main.emitter', autospec=True)
 def test_pod_list_table(emitter):
     subcmd, marathon_client = _failing_reader_fixture()
-    marathon_client.list_pod.return_value = marathon_fixtures.pod_fixture()
+    marathon_client.list_pod.return_value = pod_list_fixture()
 
     returncode = subcmd.pod_list(json_=False)
 

--- a/cli/tests/unit/test_tables.py
+++ b/cli/tests/unit/test_tables.py
@@ -10,7 +10,7 @@ from ..fixtures.marathon import (app_fixture, app_task_fixture,
                                  deployment_fixture_app_post_pods,
                                  deployment_fixture_app_pre_pods,
                                  deployment_fixture_pod,
-                                 group_fixture, pod_fixture)
+                                 group_fixture, pod_list_fixture)
 from ..fixtures.node import slave_fixture
 from ..fixtures.package import package_fixture, search_result_fixture
 from ..fixtures.service import framework_fixture
@@ -72,7 +72,9 @@ def test_group_table():
 
 
 def test_pod_table():
-    _test_table(tables.pod_table, pod_fixture(), 'tests/unit/data/pod.txt')
+    _test_table(tables.pod_table,
+                pod_list_fixture(),
+                'tests/unit/data/pod.txt')
 
 
 def test_package_table():

--- a/cli/tests/unit/test_tables.py
+++ b/cli/tests/unit/test_tables.py
@@ -10,7 +10,9 @@ from ..fixtures.marathon import (app_fixture, app_task_fixture,
                                  deployment_fixture_app_post_pods,
                                  deployment_fixture_app_pre_pods,
                                  deployment_fixture_pod,
-                                 group_fixture, pod_list_fixture)
+                                 group_fixture, pod_list_fixture,
+                                 pod_list_without_instances_fixture,
+                                 pod_list_without_spec_version_fixture)
 from ..fixtures.node import slave_fixture
 from ..fixtures.package import package_fixture, search_result_fixture
 from ..fixtures.service import framework_fixture
@@ -75,6 +77,18 @@ def test_pod_table():
     _test_table(tables.pod_table,
                 pod_list_fixture(),
                 'tests/unit/data/pod.txt')
+
+
+def test_pod_table_without_instances():
+    _test_table(tables.pod_table,
+                [pod_list_without_instances_fixture()],
+                'tests/unit/data/pod_without_instances.txt')
+
+
+def test_pod_table_without_spec_version():
+    _test_table(tables.pod_table,
+                [pod_list_without_spec_version_fixture()],
+                'tests/unit/data/pod_without_spec_version.txt')
 
 
 def test_package_table():

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -769,7 +769,7 @@ class Client(object):
         :rtype: [dict]
         """
 
-        response = self._rpc.http_req(http.get, 'v2/pods')
+        response = self._rpc.http_req(http.get, 'v2/pods/::status')
         return self._parse_json(response)
 
     def update_pod(self, pod_id, pod_json, force=False):

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -73,7 +73,7 @@ def test_show_pod_raises_dcos_exception_for_json_parse_errors():
 def test_list_pod_builds_rpc_correctly():
     marathon_client, rpc_client = _create_fixtures()
     marathon_client.list_pod()
-    rpc_client.http_req.assert_called_with(http.get, 'v2/pods')
+    rpc_client.http_req.assert_called_with(http.get, 'v2/pods/::status')
 
 
 def test_list_pod_returns_success_response_json():


### PR DESCRIPTION
New information in table view:
- container names
- instance count
- creation timestamp (version)
- status
- last status change timestamp (status since)

See `cli/tests/unit/data/pod.txt` in this PR for example table output.