### PR TITLE
make `dcos config show` consistent with other `dcos config` commands

### DIFF
--- a/cli/dcoscli/config/main.py
+++ b/cli/dcoscli/config/main.py
@@ -131,7 +131,7 @@ def _show(name):
         for key, value in sorted(toml_config.property_items()):
             if key == "core.dcos_acs_token":
                 value = "*"*8
-            emitter.publish('{}={}'.format(key, value))
+            emitter.publish('{} {}'.format(key, value))
 
     return 0
 

--- a/cli/tests/integrations/test_config.py
+++ b/cli/tests/integrations/test_config.py
@@ -40,10 +40,10 @@ def test_version():
 
 
 def _test_list_property(env):
-    stdout = b"""core.dcos_url=http://dcos.snakeoil.mesosphere.com
-core.reporting=False
-core.ssl_verify=false
-core.timeout=5
+    stdout = b"""core.dcos_url http://dcos.snakeoil.mesosphere.com
+core.reporting False
+core.ssl_verify false
+core.timeout 5
 """
     assert_command(['dcos', 'config', 'show'],
                    stdout=stdout,


### PR DESCRIPTION
#683 

`dcos config show` now has spaces between `key` and `value` instead of `=`