### PR TITLE
Marathon endpoint for `pod kill` now ends with plural `::instances`

### DIFF
--- a/cli/tests/integrations/common.py
+++ b/cli/tests/integrations/common.py
@@ -701,3 +701,41 @@ def base64_to_dict(byte_string):
     :rtype dict
     """
     return json.loads(base64.b64decode(byte_string).decode('utf-8'))
+
+
+UNIVERSE_REPO = "https://universe.mesosphere.com/repo"
+UNIVERSE_TEST_REPO = "http://universe.marathon.mesos:8085/repo"
+
+
+def setup_universe_server():
+    # add universe-server with static packages
+    assert_command(
+        ['dcos', 'marathon', 'app', 'add', 'tests/data/universe-v3-stub.json'])
+    watch_all_deployments()
+
+    assert_command(
+        ['dcos', 'package', 'repo', 'remove', 'Universe'])
+
+    assert_command(
+        ['dcos', 'package', 'repo', 'add', 'test-universe', UNIVERSE_TEST_REPO]
+    )
+
+    # Give the test universe some time to become available
+    describe_command = ['dcos', 'package', 'describe', 'helloworld']
+    for _ in range(10):
+        returncode, _, _ = exec_command(describe_command)
+        if returncode == 0:
+            break
+        time.sleep(1)
+    else:
+        teardown_universe_server()
+        assert False, 'test-universe failed to come up'
+
+
+def teardown_universe_server():
+    assert_command(
+        ['dcos', 'package', 'repo', 'remove', 'test-universe'])
+    assert_command(
+        ['dcos', 'package', 'repo', 'add', 'Universe', UNIVERSE_REPO])
+    assert_command(
+        ['dcos', 'marathon', 'app', 'remove', '/universe', '--force'])

--- a/cli/tests/integrations/common.py
+++ b/cli/tests/integrations/common.py
@@ -722,12 +722,15 @@ def setup_universe_server():
 
     # Give the test universe some time to become available
     describe_command = ['dcos', 'package', 'describe', 'helloworld']
-    for _ in range(10):
+    for _ in range(30):
         returncode, _, _ = exec_command(describe_command)
         if returncode == 0:
             break
         time.sleep(1)
     else:
+        # Explicitly clean up in this case; pytest will not automatically
+        # perform teardowns if setup fails. See the remarks at the end of
+        # http://doc.pytest.org/en/latest/xunit_setup.html for more info.
         teardown_universe_server()
         assert False, 'test-universe failed to come up'
 

--- a/cli/tests/integrations/test_service.py
+++ b/cli/tests/integrations/test_service.py
@@ -12,35 +12,18 @@ from dcos.util import create_schema
 from .common import (assert_command, assert_lines, delete_zk_node,
                      delete_zk_nodes, exec_command, get_services,
                      package_install, remove_app, service_shutdown,
-                     ssh_output, wait_for_service, watch_all_deployments)
+                     setup_universe_server, ssh_output,
+                     teardown_universe_server, wait_for_service)
 from ..fixtures.service import framework_fixture
-
-UNIVERSE_REPO = "https://universe.mesosphere.com/repo"
-UNIVERSE_TEST_REPO = "http://universe.marathon.mesos:8085/repo"
 
 
 def setup_module(module):
-    # add universe-server with static packages
-    assert_command(
-        ['dcos', 'marathon', 'app', 'add', 'tests/data/universe-v3-stub.json'])
-    watch_all_deployments()
-
-    exec_command(['dcos', 'package', 'repo', 'remove', 'Universe'])
-
-    assert_command(
-        ['dcos', 'package', 'repo', 'add', 'test-universe', UNIVERSE_TEST_REPO]
-    )
+    setup_universe_server()
 
 
 def teardown_module(module):
     delete_zk_nodes()
-
-    assert_command(['dcos', 'package', 'repo', 'remove', 'test-universe'])
-
-    assert_command(
-        ['dcos', 'package', 'repo', 'add', 'Universe', UNIVERSE_REPO])
-    assert_command(
-        ['dcos', 'marathon', 'app', 'remove', '/universe', '--force'])
+    teardown_universe_server()
 
 
 def test_help():

--- a/cli/tests/integrations/test_task.py
+++ b/cli/tests/integrations/test_task.py
@@ -159,7 +159,7 @@ def test_log_follow():
         _mark_non_blocking(proc.stdout)
 
         time.sleep(10)
-        assert len(proc.stdout.read().decode('utf-8').split('\n')) >= 1
+        assert len(_read_lines_once_available(proc.stdout)) >= 1
 
         proc.kill()
 
@@ -192,9 +192,9 @@ def test_log_two_tasks_follow():
         _mark_non_blocking(proc.stdout)
 
         time.sleep(5)
-        first_lines = proc.stdout.read().decode('utf-8').split('\n')
+        first_lines = _read_lines_once_available(proc.stdout)
         time.sleep(3)
-        second_lines = proc.stdout.read().decode('utf-8').split('\n')
+        second_lines = _read_lines_once_available(proc.stdout)
 
         assert len(first_lines) >= 1
         # assert there are more lines after sleeping
@@ -328,3 +328,15 @@ def _get_completed_task_id(app_id='test-app-completed'):
     assert len(tasks) == 1
     task_id = tasks[0]['id']
     return task_id
+
+
+def _read_lines_once_available(file_obj):
+    for _ in range(10):
+        bytes_read = file_obj.read()
+        if bytes_read is not None:
+            break
+        time.sleep(1)
+    else:
+        assert False, 'timed out trying to read bytes'
+
+    return bytes_read.decode('utf-8').split('\n')

--- a/cli/tests/integrations/test_task.py
+++ b/cli/tests/integrations/test_task.py
@@ -159,7 +159,7 @@ def test_log_follow():
         _mark_non_blocking(proc.stdout)
 
         time.sleep(10)
-        assert len(_read_lines_once_available(proc.stdout)) >= 1
+        assert len(_read_lines(proc.stdout)) >= 1
 
         proc.kill()
 
@@ -192,9 +192,9 @@ def test_log_two_tasks_follow():
         _mark_non_blocking(proc.stdout)
 
         time.sleep(5)
-        first_lines = _read_lines_once_available(proc.stdout)
+        first_lines = _read_lines(proc.stdout)
         time.sleep(3)
-        second_lines = _read_lines_once_available(proc.stdout)
+        second_lines = _read_lines(proc.stdout)
 
         assert len(first_lines) >= 1
         # assert there are more lines after sleeping
@@ -330,9 +330,18 @@ def _get_completed_task_id(app_id='test-app-completed'):
     return task_id
 
 
-def _read_lines_once_available(file_obj):
-    for _ in range(10):
-        bytes_read = file_obj.read()
+def _read_lines(raw_io):
+    """Polls calls to `read()` on the given byte stream until some bytes are
+    returned, or the maximum number of attempts is reached.
+
+    :param raw_io: the byte stream to read from
+    :type raw_io: io.RawIOBase
+    :returns: the bytes read, decoded as UTF-8 and split into a list of lines
+    :rtype: [str]
+    """
+
+    for _ in range(30):
+        bytes_read = raw_io.read()
         if bytes_read is not None:
             break
         time.sleep(1)

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -809,7 +809,7 @@ class Client(object):
         :rtype: [{}]
         """
 
-        path = self._marathon_id_path_format('v2/pods/{}::instance', pod_id)
+        path = self._marathon_id_path_format('v2/pods/{}::instances', pod_id)
         response = self._rpc.http_req(http.delete, path, json=instance_ids)
         return self._parse_json(response)
 

--- a/tests/test_marathon.py
+++ b/tests/test_marathon.py
@@ -157,7 +157,7 @@ def test_update_pod_raises_dcos_exception_if_deployment_id_missing():
 def test_kill_pod_instances_executes_successfully():
     pod_id = 'foo'
     instance_ids = ['instance1', 'instance2']
-    path = 'v2/pods/foo::instance'
+    path = 'v2/pods/foo::instances'
     response_json = {'some': ['instance', 'status']}
 
     mock_response = mock.create_autospec(requests.Response)
@@ -173,7 +173,7 @@ def test_kill_pod_instances_executes_successfully():
     with mock.patch(path_format_method_name, new=path_format):
         actual_json = marathon_client.kill_pod_instances(pod_id, instance_ids)
 
-    path_format.assert_called_once()
+    path_format.assert_called_with('v2/pods/{}::instances', pod_id)
     rpc_client.http_req.assert_called_with(
         http.delete, path, json=instance_ids)
     assert actual_json == response_json


### PR DESCRIPTION
Pod tests for PR #806 won't pass until this is merged.