### PR TITLE
tox: pin flake8-import-order due to import bug

### DIFF
--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -24,7 +24,7 @@ passenv =
 [testenv:py34-syntax]
 deps =
   flake8
-  flake8-import-order
+  flake8-import-order==0.9.2
   pep8-naming
   ..
 

--- a/cli/tox.win.ini
+++ b/cli/tox.win.ini
@@ -20,7 +20,7 @@ deps =
 [testenv:syntax]
 deps =
   flake8
-  flake8-import-order
+  flake8-import-order==0.9.2
   pep8-naming
   ..
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ passenv =
 [testenv:py34-syntax]
 deps =
   flake8
-  flake8-import-order
+  flake8-import-order==0.9.2
   pep8-naming
 
 commands =

--- a/tox.win.ini
+++ b/tox.win.ini
@@ -17,7 +17,7 @@ deps =
 [testenv:syntax]
 deps =
   flake8
-  flake8-import-order
+  flake8-import-order==0.9.2
   pep8-naming
 
 commands =


### PR DESCRIPTION
bug introduced is `0.10` from here: https://github.com/PyCQA/flake8-import-order/commit/863f4597ab4e0879ee6058fab3f5e5b1df1f3463