### PR TITLE
Encode to utf-8 if not a terminal

### DIFF
--- a/dcos/emitting.py
+++ b/dcos/emitting.py
@@ -154,7 +154,7 @@ def _page(output, pager_command=None):
     output = six.text_type(output)
 
     if not sys.stdout.isatty() or util.is_windows_platform():
-        print(output)
+        print(output.encode('utf-8'))
         return
 
     num_lines = output.count('\n')


### PR DESCRIPTION
Printing anything redirected or piped that is unicode will cause an exception if it is not encoded to UTF-8.