### PR TITLE
switch to `dcos-log` logging backend

### DIFF
--- a/cli/dcoscli/data/help/node.txt
+++ b/cli/dcoscli/data/help/node.txt
@@ -6,6 +6,8 @@ Usage:
     dcos node --info
     dcos node [--json]
     dcos node log [--follow --lines=N --leader --master --mesos-id=<mesos-id> --slave=<slave-id>]
+                  [--component=<component-name> --filter=<filter>...]
+    dcos node list-components [--leader --mesos-id=<mesos-id> --json]
     dcos node ssh [--option SSHOPT=VAL ...]
                   [--config-file=<path>]
                   [--user=<user>]
@@ -72,6 +74,13 @@ Options:
         If not set, default to present working directory.
     --version
         Print version information.
+    --list-components
+        Print a list of available DC/OS components on specified node.
+    --component=<component-name>
+        Show DC/OS component logs.
+    --filter=<filter>
+        Filter logs by field and value. Filter must be a string separated by colon.
+        For example: --filter _PID:0 --filter _UID:1
 
 Positional Arguments:
     <command>

--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -8,7 +8,9 @@ from six.moves import urllib
 import dcoscli
 from dcos import (cmds, config, cosmospackage, emitting, errors, http, mesos,
                   subprocess, util)
-from dcos.errors import DCOSException, DefaultError
+from dcos.errors import (DCOSAuthenticationException,
+                         DCOSAuthorizationException,
+                         DCOSException, DefaultError)
 from dcoscli import log, tables
 from dcoscli.package.main import confirm, get_cosmos_url
 from dcoscli.subcommand import default_command_info, default_doc
@@ -19,6 +21,7 @@ logger = util.get_logger(__name__)
 emitter = emitting.FlatEmitter()
 
 DIAGNOSTICS_BASE_URL = '/system/health/v1/report/diagnostics/'
+
 
 # if a bundle size if more then 100Mb then warn user.
 BUNDLE_WARN_SIZE = 1000000
@@ -65,8 +68,14 @@ def _cmds():
 
         cmds.Command(
             hierarchy=['node', 'log'],
-            arg_keys=['--follow', '--lines', '--leader', '--mesos-id'],
+            arg_keys=['--follow', '--lines', '--leader', '--mesos-id',
+                      '--component', '--filter'],
             function=_log),
+
+        cmds.Command(
+            hierarchy=['node', 'list-components'],
+            arg_keys=['--leader', '--mesos-id', '--json'],
+            function=_list_components),
 
         cmds.Command(
             hierarchy=['node', 'ssh'],
@@ -462,7 +471,7 @@ def _list(json_):
             emitter.publish(errors.DefaultError('No slaves found.'))
 
 
-def _log(follow, lines, leader, slave):
+def _log(follow, lines, leader, slave, component, filters):
     """ Prints the contents of leader and slave logs.
 
     :param follow: same as unix tail's -f
@@ -473,22 +482,207 @@ def _log(follow, lines, leader, slave):
     :type leader: bool
     :param slave: the slave ID to print
     :type slave: str | None
+    :param component: DC/OS component name
+    :type component: string
+    :param filters: a list of filters ["key:value", ...]
+    :type filters: list
     :returns: process return code
     :rtype: int
     """
 
     if not (leader or slave):
-        raise DCOSException('You must choose one of --leader or --mesos-id.')
+        raise DCOSException(
+            'You must choose one of --leader or --mesos-id.')
 
     if lines is None:
         lines = 10
+
     lines = util.parse_int(lines)
 
+    try:
+        _dcos_log(follow, lines, leader, slave, component, filters)
+        return 0
+    except (DCOSAuthenticationException,
+            DCOSAuthorizationException):
+            raise
+    except DCOSException as e:
+        emitter.publish(DefaultError(e))
+        emitter.publish(DefaultError('Falling back to files API...'))
+
+    if component or filters:
+        raise DCOSException('--component or --filter is not '
+                            'supported by files API')
+
+    # fail back to mesos files API.
     mesos_files = _mesos_files(leader, slave)
-
     log.log_files(mesos_files, follow, lines)
-
     return 0
+
+
+def _get_slave_ip(slave):
+    """ Get an agent IP address based on mesos id.
+        If slave parameter is empty, the function will return
+
+    :param slave: mesos node id
+    :type slave: str
+    :return: node ip address
+    :rtype: str
+    """
+    if not slave:
+        return
+
+    summary = mesos.DCOSClient().get_state_summary()
+    if 'slaves' not in summary:
+        raise DCOSException(
+            'Invalid summary report. '
+            'Missing field `slaves`. {}'.format(summary))
+
+    for s in summary['slaves']:
+        if 'hostname' not in s or 'id' not in s:
+            raise DCOSException(
+                'Invalid summary report. Missing field `id` '
+                'or `hostname`. {}'.format(summary))
+
+        if s['id'] == slave:
+            return s['hostname']
+
+    raise DCOSException('Agent `{}` not found'.format(slave))
+
+
+def _list_components(leader, slave, use_json):
+    """ List components for a leader or slave_ip node
+
+    :param leader: use leader ip flag
+    :type leader: bool
+    :param slave_ip: agent ip address
+    :type slave_ip: str
+    :param use_json: print components in json format
+    :type use_json: bool
+    """
+    if not (leader or slave):
+        raise DCOSException('--leader or --mesos-id must be provided')
+
+    if leader and slave:
+        raise DCOSException(
+            'Unable to use leader and mesos id at the same time')
+
+    slave_ip = _get_slave_ip(slave)
+    if slave_ip:
+        print_components(slave_ip, use_json)
+        return
+
+    leaders = mesos.MesosDNSClient().hosts('leader.mesos')
+    if len(leaders) != 1:
+        raise DCOSException('Expecting one leader. Got {}'.format(leaders))
+
+    if 'ip' not in leaders[0]:
+        raise DCOSException(
+            'Invalid leader response, missing field `ip`. '
+            'Got {}'.format(leaders[0]))
+
+    print_components(leaders[0]['ip'], use_json)
+
+
+def print_components(ip, use_json):
+    """ Print components for a given node ip.
+        The data is taked from 3dt endpoint:
+        /system/health/v1/nodes/<ip>/units
+
+    :param ip: DC/OS node ip address
+    :type ip: str
+    :param use_json: print components in json format
+    :type use_json: bool
+    """
+    dcos_url = config.get_config_val('core.dcos_url').rstrip("/")
+    if not dcos_url:
+        raise config.missing_config_exception(['core.dcos_url'])
+
+    url = dcos_url + '/system/health/v1/nodes/{}/units'.format(ip)
+    response = http.get(url).json()
+    if 'units' not in response:
+        raise DCOSException(
+            'Invalid response. Missing field `units`. {}'.format(response))
+
+    if use_json:
+        emitter.publish(response['units'])
+    else:
+        for component in response['units']:
+            emitter.publish(component['id'])
+
+
+def _get_unit_type(unit_name):
+    """ Get the full unit name including the type postfix
+        or default to service.
+
+    :param unit_name: unit name with or without type
+    :type unit_name: str
+    :return: unit name with type
+    :rtype: str
+    """
+    if not unit_name:
+        raise DCOSException('Empty systemd unit parameter')
+
+    # https://www.freedesktop.org/software/systemd/man/systemd.unit.html
+    unit_types = ['service', 'socket', 'device', 'mount', 'automount',
+                  'swap', 'target', 'path', 'timer', 'slice', 'scope']
+
+    for unit_type in unit_types:
+        if unit_name.endswith('.{}'.format(unit_type)):
+            return unit_name
+
+    return '{}.service'.format(unit_name)
+
+
+def _dcos_log(follow, lines, leader, slave, component, filters):
+    """ Print logs from dcos-log backend.
+
+    :param follow: same as unix tail's -f
+    :type follow: bool
+    :param lines: number of lines to print
+    :type lines: int
+    :param leader: whether to print the leading master's log
+    :type leader: bool
+    :param slave: the slave ID to print
+    :type slave: str | None
+    :param component: DC/OS component name
+    :type component: string
+    :param filters: a list of filters ["key:value", ...]
+    :type filters: list
+    """
+    if not log.dcos_log_enabled():
+        raise DCOSException('dcos-log is not supported')
+
+    filter_query = ''
+    if component:
+        filters.append('_SYSTEMD_UNIT:{}'.format(_get_unit_type(component)))
+
+    for f in filters:
+        key_value = f.split(':')
+        if len(key_value) != 2:
+            raise SystemExit('Invalid filter parameter {}. '
+                             'Must be --filter=key:value'.format(f))
+        filter_query += '&filter={}'.format(f)
+
+    endpoint = '/system/v1'
+    if leader:
+        endpoint += '/logs/v1/'
+    if slave:
+        endpoint += '/agent/{}/logs/v1/'.format(slave)
+
+    endpoint_type = 'range'
+    if follow:
+        endpoint_type = 'stream'
+
+    dcos_url = config.get_config_val('core.dcos_url').rstrip("/")
+    if not dcos_url:
+        raise config.missing_config_exception(['core.dcos_url'])
+
+    url = (dcos_url + endpoint + endpoint_type +
+           '/?skip_prev={}'.format(lines) + filter_query)
+
+    if follow:
+        return log.follow_logs(url)
+    return log.print_logs_range(url)
 
 
 def _mesos_files(leader, slave_id):

--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -490,7 +490,7 @@ def _log(follow, lines, leader, slave, component, filters):
     :rtype: int
     """
 
-    if not (leader or slave):
+    if not (leader or slave) or (leader and slave):
         raise DCOSException(
             'You must choose one of --leader or --mesos-id.')
 

--- a/cli/dcoscli/service/main.py
+++ b/cli/dcoscli/service/main.py
@@ -3,10 +3,15 @@ import six
 
 import dcoscli
 from dcos import cmds, emitting, marathon, mesos, subprocess, util
-from dcos.errors import DCOSException, DefaultError
+from dcos.errors import (DCOSAuthenticationException,
+                         DCOSAuthorizationException,
+                         DCOSException,
+                         DefaultError)
 from dcoscli import log, tables
 from dcoscli.subcommand import default_command_info, default_doc
 from dcoscli.util import decorate_docopt_usage
+
+from ..task import main as task_main
 
 logger = util.get_logger(__name__)
 emitter = emitting.FlatEmitter()
@@ -168,6 +173,21 @@ def _log_service(follow, lines, service, file_):
 
     if file_ is None:
         file_ = 'stdout'
+
+    task = _get_service_task(service)
+    try:
+        if 'id' not in task:
+            raise DCOSException('Missing `id` in task. {}'.format(task))
+
+        task_id = task['id']
+        task_main._log(follow, False, lines, task_id, file_)
+        return 0
+    except (DCOSAuthenticationException,
+            DCOSAuthorizationException):
+        raise
+    except DCOSException as e:
+        emitter.publish(DefaultError(e))
+        emitter.publish(DefaultError('Falling back to files API...'))
 
     task = _get_service_task(service)
     return _log_task(task['id'], follow, lines, file_)

--- a/cli/dcoscli/task/main.py
+++ b/cli/dcoscli/task/main.py
@@ -343,6 +343,8 @@ def _dcos_log(follow, tasks, lines, file_, completed):
 
     for task in tasks:
         executor_info = task.executor()
+        if not executor_info:
+            continue
         if (tasks_field not in executor_info and
                 not isinstance(executor_info[tasks_field], list)):
             logger.debug('Executor info: {}'.format(executor_info))

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -70,7 +70,8 @@ setup(
         'pkginfo==1.2.1',
         'toml>=0.9, <1.0',
         'virtualenv>=13.0, <16.0',
-        'cryptography==1.6'
+        'cryptography==1.6',
+        'sseclient==0.0.14'
     ],
 
     # If there are data files included in your packages that need to be

--- a/cli/tests/data/help/node.txt
+++ b/cli/tests/data/help/node.txt
@@ -6,6 +6,8 @@ Usage:
     dcos node --info
     dcos node [--json]
     dcos node log [--follow --lines=N --leader --master --mesos-id=<mesos-id> --slave=<slave-id>]
+                  [--component=<component-name> --filter=<filter>...]
+    dcos node list-components [--leader --mesos-id=<mesos-id> --json]
     dcos node ssh [--option SSHOPT=VAL ...]
                   [--config-file=<path>]
                   [--user=<user>]
@@ -72,6 +74,13 @@ Options:
         If not set, default to present working directory.
     --version
         Print version information.
+    --list-components
+        Print a list of available DC/OS components on specified node.
+    --component=<component-name>
+        Show DC/OS component logs.
+    --filter=<filter>
+        Filter logs by field and value. Filter must be a string separated by colon.
+        For example: --filter _PID:0 --filter _UID:1
 
 Positional Arguments:
     <command>

--- a/cli/tests/integrations/common.py
+++ b/cli/tests/integrations/common.py
@@ -471,7 +471,7 @@ def assert_lines(cmd, num_lines, great_then=False):
     :type cmd: [str]
     :param num_lines: expected number of lines for stdout
     :type num_lines: int
-    :param great_then: if True we assume there could be at least num_lines or more
+    :param great_then: if True assume there may be at least num_lines or more
     :type great_then: bool
     :rtype: None
     """
@@ -480,7 +480,7 @@ def assert_lines(cmd, num_lines, great_then=False):
 
     assert returncode == 0
     assert stderr == b''
-    lines =  len(stdout.decode('utf-8').split('\n')) - 1
+    lines = len(stdout.decode('utf-8').split('\n')) - 1
     if great_then:
         assert lines >= num_lines
         return

--- a/cli/tests/integrations/common.py
+++ b/cli/tests/integrations/common.py
@@ -464,13 +464,15 @@ def delete_zk_node(znode):
     http.delete(znode_url)
 
 
-def assert_lines(cmd, num_lines):
+def assert_lines(cmd, num_lines, great_then=False):
     """ Assert stdout contains the expected number of lines
 
     :param cmd: program and arguments
     :type cmd: [str]
     :param num_lines: expected number of lines for stdout
     :type num_lines: int
+    :param great_then: if True we assume there could be at least num_lines or more
+    :type great_then: bool
     :rtype: None
     """
 
@@ -478,7 +480,11 @@ def assert_lines(cmd, num_lines):
 
     assert returncode == 0
     assert stderr == b''
-    assert len(stdout.decode('utf-8').split('\n')) - 1 == num_lines
+    lines =  len(stdout.decode('utf-8').split('\n')) - 1
+    if great_then:
+        assert lines >= num_lines
+        return
+    assert lines == num_lines
 
 
 def file_json_ast(path):

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -65,7 +65,9 @@ def test_node_log_missing_slave():
 
     assert returncode == 1
     assert stdout == b''
-    assert stderr == b'No slave found with ID "bogus".\n'
+    stderr_str = str(stderr)
+    assert 'HTTP 404' in stderr_str
+    assert 'No slave found with ID "bogus".' in stderr_str
 
 
 def test_node_log_leader_slave():

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -1,6 +1,5 @@
 import json
 import os
-import re
 import sys
 
 import pytest
@@ -68,21 +67,6 @@ def test_node_log_missing_slave():
     stderr_str = str(stderr)
     assert 'HTTP 404' in stderr_str
     assert 'No slave found with ID "bogus".' in stderr_str
-
-
-def test_node_log_leader_slave():
-    slave_id = _node()[0]['id']
-
-    returncode, stdout, stderr = exec_command(
-        ['dcos', 'node', 'log', '--leader', '--mesos-id={}'.format(slave_id)])
-
-    assert returncode == 0
-    assert stderr == b''
-
-    lines = stdout.decode('utf-8').split('\n')
-    assert len(lines) == 23
-    assert re.match('===>.*<===', lines[0])
-    assert re.match('===>.*<===', lines[11])
 
 
 def test_node_log_lines():

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -55,7 +55,10 @@ def test_node_log_leader():
 
 def test_node_log_slave():
     slave_id = _node()[0]['id']
-    assert_lines(['dcos', 'node', 'log', '--mesos-id={}'.format(slave_id)], 10, great_then=True)
+    assert_lines(
+        ['dcos', 'node', 'log', '--mesos-id={}'.format(slave_id)],
+        10,
+        great_then=True)
 
 
 def test_node_log_missing_slave():
@@ -72,7 +75,10 @@ def test_node_log_missing_slave():
 def test_node_log_lines():
     # since we are getting system logs, it's not guaranteed to get back
     # exactly 4 log entries. It must be >= 4
-    assert_lines(['dcos', 'node', 'log', '--leader', '--lines=4'], 4, great_then=True)
+    assert_lines(
+        ['dcos', 'node', 'log', '--leader', '--lines=4'],
+        4,
+        great_then=True)
 
 
 def test_node_log_invalid_lines():

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -50,12 +50,12 @@ def test_node_log_empty():
 
 
 def test_node_log_leader():
-    assert_lines(['dcos', 'node', 'log', '--leader'], 10)
+    assert_lines(['dcos', 'node', 'log', '--leader'], 10, great_then=True)
 
 
 def test_node_log_slave():
     slave_id = _node()[0]['id']
-    assert_lines(['dcos', 'node', 'log', '--mesos-id={}'.format(slave_id)], 10)
+    assert_lines(['dcos', 'node', 'log', '--mesos-id={}'.format(slave_id)], 10, great_then=True)
 
 
 def test_node_log_missing_slave():
@@ -70,7 +70,9 @@ def test_node_log_missing_slave():
 
 
 def test_node_log_lines():
-    assert_lines(['dcos', 'node', 'log', '--leader', '--lines=4'], 4)
+    # since we are getting system logs, it's not guaranteed to get back
+    # exactly 4 log entries. It must be >= 4
+    assert_lines(['dcos', 'node', 'log', '--leader', '--lines=4'], 4, great_then=True)
 
 
 def test_node_log_invalid_lines():

--- a/cli/tests/integrations/test_service.py
+++ b/cli/tests/integrations/test_service.py
@@ -113,7 +113,7 @@ def test_log():
 
         assert returncode == 0
         assert len(stdout.decode('utf-8').split('\n')) > 1
-        assert stderr == b''
+        assert stderr == b'No logs for this task\n'
 
         returncode, stdout, stderr = exec_command(
             ['dcos', 'service', 'log', 'cassandra.dcos', 'stderr'])

--- a/cli/tests/integrations/test_service.py
+++ b/cli/tests/integrations/test_service.py
@@ -170,6 +170,8 @@ def test_log_config():
         returncode=1)
 
 
+@pytest.mark.skipif(os.environ.get('DCOS_ENABLE_LOG_TEST') != 1,
+                    reason='disable python buffering')
 def test_log_follow():
     package_install('chronos', deploy=True)
 

--- a/cli/tests/integrations/test_service.py
+++ b/cli/tests/integrations/test_service.py
@@ -113,7 +113,7 @@ def test_log():
 
         assert returncode == 0
         assert len(stdout.decode('utf-8').split('\n')) > 1
-        assert stderr == b'No logs for this task\n'
+        assert stderr == b''
 
         returncode, stdout, stderr = exec_command(
             ['dcos', 'service', 'log', 'cassandra.dcos', 'stderr'])
@@ -182,13 +182,19 @@ def test_log_follow():
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
     else:
+        # disable stdout/stderr buffering:
+        # https://docs.python.org/3/using/cmdline.html#cmdoption-u
+        my_env = os.environ.copy()
+        my_env['PYTHONUNBUFFERED'] = 'x'
+
         # os.setsid is only available for Unix:
         # https://docs.python.org/2/library/os.html#os.setsid
         proc = subprocess.Popen(
             args,
             preexec_fn=os.setsid,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+            stderr=subprocess.PIPE,
+            env=my_env)
 
     time.sleep(10)
 

--- a/cli/tests/integrations/test_task.py
+++ b/cli/tests/integrations/test_task.py
@@ -133,7 +133,7 @@ def test_log_pod_task():
         # logs shouldn't be seen and this pod shouldn't have any logging
         # to stderr
         assert returncode == 0
-        assert stderr == b'No logs for this task\n'
+        assert 'No logs for this task' in str(stderr)
         assert stdout == b'\n'
 
 
@@ -188,9 +188,7 @@ def test_log_two_tasks():
     assert stderr == b''
 
     lines = stdout.decode('utf-8').split('\n')
-    assert len(lines) == 17
-    assert re.match('===>.*<===', lines[0])
-    assert re.match('===>.*<===', lines[8])
+    assert len(lines) == 11
 
 
 @pytest.mark.skipif(sys.platform == 'win32',
@@ -244,7 +242,7 @@ def test_ls_no_params():
     assert returncode == 0
     assert stderr == b''
 
-    ls_line = 'stderr  stderr.logrotate.conf  stdout  stdout.logrotate.conf'
+    ls_line = 'stderr  stdout'
     lines = stdout.decode('utf-8').split('\n')
     assert len(lines) == 7
     assert re.match('===>.*<===', lines[0])
@@ -256,13 +254,13 @@ def test_ls_no_params():
 
 
 def test_ls():
-    stdout = b'stderr  stderr.logrotate.conf  stdout  stdout.logrotate.conf\n'
+    stdout = b'stderr  stdout\n'
     assert_command(['dcos', 'task', 'ls', 'test-app1'],
                    stdout=stdout)
 
 
 def test_ls_multiple_tasks():
-    ls_line = 'stderr  stderr.logrotate.conf  stdout  stdout.logrotate.conf'
+    ls_line = 'stderr  stdout'
     returncode, stdout, stderr = exec_command(
         ['dcos', 'task', 'ls', 'test-app'])
     lines = stdout.decode('utf-8').split('\n')
@@ -277,7 +275,7 @@ def test_ls_multiple_tasks():
 
 
 def test_ls_long():
-    assert_lines(['dcos', 'task', 'ls', '--long', 'test-app1'], 4)
+    assert_lines(['dcos', 'task', 'ls', '--long', 'test-app1'], 2)
 
 
 def test_ls_path():
@@ -310,7 +308,7 @@ def test_ls_completed():
     returncode, stdout, stderr = exec_command(
         ['dcos', 'task', 'ls', '--completed', task_id_completed])
 
-    out = b'stderr  stderr.logrotate.conf  stdout  stdout.logrotate.conf\n'
+    out = b'stderr  stdout\n'
     assert returncode == 0
     assert stdout == out
     assert stderr == b''

--- a/cli/tests/unit/test_task.py
+++ b/cli/tests/unit/test_task.py
@@ -4,7 +4,7 @@ from mock import MagicMock, patch
 from dcos import mesos
 from dcos.errors import DCOSException
 from dcoscli.log import log_files
-from dcoscli.task.main import main
+from dcoscli.task.main import _dcos_log, main
 
 from .common import assert_mock
 
@@ -56,3 +56,89 @@ def test_log_file_unavailable():
 
 def _mock_exception(contents='exception'):
     return MagicMock(side_effect=DCOSException(contents))
+
+
+@patch('dcos.http.get')
+@patch('dcos.config.get_config_val')
+def test_dcos_log(mocked_get_config_val, mocked_http_get):
+    mocked_get_config_val.return_value = 'http://127.0.0.1'
+
+    m = MagicMock()
+    m.status_code = 200
+    mocked_http_get.return_value = m
+
+    executor_info = {
+        'tasks': [
+            {
+                'container': 'container1',
+                'state': 'TASK_RUNNING',
+                'statuses': [
+                    {
+                        'state': 'TASK_RUNNING',
+                        'container_status': {
+                            'container_id': {
+                                'value': 'child-123',
+                                'parent': {
+                                    'value': 'parent-456'
+                                }
+                            }
+                        }
+                    }
+                ],
+                'slave_id': 'slave-123',
+                'framework_id': 'framework-123',
+                'id': 'id-123'
+            }
+        ]
+    }
+
+    task = MagicMock
+    task.executor = lambda: executor_info
+    _dcos_log(False, [task], 10, 'stdout', False)
+    mocked_http_get.assert_called_with(
+        'http://127.0.0.1/system/v1/agent/slave-123/logs/v1/range/framework/'
+        'framework-123/executor/id-123/container/parent-456.child-123'
+        '?skip_prev=10&filter=STREAM:STDOUT',
+        headers={'Accept': 'text/plain'})
+
+
+@patch('dcoscli.log.follow_logs')
+@patch('dcos.http.get')
+@patch('dcos.config.get_config_val')
+def test_dcos_log_stream(mocked_get_config_val, mocked_http_get,
+                         mocked_follow_logs):
+    mocked_get_config_val.return_value = 'http://127.0.0.1'
+
+    m = MagicMock()
+    m.status_code = 200
+    mocked_http_get.return_value = m
+
+    executor_info = {
+        'tasks': [
+            {
+                'container': 'container1',
+                'state': 'TASK_RUNNING',
+                'statuses': [
+                    {
+                        'state': 'TASK_RUNNING',
+                        'container_status': {
+                            'container_id': {
+                                'value': 'child-123',
+                            }
+                        }
+                    }
+                ],
+                'slave_id': 'slave-123',
+                'framework_id': 'framework-123',
+                'id': 'id-123'
+            }
+        ]
+    }
+
+    task = MagicMock
+    task.executor = lambda: executor_info
+    _dcos_log(True, [task], 10, 'stderr', False)
+    mocked_follow_logs.assert_called_with(
+        'http://127.0.0.1/system/v1/agent/slave-123/logs/v1/'
+        'stream/framework/framework-123/executor/id-123/container/'
+        'child-123?skip_prev=10&filter=STREAM:STDERR')

--- a/dcos/sse.py
+++ b/dcos/sse.py
@@ -1,0 +1,19 @@
+from sseclient import SSEClient
+
+from . import http
+
+
+def get(url, **kwargs):
+    """ Make a get request to streaming endpoint which
+    implements SSE (Server sent events). The parameter session=http
+    will ensure we are using `dcos.http` module with all required auth
+    headers.
+
+    :param url: server sent events streaming URL
+    :type url: str
+    :param kwargs: arbitrary params for requests
+    :type kwargs: dict
+    :return: instance of sseclient.SSEClient
+    :rtype: sseclient.SSEClient
+    """
+    return SSEClient(url, session=http, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         'requests>=2.6, <3.0',
         'six>=1.9, <2.0',
         'toml>=0.9, <1.0',
+        'sseclient==0.0.14',
     ],
 
     extras_require={


### PR DESCRIPTION
with 1.9 release all system and container logs will go to sd journal on each
host. This PR adds dcos-log support to CLI.

before using newest API CLI will try to get the cosmos capability "LOGGING".
If the cluster supports dcos-log, it will use it. If the requests fails or
dcos-log missing LOGGING capability, we will default to mesos files API.

Relevant PRs:
dcos/dcos#971
dcos/dcos#832
dcos/cosmos#527