### PR TITLE
python27: stop publishing wheel

### DIFF
--- a/bin/install/install-dcos-cli.sh
+++ b/bin/install/install-dcos-cli.sh
@@ -152,7 +152,7 @@ if [ -z "$DCOS_CLI_VERSION" ]; then
     if $(compare_version 1.6.1); then
         "$VIRTUAL_ENV_PATH/bin/pip" install --quiet "dcoscli<0.4.0"
     else
-        "$VIRTUAL_ENV_PATH/bin/pip" install --quiet "dcoscli"
+        "$VIRTUAL_ENV_PATH/bin/pip" install --quiet "dcoscli==0.4.12"
     fi
 else
     "$VIRTUAL_ENV_PATH/bin/pip" install --quiet "dcoscli==$DCOS_CLI_VERSION"

--- a/bin/install/install-optout-dcos-cli.sh
+++ b/bin/install/install-optout-dcos-cli.sh
@@ -152,7 +152,7 @@ if [ -z "$DCOS_CLI_VERSION" ]; then
     if $(compare_version 1.6.1); then
         "$VIRTUAL_ENV_PATH/bin/pip" install --quiet "dcoscli<0.4.0"
     else
-        "$VIRTUAL_ENV_PATH/bin/pip" install --quiet "dcoscli"
+        "$VIRTUAL_ENV_PATH/bin/pip" install --quiet "dcoscli==0.4.12"
     fi
 else
     "$VIRTUAL_ENV_PATH/bin/pip" install --quiet "dcoscli==$DCOS_CLI_VERSION"

--- a/cli/setup.cfg
+++ b/cli/setup.cfg
@@ -1,5 +1,0 @@
-[bdist_wheel]
-# This flag says that the code is written to work on both Python 2 and Python
-# 3. If at all possible, it is good practice to do this. If you cannot, you
-# will need to generate wheels for each Python version that you support.
-universal=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[bdist_wheel]
-# This flag says that the code is written to work on both Python 2 and Python
-# 3. If at all possible, it is good practice to do this. If you cannot, you
-# will need to generate wheels for each Python version that you support.
-universal=1


### PR DESCRIPTION
We want to be able to use python3 features.

For users on DC/OS 1.8+: They should be using the binary CLI- so this should not affect them
For legacy users (DC/OS < 1.8): With this change, they will download the latest supported 2.7 version when following the UI instructions from their cluster.  

For developers: python3 wheels for `dcos` and `dcoscli` packages will be published. If they want to use python2.7 they can still use the older 2.7 published wheels for this package. 