### PR TITLE
Reduce requests

### DIFF
--- a/cli/tests/integrations/test_marathon.py
+++ b/cli/tests/integrations/test_marathon.py
@@ -830,6 +830,14 @@ def _zero_instance_app():
 def _zero_instance_app_through_http():
     class JSONRequestHandler (BaseHTTPRequestHandler):
 
+        def do_HEAD(self):  # noqa: N802
+            self.send_response(200)
+            self.send_header("Content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(open(
+                'tests/data/marathon/apps/zero_instance_sleep.json',
+                'rb').read())
+
         def do_GET(self):  # noqa: N802
             self.send_response(200)
             self.send_header("Content-type", "application/json")

--- a/cli/tests/integrations/test_marathon.py
+++ b/cli/tests/integrations/test_marathon.py
@@ -828,15 +828,12 @@ def _zero_instance_app():
 
 @contextlib.contextmanager
 def _zero_instance_app_through_http():
-    class JSONRequestHandler (BaseHTTPRequestHandler):
+    class JSONRequestHandler(BaseHTTPRequestHandler):
 
         def do_HEAD(self):  # noqa: N802
             self.send_response(200)
             self.send_header("Content-type", "application/json")
             self.end_headers()
-            self.wfile.write(open(
-                'tests/data/marathon/apps/zero_instance_sleep.json',
-                'rb').read())
 
         def do_GET(self):  # noqa: N802
             self.send_response(200)

--- a/cli/tests/unit/test_http_auth.py
+++ b/cli/tests/unit/test_http_auth.py
@@ -102,9 +102,8 @@ def test_request_with_bad_auth_basic(mock, req_mock, auth_mock):
 
     req_mock.return_value = mock
 
-    with pytest.raises(DCOSException) as e:
-        http._request_with_auth(mock, "method", mock.url)
-    assert e.exconly().split(':')[1].strip() == "Authentication failed"
+    response = http._request_with_auth(mock, "method", mock.url)
+    assert response.status_code == 401
 
 
 @patch('requests.Response')


### PR DESCRIPTION
Reduce the requests made to HEAD requests in order to determine the type of authentication required, and actually authenticate. Once authenticated, then make the request. This strategy preserves the content of the request object, particularly when they contains stream objects as in the case of multipart/formdata requests.

Fixes #818 
