### PR TITLE
http: don't retry requests if response is 401

### DIFF
--- a/cli/dcoscli/auth/main.py
+++ b/cli/dcoscli/auth/main.py
@@ -84,8 +84,9 @@ def _login():
 
     # hit protected endpoint which will prompt for auth if cluster has auth
     try:
-        url = urllib.parse.urljoin(dcos_url, 'exhibitor/')
-        http.get(url)
+        endpoint = '/pkgpanda/active.buildinfo.full.json'
+        url = urllib.parse.urljoin(dcos_url, endpoint)
+        http.request_with_auth('HEAD', url)
     # if the user is authenticated, they have effectively "logged in" even if
     # they are not authorized for this endpoint
     except DCOSAuthorizationException:

--- a/cli/tests/unit/test_http_auth.py
+++ b/cli/tests/unit/test_http_auth.py
@@ -103,8 +103,9 @@ def test_request_with_bad_auth_basic(mock, req_mock, auth_mock):
     req_mock.return_value = mock
 
     with pytest.raises(DCOSException) as e:
-        http._request_with_auth(mock, "method", mock.url)
-    assert e.exconly().split(':')[1].strip() == "Authentication failed"
+        http.request_with_auth("method", mock.url)
+    msg = "Authentication failed. Please run `dcos auth login`"
+    assert e.exconly().split(':')[1].strip() == msg
 
 
 @patch('requests.Response')
@@ -120,7 +121,7 @@ def test_request_with_bad_auth_acl(mock, req_mock, auth_mock):
     req_mock.return_value = mock
 
     with pytest.raises(DCOSException) as e:
-        http._request_with_auth(mock, "method", mock.url)
+        http.request_with_auth("method", mock.url)
     msg = "Your core.dcos_acs_token is invalid. Please run: `dcos auth login`"
     assert e.exconly().split(':', 1)[1].strip() == msg
 
@@ -138,7 +139,7 @@ def test_request_with_bad_oauth(mock, req_mock, auth_mock):
     req_mock.return_value = mock
 
     with pytest.raises(DCOSException) as e:
-        http._request_with_auth(mock, "method", mock.url)
+        http.request_with_auth("method", mock.url)
     msg = "Your core.dcos_acs_token is invalid. Please run: `dcos auth login`"
     assert e.exconly().split(':', 1)[1].strip() == msg
 
@@ -158,7 +159,7 @@ def test_request_with_auth_basic(mock, req_mock, auth_mock):
     mock2.status_code = 200
     req_mock.return_value = mock2
 
-    response = http._request_with_auth(mock, "method", mock.url)
+    response = http.request_with_auth("method", mock.url)
     assert response.status_code == 200
 
 
@@ -177,7 +178,7 @@ def test_request_with_auth_acl(mock, req_mock, auth_mock):
     mock2.status_code = 200
     req_mock.return_value = mock2
 
-    response = http._request_with_auth(mock, "method", mock.url)
+    response = http.request_with_auth("method", mock.url)
     assert response.status_code == 200
 
 
@@ -196,5 +197,5 @@ def test_request_with_auth_oauth(mock, req_mock, auth_mock):
     mock2.status_code = 200
     req_mock.return_value = mock2
 
-    response = http._request_with_auth(mock, "method", mock.url)
+    response = http.request_with_auth("method", mock.url)
     assert response.status_code == 200

--- a/dcos/errors.py
+++ b/dcos/errors.py
@@ -34,7 +34,7 @@ class DCOSAuthenticationException(DCOSHTTPException):
         self.response = response
 
     def __str__(self):
-        return "Authentication failed"
+        return "Authentication failed. Please run `dcos auth login`"
 
 
 class DCOSAuthorizationException(DCOSHTTPException):


### PR DESCRIPTION
We were retrying requests with 401 so that we can use the response
headers to determine type of authentication. Instead, always send
request with auth if we already have credentials (from
core.dcos_acs_token).

This also fixes multi-part requests that currently break if we have to
retry the request (since the stream gets opened by the initial request).