### PR TITLE
Update for recent pycodestyle changes

### DIFF
--- a/cli/dcoscli/main.py
+++ b/cli/dcoscli/main.py
@@ -117,5 +117,6 @@ def signal_handler(signal, frame):
         errors.DefaultError("User interrupted command with Ctrl-C"))
     sys.exit(0)
 
+
 if __name__ == "__main__":
     sys.exit(main())

--- a/dcos/subcommand.py
+++ b/dcos/subcommand.py
@@ -391,6 +391,7 @@ def uninstall(package_name):
 
     return False
 
+
 BIN_DIRECTORY = 'Scripts' if util.is_windows_platform() else 'bin'
 
 


### PR DESCRIPTION
In particular https://github.com/PyCQA/pycodestyle/pull/536 which landed as part
of 2.1.0 today (https://github.com/PyCQA/pycodestyle/blob/2.2.0/CHANGES.txt#L15)
finds one place where there should have been another newline.