### PR TITLE
allow single entry schedule in json

### DIFF
--- a/cli/dcoscli/job/main.py
+++ b/cli/dcoscli/job/main.py
@@ -469,10 +469,12 @@ def _show_schedule(job_id, json_flag=False):
 
     return 0
 
+
 def reduce_to_schedule(schedules_json):
     """
-    The original design of metronome had an array of schedules defined but limited
-    it to 1.  This limits to 1 and takes the array format or just 1 schedule format.
+    The original design of metronome had an array of schedules defined but
+    limited it to 1.  This limits to 1 and takes the array format or just
+    1 schedule format.
     :param schedules_json: schedule or array of schedules in json
     :type schedules_json: json
     :returns: schedule json

--- a/cli/dcoscli/job/main.py
+++ b/cli/dcoscli/job/main.py
@@ -499,7 +499,7 @@ def _add_schedules(job_id, schedules_json):
     if schedules_json is None:
         raise DCOSException('Schedule JSON is required.')
 
-    schedule = reduce_to_schedule(schedules_json)
+    schedule = parse_schedule_json(schedules_json)
     try:
         _post_schedule(job_id, schedule)
     except DCOSHTTPException as e:

--- a/cli/dcoscli/job/main.py
+++ b/cli/dcoscli/job/main.py
@@ -470,22 +470,20 @@ def _show_schedule(job_id, json_flag=False):
     return 0
 
 
-def reduce_to_schedule(schedules_json):
+def parse_schedule_json(schedules_json):
     """
     The original design of metronome had an array of schedules defined but
     limited it to 1.  This limits to 1 and takes the array format or just
     1 schedule format.
     :param schedules_json: schedule or array of schedules in json
-    :type schedules_json: json
+    :type schedules_json: json [] or {}
     :returns: schedule json
     :rtype: json
     """
-    try:
-        schedule = schedules_json[0]
-        schedule['id'] is not None
-    except:
-        schedule = schedules_json
-    return schedule
+    if type(scheule_json) is list:
+        return schedule_json[0]
+    else:
+        return schedule_json
 
 
 def _add_schedules(job_id, schedules_json):
@@ -499,7 +497,7 @@ def _add_schedules(job_id, schedules_json):
     """
 
     if schedules_json is None:
-        return 1
+        raise DCOSException('Schedule JSON is required.')
 
     schedule = reduce_to_schedule(schedules_json)
     try:

--- a/cli/dcoscli/job/main.py
+++ b/cli/dcoscli/job/main.py
@@ -480,10 +480,10 @@ def parse_schedule_json(schedules_json):
     :returns: schedule json
     :rtype: json
     """
-    if type(scheule_json) is list:
-        return schedule_json[0]
+    if type(schedules_json) is list:
+        return schedules_json[0]
     else:
-        return schedule_json
+        return schedules_json
 
 
 def _add_schedules(job_id, schedules_json):

--- a/cli/tests/data/metronome/jobs/sch-no-array.json
+++ b/cli/tests/data/metronome/jobs/sch-no-array.json
@@ -1,9 +1,0 @@
-{
-  "concurrencyPolicy": "ALLOW",
-  "cron": "20 0 * * *",
-  "enabled": true,
-  "id": "nightly",
-  "nextRunAt": "2016-07-26T00:20:00.000+0000",
-  "startingDeadlineSeconds": 900,
-  "timezone": "UTC"
-}

--- a/cli/tests/data/metronome/jobs/sch-no-array.json
+++ b/cli/tests/data/metronome/jobs/sch-no-array.json
@@ -1,0 +1,9 @@
+{
+  "concurrencyPolicy": "ALLOW",
+  "cron": "20 0 * * *",
+  "enabled": true,
+  "id": "nightly",
+  "nextRunAt": "2016-07-26T00:20:00.000+0000",
+  "startingDeadlineSeconds": 900,
+  "timezone": "UTC"
+}


### PR DESCRIPTION
allowing the schedule json to be in array or non array format.  still only allows 1 but allows flexability.  it also provides better error reporting