### PR TITLE
Add a public agent to CI test clusters

### DIFF
--- a/ccm/start_ccm_cluster.sh
+++ b/ccm/start_ccm_cluster.sh
@@ -19,7 +19,7 @@ CLUSTER_ID=$(http --ignore-stdin \https://ccm.mesosphere.com/api/cluster/ \
      cluster_desc="DC/OS CLI testing cluster" \
      template=$CF_TEMPLATE_NAME \
      adminlocation=0.0.0.0/0 \
-     public_agents=0 \
+     public_agents=1 \
      private_agents=1 | \
      jq ".id");
 


### PR DESCRIPTION
This makes the clusters line up with developer expectations