### PR TITLE
fix python version requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Development Dependencies
 
 #. git_ must be installed to download the source code for the DC/OS CLI.
 
-#. python_ version 3.4.x must be installed.
+#. python_ version 3.5.x must be installed.
 
 #. virtualenv_ must be installed and on the system path in order to install
    legacy subcommands. New subcommands are packaged as platform specific
@@ -85,7 +85,7 @@ Running Tests
 Setup
 #####
 
-Tox, our test runner, tests against Python 3.4. We have a set of tests in
+Tox, our test runner, tests against Python 3.5. We have a set of tests in
 the :code:`dcos` package (root directory) and in the :code:`dcoscli` package
 (:code:`cli` directory). When running the tests describe below change
 directory to one of those two and follow the instructions.
@@ -114,7 +114,7 @@ to test SSL certs. To run this test suite be sure to add this resolution to your
 Running
 #######
 
-Tox will run unit and integration tests in Python 3.4 using a temporarily
+Tox will run unit and integration tests in Python 3.5 using a temporarily
 created virtualenv.
 
 You can set :code:`DCOS_CONFIG` to a config file that points to a DC/OS

--- a/cli/tests/integrations/test_ssl.py
+++ b/cli/tests/integrations/test_ssl.py
@@ -114,4 +114,5 @@ def _ssl_error_msg():
     return (
         "An SSL error occurred. To configure your SSL settings, please run: "
         "`dcos config set core.ssl_verify <value>`\n"
-        "<value>: Whether to verify SSL certs for HTTPS or path to certs\n")
+        "<value>: Whether to verify SSL certs for HTTPS or path to certs. "
+        "Valid values are True, False, or a path to a CA_BUNDLE.\n")

--- a/dcos/data/config-schema/core.json
+++ b/dcos/data/config-schema/core.json
@@ -36,7 +36,7 @@
             "type": "string",
             "default": "false",
             "title": "SSL Verification",
-            "description": "Whether to verify SSL certs for HTTPS or path to certs"
+            "description": "Whether to verify SSL certs for HTTPS or path to certs. Valid values are True, False, or a path to a CA_BUNDLE."
         },
         "pagination": {
             "type": "boolean",


### PR DESCRIPTION
The docs say we need 3.4, but then make tells me 3.5.

One of these is wrong.

```
 ~/src/m8e/dcos-cli [master|…1]
14:59 $ make env
bin/env.sh
Cannot find supported python version 3.5. Exiting...
make: *** [env] Error 1
```