### PR TITLE
dcos/http: raise exception if expired token

### DIFF
--- a/dcos/http.py
+++ b/dcos/http.py
@@ -159,7 +159,7 @@ def request(method,
         if auth_token is not None:
             msg = ("Your core.dcos_acs_token is invalid. "
                    "Please run: `dcos auth login`")
-            raise DCOSException(msg)
+            raise DCOSAuthenticationException(msg)
         else:
             raise DCOSAuthenticationException(response)
     elif response.status_code == 422:

--- a/dcos/packagemanager.py
+++ b/dcos/packagemanager.py
@@ -67,6 +67,10 @@ class PackageManager:
         try:
             response = self.cosmos.call_endpoint(
                 'capabilities').json()
+        except DCOSAuthenticationException:
+            raise
+        except DCOSAuthorizationException:
+            raise
         except Exception as e:
             logger.exception(e)
             return False


### PR DESCRIPTION
- add raise DCOSAuthenticationException in dcos.http.request if token is
  invalid.
- raise DCOSAuthenticationException in
  dcos.packagemanager.PackageManager().has_capability if user is not logged in