### PR TITLE
Fixed typo in help for dcos job kill

### DIFF
--- a/cli/dcoscli/data/help/job.txt
+++ b/cli/dcoscli/data/help/job.txt
@@ -30,7 +30,7 @@ Commands:
     job update
         Update the job.
     job kill
-        Show the job.
+        Kill the job.
     job run
         Run a job now.
     job list

--- a/cli/tests/data/help/job.txt
+++ b/cli/tests/data/help/job.txt
@@ -30,7 +30,7 @@ Commands:
     job update
         Update the job.
     job kill
-        Show the job.
+        Kill the job.
     job run
         Run a job now.
     job list


### PR DESCRIPTION
Fixed typo in dcos job kill help.