### PR TITLE
Allow read-only permissions on ssh key

### DIFF
--- a/dcos/util.py
+++ b/dcos/util.py
@@ -183,7 +183,7 @@ def enforce_file_permissions(path):
         return
     else:
         permissions = oct(stat.S_IMODE(os.lstat(path).st_mode))
-        if permissions not in ['0o600', '0600']:
+        if permissions not in ['0o600', '0600', '0o400', '0400']:
             msg = (
                 "Permissions '{}' for configuration file '{}' are too open. "
                 "File must only be accessible by owner. "

--- a/dcos/util.py
+++ b/dcos/util.py
@@ -167,7 +167,7 @@ def read_file(path):
 
 
 def enforce_file_permissions(path):
-    """Enfore 600 permissions on file
+    """Enforce 400 or 600 permissions on file
 
     :param path: Path to the TOML file
     :type path: str
@@ -193,7 +193,7 @@ def enforce_file_permissions(path):
 
 def read_file_secure(path):
     """
-    Enfore 600 permissions when reading file
+    Enforce 400 or 600 permissions when reading file
 
     :param path: path to file
     :type path: str


### PR DESCRIPTION
I spent a while this morning trying to figure out why read-only permissions on my ssh key were "too open" :)