### PR TITLE
Improve error message for not meeting minimum

### DIFF
--- a/dcos/packagemanager.py
+++ b/dcos/packagemanager.py
@@ -596,6 +596,9 @@ def _format_json_schema_mismatch_message(error):
         if err.get("found"):
             found = "Found: {}".format(err["found"])
             error_messages += [found]
+        if err.get("minimum"):
+            found = "Required minimum: {}".format(err["minimum"])
+            error_messages += [found]
         if err.get("expected"):
             expected = "Expected: {}".format(",".join(err["expected"]))
             error_messages += [expected]


### PR DESCRIPTION
Better error message.

Before:

```
Error: Options JSON failed validation
Found: 128
Path: service.mem

Please create a JSON file with the appropriate options, and pass the /path/to/file as an --options argument.
```

Seeing this, I might think that it thinks the value is missing but I check my config and it's there so I would be puzzled about what the problem is.

After:

```
Found: 128
Required minimum: 256
Path: service.mem

Please create a JSON file with the appropriate options, and pass the /path/to/file as an --options argument.
```

This makes it clear what the actual problem is.

Cc: @matthewdfuller