### PR TITLE
tox.ini: Test py35 and py36

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35-syntax, py35-unit
+envlist = py{35,36}-syntax, py{35,36}-unit
 
 [flake8]
 application-import-names=dcos
@@ -18,7 +18,7 @@ passenv =
   CLI_TEST_SSH_KEY_PATH
   TEAMCITY_VERSION
 
-[testenv:py35-syntax]
+[syntax]
 deps =
   flake8
   flake8-import-order==0.9.2
@@ -27,6 +27,20 @@ deps =
 commands =
   flake8 --verbose {env:CI_FLAGS:} dcos tests setup.py
 
-[testenv:py35-unit]
+[unit]
 commands =
   py.test -p no:cacheprovider -vv {env:CI_FLAGS:} --cov {envsitepackagesdir}/dcos tests{posargs}
+
+[testenv:py35-syntax]
+deps = {[syntax]deps}
+commands = {[syntax]commands}
+
+[testenv:py35-unit]
+commands = {[unit]commands}
+
+[testenv:py36-syntax]
+deps = {[syntax]deps}
+commands = {[syntax]commands}
+
+[testenv:py36-unit]
+commands = {[unit]commands}


### PR DESCRIPTION
```
$ tox
...
  py35-syntax: commands succeeded
  py36-syntax: commands succeeded
  py35-unit: commands succeeded
  py36-unit: commands succeeded
  congratulations :)
```