### PR TITLE
Add tests for dcos.packagemanager

### DIFF
--- a/tests/test_packagemanager.py
+++ b/tests/test_packagemanager.py
@@ -11,13 +11,13 @@ install_request_content_type = pkg_mgr.cosmos._get_content_type('package.install
 install_response_content_type = pkg_mgr.cosmos._get_accept('package.install', 'v2')
 
 
-def make_response(status_code, headers, body=None):
-    mock_response = mock.create_autospec(requests.Response)
-    mock_response.status_code = status_code
-    mock_response.headers = headers
+def mock_response(status_code, headers, body=None):
+    res = mock.create_autospec(requests.Response)
+    res.status_code = status_code
+    res.headers = headers
     if body is not None:
-        mock_response.body = body
-    return mock_response
+        res.body = body
+    return res
 
 
 def test_format_error_message_ambiguous_app_id():
@@ -67,8 +67,8 @@ def test_format_error_message_marathon_bad_response():
 @mock.patch('dcos.http.post')
 def test_install(post_fn):
     post_fn.side_effect = [
-        make_response(200, {'Content-Type': describe_response_content_type}),
-        make_response(200, {'Content-Type': install_response_content_type}),
+        mock_response(200, {'Content-Type': describe_response_content_type}),
+        mock_response(200, {'Content-Type': install_response_content_type}),
     ]
 
     pkg = pkg_mgr.get_package_version('pkg', '0.0.1')

--- a/tests/test_packagemanager.py
+++ b/tests/test_packagemanager.py
@@ -2,13 +2,13 @@ import json
 import mock
 import requests
 
-from dcos import cosmos, packagemanager
+from dcos import packagemanager
 
 
-cosmos_obj = cosmos.Cosmos()
-describe_response_content_type = cosmos_obj._get_accept('package.describe', 'v2')
-install_request_content_type = cosmos_obj._get_content_type('package.install')
-install_response_content_type = cosmos_obj._get_accept('package.install', 'v2')
+pkg_mgr = packagemanager.PackageManager('http://testserver/cosmos')
+describe_response_content_type = pkg_mgr.cosmos._get_accept('package.describe', 'v2')
+install_request_content_type = pkg_mgr.cosmos._get_content_type('package.install')
+install_response_content_type = pkg_mgr.cosmos._get_accept('package.install', 'v2')
 
 
 def make_response(status_code, headers, body=None):
@@ -71,11 +71,9 @@ def test_install(post_fn):
         make_response(200, {'Content-Type': install_response_content_type}),
     ]
 
-    cosmos_url = 'http://testserver/cosmos'
-    package_manager = packagemanager.PackageManager(cosmos_url)
     pkg = packagemanager.CosmosPackageVersion(
         name='pkg', package_version='0.0.1', url='http://url/to/package')
-    package_manager.install_app(pkg=pkg, options=None, app_id=None)
+    pkg_mgr.install_app(pkg=pkg, options=None, app_id=None)
     assert post_fn.mock_calls[0][1][0] == 'http://url/to/package/describe'
     post_fn.assert_called_with(
         'http://testserver/package/install',

--- a/tests/test_packagemanager.py
+++ b/tests/test_packagemanager.py
@@ -76,6 +76,6 @@ def test_install(post_fn):
     post_fn.assert_called_with(
         'http://testserver/package/install',
         data=None,
-        headers=mock.ANY,
+        headers=pkg_mgr.cosmos._get_header('package.install', 'v2'),
         json={'packageName': 'pkg', 'packageVersion': '0.0.1'},
     )

--- a/tests/test_packagemanager.py
+++ b/tests/test_packagemanager.py
@@ -1,4 +1,3 @@
-import json
 import mock
 import pytest
 import requests
@@ -33,7 +32,9 @@ def pkg_mgr():
 @pytest.fixture
 def fake_pkg(pkg_mgr):
     with mock.patch('dcos.http.post') as post_fn:
-        post_fn.return_value = mock_response(200, describe_response_headers(pkg_mgr))
+        post_fn.return_value = mock_response(
+            200, describe_response_headers(pkg_mgr),
+        )
         yield pkg_mgr.get_package_version('fake_pkg', '0.0.1')
 
 
@@ -41,7 +42,7 @@ def test_format_error_message_ambiguous_app_id():
     error_dict = {'type': 'AmbiguousAppId', 'message': '<fake message>'}
     ret = packagemanager._format_error_message(error_dict)
     assert '<fake message>' in ret
-    assert 'Please use --app-id to specify the ID of the app to uninstall' in ret
+    assert 'the ID of the app to uninstall' in ret
 
 
 def test_format_error_message_multiple_framework_ids():
@@ -90,7 +91,9 @@ def test_format_error_message_marathon_bad_response():
 
 @mock.patch('dcos.http.post')
 def test_install(post_fn, pkg_mgr, fake_pkg):
-    post_fn.return_value = mock_response(200, install_response_headers(pkg_mgr))
+    post_fn.return_value = mock_response(
+        200, install_response_headers(pkg_mgr),
+    )
     pkg_mgr.install_app(fake_pkg, options=None, app_id=None)
     post_fn.assert_called_with(
         'http://testserver/package/install',

--- a/tests/test_packagemanager.py
+++ b/tests/test_packagemanager.py
@@ -71,14 +71,14 @@ def test_install(post_fn):
         make_response(200, {'Content-Type': install_response_content_type}),
     ]
 
-    cosmos_url = 'http://127.0.0.1/cosmos'
+    cosmos_url = 'http://testserver/cosmos'
     package_manager = packagemanager.PackageManager(cosmos_url)
     pkg = packagemanager.CosmosPackageVersion(
         name='pkg', package_version='0.0.1', url='http://url/to/package')
     package_manager.install_app(pkg=pkg, options=None, app_id=None)
     assert post_fn.mock_calls[0][1][0] == 'http://url/to/package/describe'
     post_fn.assert_called_with(
-        mock.ANY,
+        'http://testserver/package/install',
         data=None,
         headers=mock.ANY,
         json={'packageName': 'pkg', 'packageVersion': '0.0.1'},

--- a/tests/test_packagemanager.py
+++ b/tests/test_packagemanager.py
@@ -7,7 +7,6 @@ from dcos import packagemanager
 
 pkg_mgr = packagemanager.PackageManager('http://testserver/cosmos')
 describe_response_content_type = pkg_mgr.cosmos._get_accept('package.describe', 'v2')
-install_request_content_type = pkg_mgr.cosmos._get_content_type('package.install')
 install_response_content_type = pkg_mgr.cosmos._get_accept('package.install', 'v2')
 
 

--- a/tests/test_packagemanager.py
+++ b/tests/test_packagemanager.py
@@ -51,18 +51,25 @@ def test_format_error_message_multiple_framework_ids():
     assert "Manually shut them down using 'dcos service shutdown'" in ret
 
 
-def test_format_error_message_json_schema_mismatch_unwanted():
+def test_format_error_message_json_schema_mismatch():
     error_dict = {
         'type': 'JsonSchemaMismatch',
         'message': '<fake message>',
         'data': {
             'errors': [
                 {'unwanted': ['x', 'y']},
+                {'found': 128, 'minimum': 256,
+                 'instance': {'pointer': 'service.mem'}},
+                {'expected': ['yes', 'no']},
             ],
         },
     }
     ret = packagemanager._format_error_message(error_dict)
     assert '<fake message>' in ret
+    assert 'Found: 128' in ret
+    assert 'minimum: 256' in ret
+    assert 'Path: service.mem' in ret
+    assert 'Expected: yes,no' in ret
     assert "Unexpected properties: ['x', 'y']" in ret
 
 

--- a/tests/test_packagemanager.py
+++ b/tests/test_packagemanager.py
@@ -2,12 +2,13 @@ import json
 import mock
 import requests
 
-from dcos import packagemanager
+from dcos import cosmos, packagemanager
 
 
-describe_response_content_type = 'application/vnd.dcos.package.describe-response+json;charset=utf-8;version=v2'
-install_request_content_type = 'application/vnd.dcos.package.install-request+json;charset=utf-8;version=v1'
-install_response_content_type = 'application/vnd.dcos.package.install-response+json;charset=utf-8;version=v2'
+cosmos_obj = cosmos.Cosmos()
+describe_response_content_type = cosmos_obj._get_accept('package.describe', 'v2')
+install_request_content_type = cosmos_obj._get_content_type('package.install')
+install_response_content_type = cosmos_obj._get_accept('package.install', 'v2')
 
 
 def make_response(status_code, headers, body=None):

--- a/tests/test_packagemanager.py
+++ b/tests/test_packagemanager.py
@@ -76,6 +76,6 @@ def test_install(post_fn):
     post_fn.assert_called_with(
         'http://testserver/package/install',
         data=None,
-        headers=pkg_mgr.cosmos._get_header('package.install', 'v2'),
+        headers=pkg_mgr.cosmos._get_header('package/install', 'v2'),
         json={'packageName': pkg.name(), 'packageVersion': pkg.version()},
     )

--- a/tests/test_packagemanager.py
+++ b/tests/test_packagemanager.py
@@ -71,10 +71,8 @@ def test_install(post_fn):
         make_response(200, {'Content-Type': install_response_content_type}),
     ]
 
-    pkg = packagemanager.CosmosPackageVersion(
-        name='pkg', package_version='0.0.1', url='http://url/to/package')
-    pkg_mgr.install_app(pkg=pkg, options=None, app_id=None)
-    assert post_fn.mock_calls[0][1][0] == 'http://url/to/package/describe'
+    pkg = pkg_mgr.get_package_version('pkg', '0.0.1')
+    pkg_mgr.install_app(pkg, options=None, app_id=None)
     post_fn.assert_called_with(
         'http://testserver/package/install',
         data=None,

--- a/tests/test_packagemanager.py
+++ b/tests/test_packagemanager.py
@@ -1,0 +1,84 @@
+import json
+import mock
+import requests
+
+from dcos import packagemanager
+
+
+describe_response_content_type = 'application/vnd.dcos.package.describe-response+json;charset=utf-8;version=v2'
+install_request_content_type = 'application/vnd.dcos.package.install-request+json;charset=utf-8;version=v1'
+install_response_content_type = 'application/vnd.dcos.package.install-response+json;charset=utf-8;version=v2'
+
+
+def make_response(status_code, headers, body=None):
+    mock_response = mock.create_autospec(requests.Response)
+    mock_response.status_code = status_code
+    mock_response.headers = headers
+    if body is not None:
+        mock_response.body = body
+    return mock_response
+
+
+def test_format_error_message_ambiguous_app_id():
+    error_dict = {'type': 'AmbiguousAppId', 'message': '<fake message>'}
+    ret = packagemanager._format_error_message(error_dict)
+    assert '<fake message>' in ret
+    assert 'Please use --app-id to specify the ID of the app to uninstall' in ret
+
+
+def test_format_error_message_multiple_framework_ids():
+    error_dict = {'type': 'MultipleFrameworkIds', 'message': '<fake message>'}
+    ret = packagemanager._format_error_message(error_dict)
+    assert '<fake message>' in ret
+    assert "Manually shut them down using 'dcos service shutdown'" in ret
+
+
+def test_format_error_message_json_schema_mismatch_unwanted():
+    error_dict = {
+        'type': 'JsonSchemaMismatch',
+        'message': '<fake message>',
+        'data': {
+            'errors': [
+                {'unwanted': ['x', 'y']},
+            ],
+        },
+    }
+    ret = packagemanager._format_error_message(error_dict)
+    assert '<fake message>' in ret
+    assert "Unexpected properties: ['x', 'y']" in ret
+
+
+def test_format_error_message_marathon_bad_response():
+    error_dict = {
+        'type': 'MarathonBadResponse',
+        'message': '<fake message>',
+        'data': {
+            'errors': [
+                {'error': 'Something went wrong'},
+            ],
+        },
+    }
+    ret = packagemanager._format_error_message(error_dict)
+    assert '<fake message>' in ret
+    assert "Something went wrong" in ret
+
+
+@mock.patch('dcos.http.post')
+def test_install(post_fn):
+    post_fn.side_effect = [
+        make_response(200, {'Content-Type': describe_response_content_type}),
+        make_response(200, {'Content-Type': install_response_content_type}),
+    ]
+
+    cosmos_url = 'http://127.0.0.1/cosmos'
+    package_manager = packagemanager.PackageManager(cosmos_url)
+    pkg = packagemanager.CosmosPackageVersion(
+        name='pkg', package_version='0.0.1', url='http://url/to/package')
+    package_manager.install_app(pkg=pkg, options=None, app_id=None)
+    assert post_fn.mock_calls[0][1][0] == 'http://url/to/package/describe'
+    post_fn.assert_called_with(
+        mock.ANY,
+        data=None,
+        headers=mock.ANY,
+        json={'packageName': 'pkg', 'packageVersion': '0.0.1'},
+    )

--- a/tests/test_packagemanager.py
+++ b/tests/test_packagemanager.py
@@ -77,5 +77,5 @@ def test_install(post_fn):
         'http://testserver/package/install',
         data=None,
         headers=pkg_mgr.cosmos._get_header('package.install', 'v2'),
-        json={'packageName': 'pkg', 'packageVersion': '0.0.1'},
+        json={'packageName': pkg.name(), 'packageVersion': pkg.version()},
     )

--- a/tests/test_packagemanager.py
+++ b/tests/test_packagemanager.py
@@ -6,8 +6,16 @@ from dcos import packagemanager
 
 
 pkg_mgr = packagemanager.PackageManager('http://testserver/cosmos')
-describe_response_content_type = pkg_mgr.cosmos._get_accept('package.describe', 'v2')
-install_response_content_type = pkg_mgr.cosmos._get_accept('package.install', 'v2')
+
+
+def describe_response_headers():
+    content_type = pkg_mgr.cosmos._get_accept('package.describe', 'v2')
+    return {'Content-Type': content_type}
+
+
+def install_response_headers():
+    content_type = pkg_mgr.cosmos._get_accept('package.install', 'v2')
+    return {'Content-Type': content_type}
 
 
 def mock_response(status_code, headers, body=None):
@@ -66,8 +74,8 @@ def test_format_error_message_marathon_bad_response():
 @mock.patch('dcos.http.post')
 def test_install(post_fn):
     post_fn.side_effect = [
-        mock_response(200, {'Content-Type': describe_response_content_type}),
-        mock_response(200, {'Content-Type': install_response_content_type}),
+        mock_response(200, describe_response_headers()),
+        mock_response(200, install_response_headers()),
     ]
 
     pkg = pkg_mgr.get_package_version('pkg', '0.0.1')


### PR DESCRIPTION
I noticed that `dcos.packagemanager` had 0% test coverage. So I wrote some tests. If you like, I can write some more.

Before:

```
$ tox -e py35-unit | grep 'packagemanager.*%'
.tox/py35-unit/lib/python3.5/site-packages/dcos/packagemanager.py     252    252     0%
```

After:

```
$ tox -e py35-unit | grep 'packagemanager.*%'
.tox/py35-unit/lib/python3.5/site-packages/dcos/packagemanager.py     252    139    45%
```

Cc: @matthewdfuller