### PR TITLE
tox.ini: Use --cov-report=term-missing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,4 +29,4 @@ commands =
 
 [testenv:py35-unit]
 commands =
-  py.test -p no:cacheprovider -vv {env:CI_FLAGS:} --cov {envsitepackagesdir}/dcos tests{posargs}
+  py.test -p no:cacheprovider -vv {env:CI_FLAGS:} --cov {envsitepackagesdir}/dcos --cov-report=term-missing tests{posargs}


### PR DESCRIPTION
so we can see line numbers of uncovered lines