### PR TITLE
dcos node ssh --proxy-ip=<proxy-ip>

### DIFF
--- a/cli/dcoscli/data/help/node.txt
+++ b/cli/dcoscli/data/help/node.txt
@@ -12,6 +12,7 @@ Usage:
                   [--config-file=<path>]
                   [--user=<user>]
                   [--master-proxy]
+                  [--proxy-ip=<proxy-ip>]
                   (--leader | --master | --mesos-id=<mesos-id> | --slave=<slave-id>)
                   [<command>]
     dcos node diagnostics create (<nodes>)...
@@ -56,6 +57,8 @@ Options:
         configuration, the private slaves are unreachable from the public
         internet. You can access them using this option, which will first hop
         from the publicly available master.
+    --proxy-ip=<proxy-ip>
+        Proxy the SSH connection through a different IP address.
     --option SSHOPT=VAL
         The SSH options. For information, enter `man ssh_config` in your
         terminal.

--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -81,7 +81,7 @@ def _cmds():
         cmds.Command(
             hierarchy=['node', 'ssh'],
             arg_keys=['--leader', '--mesos-id', '--option', '--config-file',
-                      '--user', '--master-proxy', '<command>'],
+                      '--user', '--master-proxy', '--proxy-ip', '<command>'],
             function=_ssh),
 
         cmds.Command(
@@ -707,7 +707,7 @@ def _mesos_files(leader, slave_id):
     return files
 
 
-def _ssh(leader, slave, option, config_file, user, master_proxy, command):
+def _ssh(leader, slave, option, config_file, user, master_proxy, proxy_ip, command):
     """SSH into a DC/OS node using the IP addresses found in master's
        state.json
 
@@ -724,6 +724,8 @@ def _ssh(leader, slave, option, config_file, user, master_proxy, command):
     :type user: str | None
     :param master_proxy: If True, SSH-hop from a master
     :type master_proxy: bool | None
+    :param proxy_ip: If set, SSH-hop from this IP address
+    :type proxy_ip: str | None
     :param command: Command to run on the node
     :type command: str | None
     :rtype: int
@@ -748,20 +750,24 @@ def _ssh(leader, slave, option, config_file, user, master_proxy, command):
     if command is None:
         command = ''
 
-    master_public_ip = dcos_client.metadata().get('PUBLIC_IPV4')
-    if master_proxy:
+    if proxy_ip:
+        master_public_ip = proxy_ip
+    else:
+        master_public_ip = dcos_client.metadata().get('PUBLIC_IPV4')
+
+    if master_proxy or proxy_ip:
         if not os.environ.get('SSH_AUTH_SOCK'):
             raise DCOSException(
                 "There is no SSH_AUTH_SOCK env variable, which likely means "
                 "you aren't running `ssh-agent`.  `dcos node ssh "
-                "--master-proxy` depends on `ssh-agent` to safely use your "
-                "private key to hop between nodes in your cluster.  Please "
-                "run `ssh-agent`, then add your private key with `ssh-add`.")
+                "--master-proxy/--proxy-ip` depends on `ssh-agent` to safely "
+                "use your private key to hop between nodes in your cluster.  "
+                "Please run `ssh-agent`, then add your private key with "
+                "`ssh-add`.")
         if not master_public_ip:
             raise DCOSException(("Cannot use --master-proxy.  Failed to find "
                                  "'PUBLIC_IPV4' at {}").format(
                                      dcos_client.get_dcos_url('metadata')))
-
         cmd = "ssh -A -t {0}{1}@{2} ssh -A -t {0}{1}@{3} {4}".format(
             ssh_options,
             user,
@@ -776,10 +782,10 @@ def _ssh(leader, slave, option, config_file, user, master_proxy, command):
             command)
 
     emitter.publish(DefaultError("Running `{}`".format(cmd)))
-    if (not master_proxy) and master_public_ip:
+    if (not master_proxy and not proxy_ip) and master_public_ip:
         emitter.publish(
             DefaultError("If you are running this command from a separate "
                          "network than DC/OS, consider using "
-                         "`--master-proxy`"))
+                         "`--master-proxy` or `--proxy-ip`"))
 
     return subprocess.Subproc().call(cmd, shell=True)

--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -707,7 +707,8 @@ def _mesos_files(leader, slave_id):
     return files
 
 
-def _ssh(leader, slave, option, config_file, user, master_proxy, proxy_ip, command):
+def _ssh(leader, slave, option, config_file, user, master_proxy, proxy_ip,
+         command):
     """SSH into a DC/OS node using the IP addresses found in master's
        state.json
 

--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -750,6 +750,7 @@ def _ssh(leader, slave, option, config_file, user, master_proxy, proxy_ip, comma
     if command is None:
         command = ''
 
+    proxy_ip = proxy_ip or config.get_config_val('core.dcos_proxy_ip')
     if proxy_ip:
         master_public_ip = proxy_ip
     else:

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -134,9 +134,10 @@ def test_node_ssh_master_proxy_no_agent():
     env.pop('SSH_AUTH_SOCK', None)
     stderr = (b"There is no SSH_AUTH_SOCK env variable, which likely means "
               b"you aren't running `ssh-agent`.  `dcos node ssh "
-              b"--master-proxy` depends on `ssh-agent` to safely use your "
-              b"private key to hop between nodes in your cluster.  Please "
-              b"run `ssh-agent`, then add your private key with `ssh-add`.\n")
+              b"--master-proxy/--proxy-ip` depends on `ssh-agent` to safely "
+              b"use your private key to hop between nodes in your cluster.  "
+              b"Please run `ssh-agent`, then add your private key with "
+              b"`ssh-add`.\n")
 
     assert_command(['dcos', 'node', 'ssh', '--master-proxy', '--leader'],
                    stderr=stderr,


### PR DESCRIPTION
In our DC/OS setup, the master node doesn't have a public IP and we use a public jump box to get to all nodes in the cluster. This adds a `--proxy-ip` option to `dcos node ssh`, so that we can specify which box to use as the SSH proxy.

In our DC/OS setup, the master node doesn't have a public IP and we use a public jump box to get to all nodes in the cluster. This adds a `--proxy-ip` option to `dcos node ssh`, so that we can specify which box to use as the SSH proxy.

```
$ dcos node ssh --proxy-ip $DCOS_PROXY_IP --mesos-id=74df965e-a46e-46a9-8d2a-639db0af0e25-S2
Running `ssh -A -t core@<redacted> ssh -A -t core@10.10.12.29 `
Last login: Fri Feb 10 23:07:26 UTC 2017 from 10.10.3.201 on pts/0
CoreOS stable (1185.5.0)
Update Strategy: No Reboots
Failed Units: 1
  user@0.service
core@ip-10-10-12-29 ~ $
```

Cc: @matthewdfuller