### PR TITLE
Better error when package config var missing

### DIFF
--- a/dcos/packagemanager.py
+++ b/dcos/packagemanager.py
@@ -602,6 +602,11 @@ def _format_json_schema_mismatch_message(error):
         if err.get("expected"):
             expected = "Expected: {}".format(",".join(err["expected"]))
             error_messages += [expected]
+        if err.get("missing"):
+            missing = "Required parameter missing: {}".format(
+                ",".join(err["missing"]),
+            )
+            error_messages += [missing]
         if err.get("instance"):
             pointer = err["instance"].get("pointer")
             formatted_path = pointer.lstrip("/").replace("/", ".")


### PR DESCRIPTION
Before:

```
Error: Options JSON failed validation
Path: environment
```

After:

```
Error: Options JSON failed validation
Required parameter missing: dbHost
Path: environment
```

Fixes: https://dcosjira.atlassian.net/browse/DCOS-191

Cc: @tamarrow, @jerith, @matthewdfuller