### PR TITLE
dcos node ssh --private-ip=<private-ip>

### DIFF
--- a/cli/dcoscli/data/help/node.txt
+++ b/cli/dcoscli/data/help/node.txt
@@ -13,7 +13,7 @@ Usage:
     dcos node list-components [--leader --mesos-id=<mesos-id> --json]
     dcos node log [--follow --lines=N --leader --master --mesos-id=<mesos-id> --slave=<agent-id>]
                   [--component=<component-name> --filter=<filter>...]
-    dcos node ssh (--leader | --master | --mesos-id=<mesos-id> | --slave=<slave-id> | --private-ip=<private-ip>)
+    dcos node ssh (--leader | --master | --mesos-id=<mesos-id> | --private-ip=<private-ip> | --slave=<agent-id>)
                   [--config-file=<path>]
                   [--user=<user>]
                   [--master-proxy]
@@ -70,24 +70,16 @@ Options:
     --master-proxy
         Proxy the SSH connection through a master node. This can be useful when
         accessing DC/OS from a separate network. For example, in the default AWS
-<<<<<<< HEAD
         configuration, the private agents are unreachable from the public
         internet. You can access them using this option, which will proxy the SSH
         connection through the publicly reachable master.
     --mesos-id=<mesos-id>
         The agent ID of a node.
-=======
-        configuration, the private slaves are unreachable from the public
-        internet. You can access them using this option, which will first hop
-        from the publicly available master.
-    --private-ip=<private-ip>
-        Agent node with the provided private IP.
-    --proxy-ip=<proxy-ip>
-        Proxy the SSH connection through a different IP address.
->>>>>>> dcos node ssh --private-ip=<private-ip>
     --option SSHOPT=VAL
         The SSH options. For more information, enter `man ssh_config` in your
         terminal.
+    --private-ip=<private-ip>
+        Agent node with the provided private IP.
     --proxy-ip=<proxy-ip>
         Proxy the SSH connection through a different IP address.
     --slave=<agent-id>

--- a/cli/dcoscli/data/help/node.txt
+++ b/cli/dcoscli/data/help/node.txt
@@ -13,7 +13,7 @@ Usage:
     dcos node list-components [--leader --mesos-id=<mesos-id> --json]
     dcos node log [--follow --lines=N --leader --master --mesos-id=<mesos-id> --slave=<agent-id>]
                   [--component=<component-name> --filter=<filter>...]
-    dcos node ssh (--leader | --master | --mesos-id=<mesos-id> | --slave=<agent-id>)
+    dcos node ssh (--leader | --master | --mesos-id=<mesos-id> | --slave=<slave-id> | --private-ip=<private-ip>)
                   [--config-file=<path>]
                   [--user=<user>]
                   [--master-proxy]
@@ -70,11 +70,21 @@ Options:
     --master-proxy
         Proxy the SSH connection through a master node. This can be useful when
         accessing DC/OS from a separate network. For example, in the default AWS
+<<<<<<< HEAD
         configuration, the private agents are unreachable from the public
         internet. You can access them using this option, which will proxy the SSH
         connection through the publicly reachable master.
     --mesos-id=<mesos-id>
         The agent ID of a node.
+=======
+        configuration, the private slaves are unreachable from the public
+        internet. You can access them using this option, which will first hop
+        from the publicly available master.
+    --private-ip=<private-ip>
+        Agent node with the provided private IP.
+    --proxy-ip=<proxy-ip>
+        Proxy the SSH connection through a different IP address.
+>>>>>>> dcos node ssh --private-ip=<private-ip>
     --option SSHOPT=VAL
         The SSH options. For more information, enter `man ssh_config` in your
         terminal.

--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -81,7 +81,8 @@ def _cmds():
         cmds.Command(
             hierarchy=['node', 'ssh'],
             arg_keys=['--leader', '--mesos-id', '--option', '--config-file',
-                      '--user', '--master-proxy', '--proxy-ip', '<command>'],
+                      '--user', '--master-proxy', '--proxy-ip', '--private-ip',
+                      '<command>'],
             function=_ssh),
 
         cmds.Command(
@@ -735,7 +736,7 @@ def _mesos_files(leader, slave_id):
 
 
 def _ssh(leader, slave, option, config_file, user, master_proxy, proxy_ip,
-         command):
+         private_ip, command):
     """SSH into a DC/OS node using the IP addresses found in master's
        state.json
 
@@ -754,6 +755,8 @@ def _ssh(leader, slave, option, config_file, user, master_proxy, proxy_ip,
     :type master_proxy: bool | None
     :param proxy_ip: If set, SSH-hop from this IP address
     :type proxy_ip: str | None
+    :param private_ip: The private IP address of the node we want to SSH to.
+    :type private_ip: str | None
     :param command: Command to run on the node
     :type command: str | None
     :rtype: int
@@ -765,6 +768,8 @@ def _ssh(leader, slave, option, config_file, user, master_proxy, proxy_ip,
 
     if leader:
         host = mesos.MesosDNSClient().hosts('leader.mesos.')[0]['ip']
+    elif private_ip:
+        host = private_ip
     else:
         summary = dcos_client.get_state_summary()
         slave_obj = next((slave_ for slave_ in summary['slaves']

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -101,6 +101,11 @@ def test_node_ssh_slave():
     _node_ssh(['--mesos-id={}'.format(slave_id), '--master-proxy'])
 
 
+def test_node_ssh_slave_with_private_ip():
+    slave_ip = mesos.DCOSClient().get_state_summary()['slaves'][0]['hostname']
+    _node_ssh(['--private-ip={}'.format(slave_ip), '--master-proxy'])
+
+
 @pytest.mark.skipif(sys.platform == 'win32',
                     reason='No pseudo terminal on windows')
 def test_node_ssh_option():
@@ -184,7 +189,7 @@ def test_node_ssh_with_command():
 def test_node_ssh_slave_with_command():
     slave = mesos.DCOSClient().get_state_summary()['slaves'][0]
     _node_ssh(['--mesos-id={}'.format(slave['id']), '--master-proxy',
-              '/opt/mesosphere/bin/detect_ip'], 0, slave['hostname'])
+               '/opt/mesosphere/bin/detect_ip'], 0, slave['hostname'])
 
 
 def _node_ssh_output(args):

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -101,6 +101,8 @@ def test_node_ssh_slave():
     _node_ssh(['--mesos-id={}'.format(slave_id), '--master-proxy'])
 
 
+@pytest.mark.skipif(sys.platform == 'win32',
+                    reason='No pseudo terminal on windows')
 def test_node_ssh_slave_with_private_ip():
     slave_ip = mesos.DCOSClient().get_state_summary()['slaves'][0]['hostname']
     _node_ssh(['--private-ip={}'.format(slave_ip), '--master-proxy'])


### PR DESCRIPTION
People working on the soak clusters at Mesosphere receive alerts when
something unexpected is happening, e.g. 'Some containers failed to
launch on an agent on agent:<private_ip>'.

This new command allows us to quickly take a look without
having to check the Mesos UI to find the Mesos ID of an agent. Another
use case is when a developer sees an unhealthy AWS instance that is a
DC/OS private agent without a public IP.