### PR TITLE
use config file to determine logs source

### DIFF
--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -498,7 +498,8 @@ def _log(follow, lines, leader, slave, component, filters):
     lines = util.parse_int(lines)
 
     # if journald logging is disabled. Read from files API and exit.
-    if not log.dcos_log_enabled():
+    # https://github.com/dcos/dcos/blob/master/gen/calc.py#L151
+    if 'journald' not in log.logging_strategy():
         if component or filters:
             raise DCOSException('--component or --filter is not '
                                 'supported by files API')
@@ -675,8 +676,6 @@ def _dcos_log(follow, lines, leader, slave, component, filters):
     :param filters: a list of filters ["key:value", ...]
     :type filters: list
     """
-    if not log.dcos_log_enabled():
-        raise DCOSException('dcos-log is not supported')
 
     filter_query = ''
     if component:

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -68,7 +68,6 @@ def test_node_log_missing_slave():
     assert returncode == 1
     assert stdout == b''
     stderr_str = str(stderr)
-    assert 'HTTP 404' in stderr_str
     assert 'No slave found with ID "bogus".' in stderr_str
 
 

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -68,7 +68,7 @@ def test_node_log_missing_slave():
     assert returncode == 1
     assert stdout == b''
     stderr_str = str(stderr)
-    assert 'No slave found with ID "bogus".' in stderr_str
+    assert 'HTTP 404: Not Found' in stderr_str
 
 
 def test_node_log_lines():

--- a/cli/tests/integrations/test_task.py
+++ b/cli/tests/integrations/test_task.py
@@ -188,7 +188,7 @@ def test_log_two_tasks():
     assert stderr == b''
 
     lines = stdout.decode('utf-8').split('\n')
-    assert len(lines) == 11
+    assert len(lines) == 23
 
 
 @pytest.mark.skipif(sys.platform == 'win32',


### PR DESCRIPTION
DC/OS metadata endpoint will expose a config where the user is able to specify
what logging strategy to use. We should be using `dcos-log` API only if user
explicitly disables sandbox logging.
https://github.com/dcos/dcos/pull/1259