### PR TITLE
task: add mesos agent ID to `dcos task` table

### DIFF
--- a/cli/dcoscli/tables.py
+++ b/cli/dcoscli/tables.py
@@ -40,12 +40,14 @@ def task_table(tasks):
         ("USER", lambda t: t.user()),
         ("STATE", lambda t: t["state"].split("_")[-1][0]),
         ("ID", lambda t: t["id"]),
+        ("MESOS ID", lambda t: t["slave_id"]),
     ])
 
     tb = table(fields, tasks, sortby="NAME")
     tb.align["NAME"] = "l"
     tb.align["HOST"] = "l"
     tb.align["ID"] = "l"
+    tb.align["MESOS ID"] = "l"
 
     return tb
 

--- a/cli/tests/unit/data/task.txt
+++ b/cli/tests/unit/data/task.txt
@@ -1,2 +1,2 @@
-NAME      HOST           USER  STATE  ID                                             
-test-app  mock-hostname  root    R    test-app.d44dd7f2-f9b7-11e4-bb43-56847afe9799  
+NAME      HOST           USER  STATE  ID                                             MESOS ID                                
+test-app  mock-hostname  root    R    test-app.d44dd7f2-f9b7-11e4-bb43-56847afe9799  20150513-185808-177048842-5050-1220-S0  


### PR DESCRIPTION
This makes it easy to see a task, and ssh into the agent using either the private ip or the mesos id.