### PR TITLE
Set exception cause for proper traceback of requests.

### DIFF
--- a/dcos/rpcclient.py
+++ b/dcos/rpcclient.py
@@ -127,8 +127,7 @@ class RpcClient(object):
             return method_fn(url, *args, **kwargs)
         except DCOSHTTPException as e:
             text = _get_response_text(e.response)
-            logger.error('DCOS Error: %s\n%s',
-                         e.response.reason, text)
+            logger.exception('DCOS Error: %s\n%s', e.response.reason, text)
 
             try:
                 json_body = e.response.json()

--- a/dcos/rpcclient.py
+++ b/dcos/rpcclient.py
@@ -145,7 +145,8 @@ class RpcClient(object):
                 request_method=e.response.request.method,
                 request_url=e.response.request.url,
                 json_body=json_body)
-            raise DCOSException(message)
+
+            raise DCOSException(message) from e
 
 
 def _get_response_text(response):

--- a/dcos/rpcclient.py
+++ b/dcos/rpcclient.py
@@ -103,7 +103,7 @@ class RpcClient(object):
         return 'Error: {}'.format(message)
 
     def http_req(self, method_fn, path, *args, **kwargs):
-        """Make an HTTP request, and raise a DCOS-specific exception for
+        """Make an HTTP request, and raise a DC/OS-specific exception for
         HTTP error codes.
 
         :param method_fn: function to call that invokes a specific HTTP method
@@ -127,7 +127,7 @@ class RpcClient(object):
             return method_fn(url, *args, **kwargs)
         except DCOSHTTPException as e:
             text = _get_response_text(e.response)
-            logger.exception('DCOS Error: %s\n%s', e.response.reason, text)
+            logger.exception('DC/OS Error: %s\n%s', e.response.reason, text)
 
             try:
                 json_body = e.response.json()


### PR DESCRIPTION
Exceptions would be swollowed in `dcos.rpcclient.http_req`. This changes adds an
exception cause according to PEP-3134. Closes VELOCITY-1289.