### PR TITLE
.gitignore: Add .cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pydoc/_build/
 .ropeproject/
 .tox/
 .coverage
+.cache
 
 *.pyc
 


### PR DESCRIPTION
I think these `.cache` directories are coming from newer versions of `py.test`, which [cache info about test runs](http://doc.pytest.org/en/latest/cache.html).

```
$ git status
On branch master
Your branch is up-to-date with 'upstream/master'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	.cache/
	cli/.cache/
```