### PR TITLE
dcos node: Add --masters option

### DIFF
--- a/cli/dcoscli/data/help/node.txt
+++ b/cli/dcoscli/data/help/node.txt
@@ -4,7 +4,7 @@ Description:
 Usage:
     dcos node --help
     dcos node --info
-    dcos node [--json]
+    dcos node [--json] [--masters]
     dcos node --version
     dcos node diagnostics (--list | --status | --cancel) [--json]
     dcos node diagnostics create (<nodes>)...

--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -115,7 +115,7 @@ def _cmds():
 
         cmds.Command(
             hierarchy=['node'],
-            arg_keys=['--json'],
+            arg_keys=['--json', '--masters'],
             function=_list)
     ]
 
@@ -458,7 +458,7 @@ def _info():
     return 0
 
 
-def _list(json_):
+def _list(json_, masters):
     """List DC/OS nodes
 
     :param json_: If true, output json.
@@ -469,6 +469,18 @@ def _list(json_):
     """
 
     client = mesos.DCOSClient()
+    if masters:
+        masters = mesos.MesosDNSClient().hosts('master.mesos.')
+        if json_:
+            emitter.publish(masters)
+        else:
+            table = tables.master_table(masters)
+            output = six.text_type(table)
+            if output:
+                emitter.publish(output)
+            else:
+                emitter.publish(errors.DefaultError('No masters found.'))
+        return
     slaves = client.get_state_summary()['slaves']
     if json_:
         emitter.publish(slaves)

--- a/cli/dcoscli/tables.py
+++ b/cli/dcoscli/tables.py
@@ -853,6 +853,23 @@ def slave_table(slaves):
     return tb
 
 
+def master_table(masters):
+    """Returns a PrettyTable representation of the provided DC/OS masters
+
+    :param masters: masters to render.  dicts from /mesos/state-summary
+    :type masters: [dict]
+    :rtype: PrettyTable
+    """
+
+    fields = OrderedDict([
+        ('HOSTNAME', lambda s: s['host']),
+        ('IP', lambda s: s['ip']),
+    ])
+
+    tb = table(fields, masters, sortby="HOSTNAME")
+    return tb
+
+
 def _format_unix_timestamp(ts):
     """ Formats a unix timestamp in a `dcos task ls --long` format.
 


### PR DESCRIPTION
AFAICT `dcos node` currently can only give info about agents. This seeks to rectify that:

```
$ dcos node --masters
   HOSTNAME         IP
master.mesos.  10.10.11.179
master.mesos.  10.10.12.68
master.mesos.  10.10.13.72

$ dcos node --masters --json
[
  {
    "host": "master.mesos.",
    "ip": "10.10.12.68"
  },
  {
    "host": "master.mesos.",
    "ip": "10.10.13.72"
  },
  {
    "host": "master.mesos.",
    "ip": "10.10.11.179"
  }
]
```

Cc: @matthewdfuller, @bossjones