### PR TITLE
dcos node: Add --field option

### DIFF
--- a/cli/dcoscli/data/help/node.txt
+++ b/cli/dcoscli/data/help/node.txt
@@ -53,8 +53,8 @@ Options:
     --config-file=<path>
         Path to SSH configuration file.
     --field=<field>
-        Name of field to include in the output of `dcos node`
-        [Default: HOSTNAME IP ID]
+        Name of extra field to include in the output of `dcos node`.
+        Can be repeated multiple times to add several fields.
     --filter=<filter>
         Filter logs by field and value. Filter must be a string separated by colon.
         For example: --filter _PID:0 --filter _UID:1.

--- a/cli/dcoscli/data/help/node.txt
+++ b/cli/dcoscli/data/help/node.txt
@@ -4,7 +4,7 @@ Description:
 Usage:
     dcos node --help
     dcos node --info
-    dcos node [--json]
+    dcos node [--json | --field=<field>...]
     dcos node --version
     dcos node diagnostics (--list | --status | --cancel) [--json]
     dcos node diagnostics create (<nodes>)...
@@ -52,6 +52,9 @@ Options:
         Show DC/OS component logs.
     --config-file=<path>
         Path to SSH configuration file.
+    --field=<field>
+        Name of field to include in the output of `dcos node`
+        [Default: HOSTNAME IP ID]
     --filter=<filter>
         Filter logs by field and value. Filter must be a string separated by colon.
         For example: --filter _PID:0 --filter _UID:1.

--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -458,7 +458,7 @@ def _info():
     return 0
 
 
-def _list(json_, field_names):
+def _list(json_, extra_field_names):
     """List DC/OS nodes
 
     :param json_: If true, output json.
@@ -473,7 +473,7 @@ def _list(json_, field_names):
     if json_:
         emitter.publish(slaves)
     else:
-        table = tables.slave_table(slaves, field_names)
+        table = tables.slave_table(slaves, extra_field_names)
         output = six.text_type(table)
         if output:
             emitter.publish(output)

--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -464,6 +464,9 @@ def _list(json_, extra_field_names):
     :param json_: If true, output json.
         Otherwise, output a human readable table.
     :type json_: bool
+    :param extra_field_names: List of additional field names to include in
+        table output
+    :type extra_field_names: [str]
     :returns: process return code
     :rtype: int
     """

--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -478,12 +478,13 @@ def _list(json_, extra_field_names):
     else:
         for extra_field_name in extra_field_names:
             field_name = extra_field_name.split(':')[-1]
-            try:
-                tables._dotted_itemgetter(field_name)(slaves[0])
-            except KeyError:
-                emitter.publish(errors.DefaultError(
-                    'Field "%s" is invalid.' % field_name))
-                return
+            if len(slaves) > 0:
+                try:
+                    tables._dotted_itemgetter(field_name)(slaves[0])
+                except KeyError:
+                    emitter.publish(errors.DefaultError(
+                        'Field "%s" is invalid.' % field_name))
+                    return
         table = tables.slave_table(slaves, extra_field_names)
         output = six.text_type(table)
         if output:

--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -476,6 +476,14 @@ def _list(json_, extra_field_names):
     if json_:
         emitter.publish(slaves)
     else:
+        for extra_field_name in extra_field_names:
+            field_name = extra_field_name.split(':')[-1]
+            try:
+                tables._dotted_itemgetter(field_name)(slaves[0])
+            except KeyError:
+                emitter.publish(errors.DefaultError(
+                    'Field "%s" is invalid.' % field_name))
+                return
         table = tables.slave_table(slaves, extra_field_names)
         output = six.text_type(table)
         if output:

--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -115,7 +115,7 @@ def _cmds():
 
         cmds.Command(
             hierarchy=['node'],
-            arg_keys=['--json'],
+            arg_keys=['--json', '--field'],
             function=_list)
     ]
 
@@ -458,7 +458,7 @@ def _info():
     return 0
 
 
-def _list(json_):
+def _list(json_, field_names):
     """List DC/OS nodes
 
     :param json_: If true, output json.
@@ -473,7 +473,7 @@ def _list(json_):
     if json_:
         emitter.publish(slaves)
     else:
-        table = tables.slave_table(slaves)
+        table = tables.slave_table(slaves, field_names)
         output = six.text_type(table)
         if output:
             emitter.publish(output)

--- a/cli/dcoscli/tables.py
+++ b/cli/dcoscli/tables.py
@@ -1017,7 +1017,10 @@ def truncate_table(fields, objs, limits, **kwargs):
         :type function: function
         :rtype: PrettyTable
         """
-        result = str(function(obj))
+        try:
+            result = str(function(obj))
+        except KeyError:
+            result = '???'
         if (limits is not None and limits.get(key) is not None):
             result = textwrap.\
                 shorten(result, width=limits.get(key), placeholder='...')

--- a/cli/dcoscli/tables.py
+++ b/cli/dcoscli/tables.py
@@ -855,14 +855,13 @@ def slave_table(slaves, field_names=()):
     ])
 
     for field_name in field_names:
-        if field_name.lower() == 'ip':
-            fields[field_name.upper()] = lambda s: mesos.parse_pid(s['pid'])[1]
+        if field_name.upper() in fields:
+            continue
+        if ':' in field_name:
+            heading, field_name = field_name.split(':', 1)
         else:
-            if ':' in field_name:
-                heading, field_name = field_name.split(':', 1)
-            else:
-                heading = field_name
-            fields[heading.upper()] = _dotted_itemgetter(field_name.lower())
+            heading = field_name
+        fields[heading.upper()] = _dotted_itemgetter(field_name.lower())
 
     sortby = list(fields.keys())[0]
     kwargs = {}

--- a/cli/dcoscli/tables.py
+++ b/cli/dcoscli/tables.py
@@ -873,6 +873,25 @@ def slave_table(slaves, field_names=()):
 
 
 def _dotted_itemgetter(field_name):
+    """Returns a func that gets the value in a nested dict where the
+    `field_name` is a dotted path to the key.
+
+    Example:
+
+      >>> from dcoscli.tables import _dotted_itemgetter
+      >>> d1 = {'a': {'b': {'c': 21}}}
+      >>> d2 = {'a': {'b': {'c': 22}}}
+      >>> func = _dotted_itemgetter('a.b.c')
+      >>> func(d1)
+      21
+      >>> func(d2)
+      22
+
+    :param field_name: dotted path to key in nested dict
+    :type field_name: str
+    :rtype: callable
+    """
+
     if '.' not in field_name:
         return operator.itemgetter(field_name)
     head, tail = field_name.split('.', 1)

--- a/cli/dcoscli/tables.py
+++ b/cli/dcoscli/tables.py
@@ -1019,7 +1019,7 @@ def truncate_table(fields, objs, limits, **kwargs):
         try:
             result = str(function(obj))
         except KeyError:
-            result = '???'
+            result = 'N/A'
         if (limits is not None and limits.get(key) is not None):
             result = textwrap.\
                 shorten(result, width=limits.get(key), placeholder='...')

--- a/cli/dcoscli/tables.py
+++ b/cli/dcoscli/tables.py
@@ -840,7 +840,7 @@ def auth_provider_table(providers):
     return tb
 
 
-def slave_table(slaves, field_names=('HOSTNAME', 'IP', 'ID')):
+def slave_table(slaves, field_names=()):
     """Returns a PrettyTable representation of the provided DC/OS slaves
 
     :param slaves: slaves to render.  dicts from /mesos/state-summary
@@ -848,7 +848,12 @@ def slave_table(slaves, field_names=('HOSTNAME', 'IP', 'ID')):
     :rtype: PrettyTable
     """
 
-    fields = OrderedDict()
+    fields = OrderedDict([
+        ('HOSTNAME', lambda s: s['hostname']),
+        ('IP', lambda s: mesos.parse_pid(s['pid'])[1]),
+        ('ID', lambda s: s['id'])
+    ])
+
     for field_name in field_names:
         if field_name.lower() == 'ip':
             fields[field_name.upper()] = lambda s: mesos.parse_pid(s['pid'])[1]

--- a/cli/dcoscli/tables.py
+++ b/cli/dcoscli/tables.py
@@ -845,6 +845,8 @@ def slave_table(slaves, field_names=()):
 
     :param slaves: slaves to render.  dicts from /mesos/state-summary
     :type slaves: [dict]
+    :param field_names: Extra fields to add to the table
+    :type slaves: [str]
     :rtype: PrettyTable
     """
 

--- a/cli/dcoscli/tables.py
+++ b/cli/dcoscli/tables.py
@@ -864,10 +864,7 @@ def slave_table(slaves, field_names=()):
         fields[heading.upper()] = _dotted_itemgetter(field_name.lower())
 
     sortby = list(fields.keys())[0]
-    kwargs = {}
-    if sortby.lower() == 'ip':
-        kwargs['sort_key'] = lambda d: tuple(int(x) for x in d[0].split('.'))
-    tb = table(fields, slaves, sortby=sortby, **kwargs)
+    tb = table(fields, slaves, sortby=sortby)
     return tb
 
 

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -46,7 +46,7 @@ def test_node_table():
 
 
 def test_node_table_field_option():
-    returncode, stdout, stderr = exec_command(['dcos', 'node', '--field="disk used:used_resources.disk"'])
+    returncode, stdout, stderr = exec_command(['dcos', 'node', '--field=disk used:used_resources.disk'])
 
     assert returncode == 0
     assert stderr == b''

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -46,7 +46,8 @@ def test_node_table():
 
 
 def test_node_table_field_option():
-    returncode, stdout, stderr = exec_command(['dcos', 'node', '--field=disk_used:used_resources.disk'])
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'node', '--field=disk_used:used_resources.disk'])
 
     assert returncode == 0
     assert stderr == b''

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -52,7 +52,7 @@ def test_node_table_field_option():
     assert returncode == 0
     assert stderr == b''
     lines = stdout.decode('utf-8').splitlines()
-    assert len(lines) > 2
+    assert len(lines) > 1
     assert lines[0].split() == ['HOSTNAME', 'IP', 'ID', 'DISK_USED']
 
 

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -52,7 +52,7 @@ def test_node_table_field_option():
     assert returncode == 0
     assert stderr == b''
     lines = stdout.decode('utf-8').splitlines()
-    assert len(lines) > 1
+    assert len(lines) > 2
     assert lines[0].split() == ['HOSTNAME', 'IP', 'ID', 'DISK_USED']
 
 

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -45,6 +45,14 @@ def test_node_table():
     assert len(stdout.decode('utf-8').split('\n')) > 2
 
 
+def test_node_table_field_option():
+    returncode, stdout, stderr = exec_command(['dcos', 'node', '--field="disk used:used_resources.disk"'])
+
+    assert returncode == 0
+    assert stderr == b''
+    assert len(stdout.decode('utf-8').split('\n')) > 2
+
+
 def test_node_log_empty():
     stderr = b"You must choose one of --leader or --mesos-id.\n"
     assert_command(['dcos', 'node', 'log'], returncode=1, stderr=stderr)

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -46,11 +46,13 @@ def test_node_table():
 
 
 def test_node_table_field_option():
-    returncode, stdout, stderr = exec_command(['dcos', 'node', '--field=disk used:used_resources.disk'])
+    returncode, stdout, stderr = exec_command(['dcos', 'node', '--field=disk_used:used_resources.disk'])
 
     assert returncode == 0
     assert stderr == b''
-    assert len(stdout.decode('utf-8').split('\n')) > 2
+    lines = stdout.decode('utf-8').splitlines()
+    assert len(lines) > 2
+    assert lines[0].split() == ['HOSTNAME', 'IP', 'ID', 'DISK_USED']
 
 
 def test_node_log_empty():


### PR DESCRIPTION
This lets the user control what fields are printed in the table and allows printing arbitary data that wasn't possible to show before, except when using `--json`.

Here's an example of referencing a custom attribute called `ethos_role`:

```
$ dcos node --field=ip --field=id --field=attributes.ethos_role
     IP                          ID                    ATTRIBUTES.ETHOS_ROLE
10.10.3.201   74df965e-a46e-46a9-8d2a-639db0af0e25-S3          public
10.10.12.29   74df965e-a46e-46a9-8d2a-639db0af0e25-S2         control
10.10.12.174  74df965e-a46e-46a9-8d2a-639db0af0e25-S0          worker
10.10.12.237  74df965e-a46e-46a9-8d2a-639db0af0e25-S1          proxy
```

By using a `:` in a field name, you can give it a custom heading in the table.

```
$ dcos node --field=ip --field=id --field=ethos_role:attributes.ethos_role
     IP                          ID                    ETHOS_ROLE
10.10.3.201   74df965e-a46e-46a9-8d2a-639db0af0e25-S3    public
10.10.12.29   74df965e-a46e-46a9-8d2a-639db0af0e25-S2   control
10.10.12.174  74df965e-a46e-46a9-8d2a-639db0af0e25-S0    worker
10.10.12.237  74df965e-a46e-46a9-8d2a-639db0af0e25-S1    proxy
```

Note that the table is always sorted by the first field specified and if it's `ip`, it sorts numerically instead of alphabetically.

One more example:

```
$ dcos node --field=disk\ used:used_resources.disk --field=endpoint:pid --field=version
DISK USED           ENDPOINT           VERSION
   0.0     slave(1)@10.10.3.201:5051    1.0.1
  4096.0   slave(1)@10.10.12.174:5051   1.0.1
  4096.0   slave(1)@10.10.12.237:5051   1.0.1
  5096.0   slave(1)@10.10.12.29:5051    1.0.1
```

Cc: @tamarrow, @matthewdfuller, @bossjones