### PR TITLE
Allow removing multiple repos in one command

### DIFF
--- a/cli/dcoscli/data/help/package.txt
+++ b/cli/dcoscli/data/help/package.txt
@@ -18,7 +18,7 @@ Usage:
     dcos package repo add <repo-name> <repo-url> [--index=<index>]
     dcos package repo import <repos-file>
     dcos package repo list [--json]
-    dcos package repo remove <repo-name>
+    dcos package repo remove <repo-names>...
     dcos package search [<query> --json]
     dcos package uninstall <package-name>
                            [--cli | [--app --app-id=<app-id> --all]]

--- a/cli/dcoscli/package/main.py
+++ b/cli/dcoscli/package/main.py
@@ -65,7 +65,7 @@ def _cmds():
 
         cmds.Command(
             hierarchy=['package', 'repo', 'remove'],
-            arg_keys=['<repo-name>'],
+            arg_keys=['<repo-names>'],
             function=_remove_repo),
 
         cmds.Command(
@@ -232,17 +232,25 @@ def _raise_invalid_repos_file():
         '{"repositories": [{"name": "Universe", "uri": "uri-here"}]}')
 
 
-def _remove_repo(repo_name):
+def _remove_repo(repo_names):
     """Remove package repo and update repo with new repo
 
-    :param repo_name: name to call repo
-    :type repo_name: str
+    :param repo_names: names of repos
+    :type repo_name: str or [str]
     :returns: Process status
     :rtype: int
     """
 
+    try:
+        # Try treating repo_name as a string
+        repo_names = repo_names.split(',')
+    except AttributeError:
+        # Not a string, let's hope it's a list, tuple, etc.
+        pass
+
     package_manager = get_package_manager()
-    package_manager.remove_repo(repo_name)
+    for repo_name in repo_names:
+        package_manager.remove_repo(repo_name)
 
     return 0
 

--- a/cli/dcoscli/package/main.py
+++ b/cli/dcoscli/package/main.py
@@ -236,7 +236,7 @@ def _remove_repo(repo_names):
     """Remove package repo and update repo with new repo
 
     :param repo_names: names of repos
-    :type repo_name: str or [str]
+    :type repo_name: [str]
     :returns: Process status
     :rtype: int
     """

--- a/cli/dcoscli/package/main.py
+++ b/cli/dcoscli/package/main.py
@@ -241,13 +241,6 @@ def _remove_repo(repo_names):
     :rtype: int
     """
 
-    try:
-        # Try treating repo_name as a string
-        repo_names = repo_names.split(',')
-    except AttributeError:
-        # Not a string, let's hope it's a list, tuple, etc.
-        pass
-
     package_manager = get_package_manager()
     for repo_name in repo_names:
         package_manager.remove_repo(repo_name)

--- a/cli/tests/integrations/test_package.py
+++ b/cli/tests/integrations/test_package.py
@@ -110,6 +110,26 @@ def test_repo_remove():
     _repo_remove(['Universe'], repo_list)
 
 
+def test_repo_remove_multi():
+    # Add "Universe" repo so we can test removing it
+    repo_list = bytes("test-universe: {}\nUniverse: {}\n".format(
+        UNIVERSE_TEST_REPO, UNIVERSE_REPO), 'utf-8')
+    args = ["Universe", UNIVERSE_REPO]
+    _repo_add(args, repo_list)
+
+    # Add "1.7-universe" repo so we can test removing it
+    repo17 = "http://universe.mesosphere.com/repo-1.7"
+    repo_list = bytes(
+        "test-universe: {}\n1.7-universe: {}\nUniverse: {}\n".format(
+            UNIVERSE_TEST_REPO, repo17,  UNIVERSE_REPO), 'utf-8')
+    args = ["1.7-universe", repo17, '--index=1']
+    _repo_add(args, repo_list)
+
+    repo_list = bytes(
+        "test-universe: {}\n".format(UNIVERSE_TEST_REPO), 'utf-8')
+    _repo_remove(['1.7-universe', 'Universe'], repo_list)
+
+
 def test_repo_empty():
     assert_command(
         ['dcos', 'package', 'repo', 'remove', 'test-universe'])


### PR DESCRIPTION
e.g.:

```
$ dcos package repo list
ethos-core-universe: https://dcos-private-universe.s3.amazonaws.com/ethos/1.0/unstable/repo/repo-up-to-1.8.json
Universe: https://universe.mesosphere.com/repo

$ dcos package repo remove 'ethos-core-universe' 'Universe'

$ dcos package repo list
There are currently no repos configured. Please use `dcos package repo add` to add a repo
```