### PR TITLE
Implement a `dcos service http` command

### DIFF
--- a/cli/dcoscli/data/help/service.txt
+++ b/cli/dcoscli/data/help/service.txt
@@ -6,11 +6,18 @@ Usage:
     dcos service --info
     dcos service --version
     dcos service [--completed --inactive --json]
+    dcos service [--method=<method>] [--data=<data>]
+                 [--cookie=<data>] [--header=<header>]...
+                 [--output=<file>]
+                 http <service> <request-path>
     dcos service log [--follow --lines=N --ssh-config-file=<path>]
                      <service> [<file>]
     dcos service shutdown <service-id>
 
 Commands:
+    http
+        Do HTTP request to a service.
+
     log
         Print the service logs.
 
@@ -35,6 +42,18 @@ Options:
         Print JSON-formatted list of DC/OS services.
     --lines=N
         Print the last N lines, where 10 is the default.
+    --method=<method>, -X <method>
+        HTTP request method to use (e.g.: "GET", "POST", "PUT", etc.).
+        [default: GET]
+    --data=<data>, -d <data>
+        Data for HTTP POST/PUT/PATCH request body
+    --header=<line>, -H <line>
+        Pass custom header <line> to server
+    --cookie=<data>, -b <data>
+        Pass the data to the HTTP server in the Cookie header.
+        The data should be in the format "NAME1=VALUE1; NAME2=VALUE2".
+    --output=<file>, -o <file>
+        Write output to <file> instead of stdout.
     --ssh-config-file=<path>
         The path to the SSH config file. This is used to access the Marathon
         logs.


### PR DESCRIPTION
that allows user to issue HTTP requests (with authentication applied) to arbitrary services in their DC/OS cluster.

E.g.:

```
$ dcos service http --help
...
    dcos service [--method=<method>] [--data=<data>] [--header=<header>]...
                 http <service> <request-path>
...
Commands:
    http
        Do HTTP request to a service.
...
    --method=<method>, -X <method>
        HTTP request method to use (e.g.: "GET", "POST", "PUT", etc.).
        [default: GET]
    --data=<data>, -d <data>
        Data for HTTP POST/PUT/PATCH request body
    --header=<line>, -H <line>
        Pass custom header <line> to server
...

$ dcos service http httpbin /get
>>> GET http://<redacted host>/service/httpbin/get
{
  "args": {},
  "headers": {
    "Accept": "*/*",
    "Authorization": "token=<redacted token>",
    "Connection": "upgrade",
    "Host": "<redacted host>",
    "User-Agent": "python-requests/2.13.0",
    "Via": "1.1 wsg.sanjose06 C0960B77"
  },
  "origin": "10.10.2.225",
  "url": "http://<redacted host>/get"
}

$ dcos service http metronome v1/metrics | jq -r '.version'
>>> GET http://<redacted host>/service/metronome/v1/metrics
3.0.0

$ dcos service http jenkins computer/api/json | jq '.computer[0].monitorData["hudson.node_monitors.DiskSpaceMonitor"]'
>>> GET http://<redacted host>/service/jenkins/computer/api/json
{
  "_class": "hudson.node_monitors.DiskSpaceMonitorDescriptor$DiskSpace",
  "path": "/var/jenkins_home",
  "size": 3430887424,
  "timestamp": 1489170370576
}
```

Here's a more complex invocation using the `--method` (`-X`), `--data` (`-d`), and `--header` (`-H`) options -- note that the short option names used here were chosen intentionally to mimic those of [`curl`](https://curl.haxx.se/docs/manpage.html), which I figure a lot of people are probably familiar with:

```
$ dcos service http \
    -X PUT \
    -d '{"foo": "bar", "nums": [1, 2, 3]}' \
    -H 'Accept: application/json' \
    -H 'User-Agent: Agent Mulder' \
    -H 'Cookie: chocolate chip' \
    httpbin /put
>>> PUT http://<redacted host>/service/httpbin/put
{
  "args": {},
  "data": "{\"foo\": \"bar\", \"nums\": [1, 2, 3]}",
  "files": {},
  "form": {},
  "headers": {
    "Accept": "application/json",
    "Authorization": "token=<redacted token>",
    "Connection": "upgrade",
    "Content-Length": "33",
    "Cookie": "chocolate chip",
    "Host": "<redacted host>",
    "User-Agent": "Agent Mulder",
    "Via": "1.1 wsg.sanjose05 C0960B89"
  },
  "json": {
    "foo": "bar",
    "nums": [
      1,
      2,
      3
    ]
  },
  "origin": "10.10.2.225",
  "url": "http://<redacted host>/put"
}
```

Under the covers, what it's doing is issuing a request to `/service/<service>/<request-path>` with an `Authorization` header containing a DC/OS token to make the admin proxy happy:

```
$ dcos --debug service http metronome v1/metrics
>>> GET http://<redacted host>/service/metronome/v1/metrics
send: b'GET /service/metronome/v1/metrics HTTP/1.1\r\nHost: <redacted host>\r\nAccept-Encoding: gzip, deflate\r\nAccept: */*\r\nConnection: keep-alive\r\nUser-Agent: python-requests/2.13.0\r\nAuthorization: token=<redacted token>\r\n\r\n'
reply: 'HTTP/1.1 200 OK\r\n'
...
```

Also note that I'm using [httpbin](https://httpbin.org/) installed in my DC/OS cluster for testing. Here's a [PR to add an `httpbin` package to Universe](https://github.com/mesosphere/universe/pull/1003).

Cc: @matthewdfuller, @bossjones, @tamarrow 