### PR TITLE
Update test to reflect metrics interface change

### DIFF
--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -124,7 +124,7 @@ def test_node_metrics_agent_details_json():
     )
 
     names = [d['name'] for d in node_json]
-    assert 'uptime' in names
+    assert 'system.uptime' in names
     assert 'cpu.cores' in names
 
 


### PR DESCRIPTION
dcos/dcos-metrics#77 changed the key for system uptime in the node
metrics data endpoint from `uptime` to `system.uptime`. This had
the side-effect of breaking the CLI integration tests.

Functionality was not affected, but I'll be careful to avoid this in the 
future. Apologies for all the inconvenience caused. 