### PR TITLE
Use stat (not lstat) to check file permissions

### DIFF
--- a/dcos/util.py
+++ b/dcos/util.py
@@ -182,8 +182,10 @@ def enforce_file_permissions(path):
     if sys.platform == 'win32':
         return
     else:
-        permissions = oct(stat.S_IMODE(os.lstat(path).st_mode))
+        permissions = oct(stat.S_IMODE(os.stat(path).st_mode))
         if permissions not in ['0o600', '0600', '0o400', '0400']:
+            if os.path.realpath(path) != path:
+                path = '%s (pointed to by %s)' % (os.path.realpath(path), path)
             msg = (
                 "Permissions '{}' for configuration file '{}' are too open. "
                 "File must only be accessible by owner. "


### PR DESCRIPTION
because for symlinks we should look at the permissions of the file
itself rather than the permissions of the symlink.

To illustrate why, look at the following example in which I make the
symlink read-only to make `dcos` happy, but in fact this is not very
secure, because the symlink is pointing to a world-readable and writable
file.

Before:

```
$ ls -l ~/.dcos/dcos.toml ~/dcos-aws-sandbox.toml
lrwxr-xr-x  1 abramowi  staff   37 Mar 14 08:28 /Users/abramowi/.dcos/dcos.toml@ -> /Users/abramowi/dcos-aws-sandbox.toml
-rwxrwxrwx  1 abramowi  staff  542 Mar 14 08:27 /Users/abramowi/dcos-aws-sandbox.toml*

$ dcos node
Permissions '0o755' for configuration file '/Users/abramowi/.dcos/dcos.toml' are too open. File must only be accessible by owner. Aborting...

$ chmod -h 600 ~/.dcos/dcos.toml

$ ls -l ~/.dcos/dcos.toml ~/dcos-aws-sandbox.toml
lrw-------  1 abramowi  staff   37 Mar 14 08:28 /Users/abramowi/.dcos/dcos.toml@ -> /Users/abramowi/dcos-aws-sandbox.toml
-rwxrwxrwx  1 abramowi  staff  542 Mar 14 08:27 /Users/abramowi/dcos-aws-sandbox.toml*

$ dcos node
  HOSTNAME         IP                          ID
10.10.12.174  10.10.12.174  74df965e-a46e-46a9-8d2a-639db0af0e25-S0
10.10.12.183  10.10.12.183  74df965e-a46e-46a9-8d2a-639db0af0e25-S4
10.10.12.29   10.10.12.29   74df965e-a46e-46a9-8d2a-639db0af0e25-S2
10.10.3.201   10.10.3.201   74df965e-a46e-46a9-8d2a-639db0af0e25-S3
```

After:

```
$ dcos node
Permissions '0o777' for configuration file '/Users/abramowi/dcos-aws-sandbox.toml (pointed to by /Users/abramowi/.dcos/dcos.toml)' are too open. File must only be accessible by owner. Aborting...
```