### PR TITLE
split('\n') => splitlines()

### DIFF
--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -42,7 +42,7 @@ def test_node_table():
 
     assert returncode == 0
     assert stderr == b''
-    assert len(stdout.decode('utf-8').split('\n')) > 2
+    assert len(stdout.decode('utf-8').splitlines()) > 2
 
 
 def test_node_log_empty():


### PR DESCRIPTION
because `splitlines` is smarter about dealing with different line endings.

It will be interesting to see if this test still passes or if it fails on Windows, like the one in #922...