### PR TITLE
Add `dcos config edit` command

### DIFF
--- a/cli/dcoscli/config/main.py
+++ b/cli/dcoscli/config/main.py
@@ -3,10 +3,10 @@ import collections
 import docopt
 
 import dcoscli
-from dcos import cmds, config, emitting, http, util
+from dcos import cmds, config, emitting, http, subprocess, util
 from dcos.errors import DCOSException, DefaultError
 from dcoscli.subcommand import default_command_info, default_doc
-from dcoscli.util import decorate_docopt_usage
+from dcoscli.util import decorate_docopt_usage, edit_file
 
 emitter = emitting.FlatEmitter()
 logger = util.get_logger(__name__)
@@ -58,6 +58,11 @@ def _cmds():
             hierarchy=['config', 'validate'],
             arg_keys=[],
             function=_validate),
+
+        cmds.Command(
+            hierarchy=['config', 'edit'],
+            arg_keys=[],
+            function=_edit),
 
         cmds.Command(
             hierarchy=['config'],
@@ -233,4 +238,25 @@ def _validate():
         return 1
 
     emitter.publish("Congratulations, your configuration is valid!")
+    return 0
+
+
+def _edit():
+    """
+    :returns: process status
+    :rtype: int
+    """
+
+    def validate(config_file_obj):
+        toml_config = config.load_from_path(config_file_obj.name)
+        schema = config.generate_root_schema(toml_config)
+        errs = util.validate_json(toml_config._dictionary, schema)
+        if len(errs) != 0:
+            emitter.publish(util.list_to_err(errs))
+            return False
+        return True
+
+    config_path = config.get_config_path()
+    edit_file(config_path, validate=validate)
+
     return 0

--- a/cli/dcoscli/data/help/config.txt
+++ b/cli/dcoscli/data/help/config.txt
@@ -9,6 +9,7 @@ Usage:
     dcos config show [<name>]
     dcos config unset <name>
     dcos config validate
+    dcos config edit
 
 Commands:
     set
@@ -22,6 +23,8 @@ Commands:
         Remove a property from the configuration file.
     validate
         Validate changes to the configuration file.
+    edit
+        Open configuration file with $EDITOR and then validate it.
 
 Options:
     -h, --help

--- a/cli/dcoscli/util.py
+++ b/cli/dcoscli/util.py
@@ -1,8 +1,11 @@
 from functools import wraps
+import os
+from shutil import copyfile
+from tempfile import NamedTemporaryFile
 
 import docopt
 
-from dcos import emitting
+from dcos import emitting, subprocess
 
 emitter = emitting.FlatEmitter()
 
@@ -26,3 +29,23 @@ def decorate_docopt_usage(func):
             return 1
         return result
     return wrapper
+
+
+def edit_file(filename, validate=None):
+    with NamedTemporaryFile() as temp_file_obj:
+        copyfile(filename, temp_file_obj.name)
+
+        editor = os.environ.get('EDITOR', 'vi')
+        cmd = '%s %s' % (editor, temp_file_obj.name)
+        emitter.publish('Executing: %s' % cmd)
+        subprocess.Subproc().call(cmd, shell=True)
+
+        if validate:
+            if not validate(temp_file_obj):
+                emitter.publish(
+                    'File %s failed validation check. Not updating %s.'
+                    % (temp_file_obj.name, filename))
+                return False
+
+        copyfile(temp_file_obj.name, filename)
+        emitter.publish('Updated file: %s' % filename)


### PR DESCRIPTION
which opens temporary file copy of config file with `$EDITOR` and only updates the real config file if validation succeeds.

Happy path, when the edits result in a valid config file:

```
$ dcos config edit
Executing: vim /var/folders/3b/sf0lrb1d69v8gfr8gvzxyy0h0000gn/T/tmp_rfx8308
Updated file: /Users/abramowi/.dcos/dcos.toml
```

Sad path, when user used some unknown parameter:

```
$ dcos config edit
Executing: vim /var/folders/3b/sf0lrb1d69v8gfr8gvzxyy0h0000gn/T/tmpzi8i4xpb
Error: Additional properties are not allowed ('some_unknown_param' was unexpected)
Path: core
Value: {"some_unknown_param": "blah", ...}
File /var/folders/3b/sf0lrb1d69v8gfr8gvzxyy0h0000gn/T/tmpzi8i4xpb failed validation check. Not updating /Users/abramowi/.dcos/dcos.toml.
```

I implemented `dcoscli.util.edit_file` as a (hopefully reusable) util function, because I noticed there are some places in the code where it mentioned that opening with an editor would be a useful future addition.