### PR TITLE
Show path of config file we're validating

### DIFF
--- a/cli/dcoscli/config/main.py
+++ b/cli/dcoscli/config/main.py
@@ -226,6 +226,7 @@ def _validate():
 
     toml_config = config.get_config(True)
 
+    emitter.publish('Validating %s ...' % config.get_config_path())
     errs = util.validate_json(toml_config._dictionary,
                               config.generate_root_schema(toml_config))
     if len(errs) != 0:

--- a/cli/tests/integrations/test_config.py
+++ b/cli/tests/integrations/test_config.py
@@ -4,7 +4,7 @@ import os
 import pytest
 import six
 
-from dcos import constants
+from dcos import config, constants
 
 from .helpers.common import (assert_command, config_set, config_unset,
                              exec_command, update_config)
@@ -191,7 +191,10 @@ def test_unset_top_property(env):
 
 
 def test_validate(env):
-    stdout = b'Congratulations, your configuration is valid!\n'
+    os.environ['DCOS_CONFIG'] = env['DCOS_CONFIG']
+    stdout = 'Validating %s ...\n' % config.get_config_path() + \
+             'Congratulations, your configuration is valid!\n'
+    stdout = stdout.encode('utf-8')
     assert_command(['dcos', 'config', 'validate'],
                    env=env, stdout=stdout)
 


### PR DESCRIPTION
so we know what the active config file is:

```
$ dcos config validate
Validating /Users/abramowi/.dcos/dcos.toml ...
Congratulations, your configuration is valid!

$ dcos config validate
Validating /Users/abramowi/.dcos/dcos.toml ...
Error: Additional properties are not allowed ('prompt_login' was unexpected)
Path: core
Value: {"prompt_login": true, ...}
```