### PR TITLE
Move PyJWT dep from cli/setup.py to setup.py

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -66,7 +66,6 @@ setup(
     install_requires=[
         'dcos=={}'.format(dcoscli.version),
         'docopt>=0.6, <1.0',
-        'PyJWT==1.4.2',
         'pkginfo==1.2.1',
         'toml>=0.9, <1.0',
         'virtualenv>=13.0, <16.0',

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         'jsonschema>=2.5, <3.0',
         'pager>=3.3, <4.0',
         'prettytable>=0.7, <1.0',
+        'PyJWT==1.4.2',
         'pygments>=2.0, <3.0',
         'requests>=2.6, <3.0',
         'six>=1.9, <2.0',


### PR DESCRIPTION
because `jwt` is used only in `dcos/auth.py`

In fact, it looks like it's only used in `dcos/auth.py` and not used at all in `dcos/cli`:

```
$ ag --ignore=tests --ignore=env --ignore=venv jwt --ignore='*.egg-info'
cli/setup.py
69:        'PyJWT==1.4.2',

dcos/auth.py
7:import jwt
21:       'acsjwt' (DC/OS acs auth), 'oauthjwt' (DC/OS acs oauth), or
33:                       if auth_type.rstrip().lower().startswith("acsjwt") or
34:                       auth_type.rstrip().lower().startswith("oauthjwt")),
42:                   "'{}', DC/OS only supports ['oauthjwt', 'acsjwt']".format(
89:    jwt token encoded with private key).
257:        'token': jwt.encode(
323:            if auth_scheme == "oauthjwt":
325:            # auth_scheme == "acsjwt"
```

so I think the dependency should be moved.