### PR TITLE
tests: don't use DCOS_CONFIG

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,8 +99,6 @@ make sure you set owner only permissions on these files:
 
 :code:`chmod 600 cli/tests/data/dcos.toml`
 
-:code:`chmod 600 cli/tests/data/config/parse_error.toml`
-
 The :code:`node` integration tests use :code:`CLI_TEST_SSH_KEY_PATH` for ssh
 credentials to your cluster.
 
@@ -116,10 +114,6 @@ Running
 
 Tox will run unit and integration tests in Python 3.5 using a temporarily
 created virtualenv.
-
-You can set :code:`DCOS_CONFIG` to a config file that points to a DC/OS
-cluster you want to use for integration tests. This defaults to
-:code:`~/.dcos/dcos.toml`
 
 Note that in order for all the integration tests to pass, your DC/OS cluster
 must have the experimental packaging features enabled. In order to enable

--- a/cli/bin/test.sh
+++ b/cli/bin/test.sh
@@ -11,6 +11,5 @@ fi
 echo "Virtualenv activated."
 
 chmod 600 $BASEDIR/tests/data/dcos.toml
-chmod 600 $BASEDIR/tests/data/config/parse_error.toml
 
 tox

--- a/cli/tests/data/config/invalid_section.toml
+++ b/cli/tests/data/config/invalid_section.toml
@@ -1,2 +1,0 @@
-[foo]
-bar = "baz"

--- a/cli/tests/data/config/parse_error.toml
+++ b/cli/tests/data/config/parse_error.toml
@@ -1,2 +1,0 @@
-header]
-key=value

--- a/cli/tests/integrations/test_auth.py
+++ b/cli/tests/integrations/test_auth.py
@@ -10,10 +10,7 @@ from .helpers.common import assert_command, exec_command, update_config
 @pytest.fixture
 def env():
     r = os.environ.copy()
-    r.update({
-        constants.PATH_ENV: os.environ[constants.PATH_ENV],
-        constants.DCOS_CONFIG_ENV: os.path.join("tests", "data", "dcos.toml"),
-    })
+    r.update({constants.PATH_ENV: os.environ[constants.PATH_ENV]})
 
     return r
 

--- a/cli/tests/integrations/test_config.py
+++ b/cli/tests/integrations/test_config.py
@@ -13,10 +13,7 @@ from .helpers.common import (assert_command, config_set, config_unset,
 @pytest.fixture
 def env():
     r = os.environ.copy()
-    r.update({
-        constants.PATH_ENV: os.environ[constants.PATH_ENV],
-        constants.DCOS_CONFIG_ENV: os.path.join("tests", "data", "dcos.toml"),
-    })
+    r.update({constants.PATH_ENV: os.environ[constants.PATH_ENV]})
 
     return r
 
@@ -148,15 +145,6 @@ def test_set_nonexistent_subcommand(env):
         stderr=b"'foo' is not a dcos command.\n",
         returncode=1,
         env=env)
-
-
-def test_set_when_extra_section(env):
-    path = os.path.join('tests', 'data', 'config', 'invalid_section.toml')
-    env['DCOS_CONFIG'] = path
-    os.chmod(path, 0o600)
-
-    config_set('core.dcos_url', 'http://dcos.snakeoil.mesosphere.com', env)
-    config_unset('core.dcos_url', env)
 
 
 def test_unset_property(env):
@@ -295,19 +283,6 @@ def test_timeout(env):
             assert returncode == 1
             assert stdout == b''
             assert "(connect timeout=1)".encode('utf-8') in stderr
-
-
-def test_parse_error(env):
-    path = os.path.join('tests', 'data', 'config', 'parse_error.toml')
-    os.chmod(path, 0o600)
-    env['DCOS_CONFIG'] = path
-
-    assert_command(['dcos', 'config', 'show'],
-                   returncode=1,
-                   stderr=six.b(("Error parsing config file at [{}]: Found "
-                                 "invalid character in key name: ']'. "
-                                 "Try quoting the key name.\n").format(path)),
-                   env=env)
 
 
 def _fail_url_validation(command, key, value, env):

--- a/cli/tests/integrations/test_job.py
+++ b/cli/tests/integrations/test_job.py
@@ -29,10 +29,7 @@ def test_info():
 @pytest.fixture
 def env():
     r = os.environ.copy()
-    r.update({
-        constants.PATH_ENV: os.environ[constants.PATH_ENV],
-        constants.DCOS_CONFIG_ENV: os.path.join("tests", "data", "dcos.toml"),
-    })
+    r.update({constants.PATH_ENV: os.environ[constants.PATH_ENV]})
 
     return r
 

--- a/cli/tests/integrations/test_marathon.py
+++ b/cli/tests/integrations/test_marathon.py
@@ -50,10 +50,7 @@ def test_about():
 @pytest.fixture
 def env():
     r = os.environ.copy()
-    r.update({
-        constants.PATH_ENV: os.environ[constants.PATH_ENV],
-        constants.DCOS_CONFIG_ENV: os.path.join("tests", "data", "dcos.toml"),
-    })
+    r.update({constants.PATH_ENV: os.environ[constants.PATH_ENV]})
 
     return r
 

--- a/cli/tests/integrations/test_package.py
+++ b/cli/tests/integrations/test_package.py
@@ -23,10 +23,7 @@ from ..common import file_bytes
 @pytest.fixture
 def env():
     r = os.environ.copy()
-    r.update({
-        constants.PATH_ENV: os.environ[constants.PATH_ENV],
-        constants.DCOS_CONFIG_ENV: os.path.join("tests", "data", "dcos.toml"),
-    })
+    r.update({constants.PATH_ENV: os.environ[constants.PATH_ENV]})
 
     return r
 

--- a/cli/tests/integrations/test_ssl.py
+++ b/cli/tests/integrations/test_ssl.py
@@ -12,7 +12,6 @@ def env():
     r = os.environ.copy()
     r.update({
         constants.PATH_ENV: os.environ[constants.PATH_ENV],
-        constants.DCOS_CONFIG_ENV: os.path.join("tests", "data", "dcos.toml"),
         'DCOS_SNAKEOIL_CRT_PATH': os.environ.get(
             "DCOS_SNAKEOIL_CRT_PATH", "/dcos-cli/adminrouter/snakeoil.crt")
     })


### PR DESCRIPTION
Now that clusters are managed by the CLI we should use it instead of
relying on using DCOS_CONFIG to point to the correct config.