### PR TITLE
Fixes DCOS-14685: CLI was not able to kill a running metronome job

### DIFF
--- a/cli/dcoscli/data/help/job.txt
+++ b/cli/dcoscli/data/help/job.txt
@@ -10,7 +10,7 @@ Description:
         dcos job remove <job-id> [--stop-current-job-runs]
         dcos job show <job-id>
         dcos job update <job-file>
-        dcos job kill <job-id> [run-id][--all]
+        dcos job kill <job-id> [<run-id>][--all]
         dcos job run <job-id>
         dcos job list [--json]
         dcos job schedule add <job-id> <schedule-file>

--- a/cli/dcoscli/job/main.py
+++ b/cli/dcoscli/job/main.py
@@ -226,7 +226,7 @@ def _kill(job_id, run_id, all=False):
     client = metronome.create_client()
     for dead in deadpool:
         try:
-            client.kill_run(job_id, run_id)
+            client.kill_run(job_id, dead)
         except DCOSHTTPException as e:
             if e.response.status_code == 404:
                 raise DCOSException("Job ID or Run ID does NOT exist.")

--- a/cli/dcoscli/job/main.py
+++ b/cli/dcoscli/job/main.py
@@ -216,7 +216,6 @@ def _kill(job_id, run_id, all=False):
     :returns: process return code
     :rtype: int
     """
-    response = None
     deadpool = []
     if run_id is None and all is True:
         deadpool = _get_ids(_get_runs(job_id))
@@ -234,9 +233,8 @@ def _kill(job_id, run_id, all=False):
             raise DCOSException("Unable stop run ID '{}' for job ID '{}'"
                                 .format(dead, job_id))
         else:
-            if response.status_code == 200:
-                emitter.publish("Run '{}' for job '{}' killed."
-                                .format(dead, job_id))
+            emitter.publish("Run '{}' for job '{}' killed."
+                            .format(dead, job_id))
     return 0
 
 


### PR DESCRIPTION
Refactoring in https://github.com/dcos/dcos-cli/pull/826 introduced wrapper classes for metronome, but broke functionality to kill a currently running job. This issue was described in https://jira.mesosphere.com/browse/DCOS-14685.

The problematic lines are 229 to 231 in this diff: https://github.com/dcos/dcos-cli/pull/826/files#diff-7779ca4ca7c5274182e7ca22c94ff4e2L229. You see that `dead` iterator variable was used and that `response` was assigned before the PR was merged.

By the way I fixed the broken functionality to kill a job run directly through providing run-id. For example via `dcos job kill longsleep 20170322093250yxIvK`.

Walk through with one running job, two running jobs and dedicated kill of a particular job looks like:
```
Johanness-MacBook-Pro:cli junterstein$ dcos job kill longsleep --all
Run '20170322101442uKapt' for job 'longsleep' killed.
Johanness-MacBook-Pro:cli junterstein$ dcos job kill longsleep --all
Run '20170322101509tLSfQ' for job 'longsleep' killed.
Run '20170322101506p358y' for job 'longsleep' killed.
Johanness-MacBook-Pro:cli junterstein$ dcos job kill longsleep 20170322101529b3yeh
Run '20170322101529b3yeh' for job 'longsleep' killed.
Johanness-MacBook-Pro:cli junterstein$ 
```