### PR TITLE
node: Allow showing non-lowercase fields

### DIFF
--- a/cli/dcoscli/tables.py
+++ b/cli/dcoscli/tables.py
@@ -894,7 +894,7 @@ def node_table(nodes, field_names=()):
             heading, field_name = field_name.split(':', 1)
         else:
             heading = field_name
-        fields[heading.upper()] = _dotted_itemgetter(field_name.lower())
+        fields[heading.upper()] = _dotted_itemgetter(field_name)
 
     sortby = list(fields.keys())[0]
     tb = table(fields, nodes, sortby=sortby)

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -57,6 +57,17 @@ def test_node_table_field_option():
     assert lines[0].split() == ['HOSTNAME', 'IP', 'ID', 'TYPE', 'DISK_USED']
 
 
+def test_node_table_uppercase_field_option():
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'node', '--field=TASK_RUNNING'])
+
+    assert returncode == 0
+    assert stderr == b''
+    lines = stdout.decode('utf-8').splitlines()
+    assert len(lines) > 2
+    assert lines[0].split() == ['HOSTNAME', 'IP', 'ID', 'TYPE', 'TASK_RUNNING']
+
+
 def test_node_log_empty():
     stderr = b"You must choose one of --leader or --mesos-id.\n"
     assert_command(['dcos', 'node', 'log'], returncode=1, stderr=stderr)


### PR DESCRIPTION
like `TASK_RUNNING` for example.

```
$ dcos node --field=TASK_RUNNING
  HOSTNAME         IP                          ID                    TASK_RUNNING
10.10.12.174  10.10.12.174  74df965e-a46e-46a9-8d2a-639db0af0e25-S0       11
10.10.12.183  10.10.12.183  74df965e-a46e-46a9-8d2a-639db0af0e25-S4       6
10.10.12.29   10.10.12.29   74df965e-a46e-46a9-8d2a-639db0af0e25-S2       8
10.10.3.201   10.10.3.201   74df965e-a46e-46a9-8d2a-639db0af0e25-S3       0
```