### PR TITLE
tox.ini: Remove -x flag for unit tests

### DIFF
--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -33,7 +33,7 @@ commands =
 
 [testenv:py35-integration]
 commands =
-  py.test -p no:cacheprovider -vv -x {env:CI_FLAGS:} tests/integrations{posargs}
+  py.test -p no:cacheprovider -vv {env:CI_FLAGS:} tests/integrations{posargs}
 
 [testenv:py35-unit]
 commands =


### PR DESCRIPTION
The `-x` makes py.test abort the test run after the first failure. While this makes the tests fail faster , it is inconvenient if there many tests that are failing, because you will only see 1 test failure and you will have to fix each failure one at a time.