### PR TITLE
config: add deprecation notice for `dcos config set core.dcos_url`

### DIFF
--- a/cli/dcoscli/config/main.py
+++ b/cli/dcoscli/config/main.py
@@ -88,9 +88,14 @@ def _set(name, value):
         notice = ("This config property has been deprecated. "
                   "Please add your repositories with `dcos package repo add`")
         return DCOSException(notice)
-    if name == "core.email":
+    elif name == "core.email":
         notice = "This config property has been deprecated."
         return DCOSException(notice)
+    elif name == "core.dcos_url":
+        notice = ("This config property is being deprecated. "
+                  "To setup the CLI to talk to your cluster, please run "
+                  "`dcos cluster setup <dcos_url>`.")
+        emitter.publish(DefaultError(notice))
 
     toml, msg = config.set_val(name, value)
     emitter.publish(DefaultError(msg))

--- a/cli/tests/integrations/test_config.py
+++ b/cli/tests/integrations/test_config.py
@@ -60,7 +60,10 @@ def test_get_missing_property(env):
 def test_dcos_url_without_scheme(env):
     with update_config("core.dcos_url", None, env):
         new = b"abc.com"
-        out = b"[core.dcos_url]: set to 'https://%b'\n" % (new)
+        out = (b"This config property is being deprecated. "
+               b"To setup the CLI to talk to your cluster, please run "
+               b"`dcos cluster setup <dcos_url>`.\n"
+               b"[core.dcos_url]: set to 'https://%b'\n" % (new))
         assert_command(
             ['dcos', 'config', 'set', 'core.dcos_url', new.decode('utf-8')],
             stderr=out,
@@ -130,11 +133,14 @@ def test_set_same_output(env):
 
 def test_set_new_output(env):
     with update_config("core.dcos_url", None, env):
+        new = b"http://dcos.snakeoil.mesosphere.com:5081"
+        out = (b"This config property is being deprecated. "
+               b"To setup the CLI to talk to your cluster, please run "
+               b"`dcos cluster setup <dcos_url>`.\n"
+               b"[core.dcos_url]: set to '%b'\n" % (new))
         assert_command(
-            ['dcos', 'config', 'set', 'core.dcos_url',
-                'http://dcos.snakeoil.mesosphere.com:5081'],
-            stderr=(b"[core.dcos_url]: set to "
-                    b"'http://dcos.snakeoil.mesosphere.com:5081'\n"),
+            ['dcos', 'config', 'set', 'core.dcos_url', new.decode('utf-8')],
+            stderr=out,
             env=env)
 
 
@@ -294,8 +300,8 @@ def _fail_url_validation(command, key, value, env):
 
     assert returncode_ == 1
     assert stdout_ == b''
-    assert stderr_.startswith(str(
-        'Unable to parse {!r} as a url'.format(value)).encode('utf-8'))
+    err = str('Unable to parse {!r} as a url'.format(value)).encode('utf-8')
+    assert err in stderr_
 
 
 def _get_value(key, value, env):

--- a/dcos/config.py
+++ b/dcos/config.py
@@ -248,8 +248,7 @@ def set_val(name, value):
         msg += "changed from '{}' to '{}'".format(old_value, new_value)
 
     if token_unset:
-        msg += ("\n[core.dcos_acs_token]: removed\n"
-                "Please run `dcos auth login` to authenticate to new dcos_url")
+        msg += "\n[core.dcos_acs_token]: removed"
 
     return toml_config, msg
 


### PR DESCRIPTION
To setup a cluster, we should now be using `dcos cluster setup
<dcos_url>` and not have to mess with the config properties.