### PR TITLE
package: add --global option for CLIs in `package install`

### DIFF
--- a/cli/dcoscli/data/help/package.txt
+++ b/cli/dcoscli/data/help/package.txt
@@ -10,7 +10,7 @@ Usage:
                           [--package-version=<package-version>]
     dcos package describe <package-name> --package-versions
     dcos package install <package-name>
-                         [--cli | [--app --app-id=<app-id>]]
+                         [(--cli [--global]) | [--app --app-id=<app-id>]]
                          [--package-version=<package-version>]
                          [--options=<file>]
                          [--yes]
@@ -57,6 +57,8 @@ Options:
         Command line only.
     --config
         Print the configurable properties of the `marathon.json` file.
+    --global
+        Install a subcommand for all configured clusters
     --index=<index>
         The numerical position in the package repository list. Package
         repositories are searched in descending order. By default, the Universe

--- a/cli/dcoscli/package/main.py
+++ b/cli/dcoscli/package/main.py
@@ -78,7 +78,7 @@ def _cmds():
         cmds.Command(
             hierarchy=['package', 'install'],
             arg_keys=['<package-name>', '--package-version', '--options',
-                      '--app-id', '--cli', '--app', '--yes'],
+                      '--app-id', '--cli', '--global', '--app', '--yes'],
             function=_install),
 
         cmds.Command(
@@ -316,8 +316,8 @@ def _describe(package_name,
     return 0
 
 
-def _install(package_name, package_version, options_path, app_id, cli, app,
-             yes):
+def _install(package_name, package_version, options_path, app_id, cli,
+             global_, app, yes):
     """Install the specified package.
 
     :param package_name: the package to install
@@ -330,6 +330,8 @@ def _install(package_name, package_version, options_path, app_id, cli, app,
     :type app_id: str
     :param cli: indicates if the cli should be installed
     :type cli: bool
+    :param global_: indicates that the cli should be installed globally
+    :type global_: bool
     :param app: indicate if the application should be installed
     :type app: bool
     :param yes: automatically assume yes to all prompts
@@ -378,7 +380,7 @@ def _install(package_name, package_version, options_path, app_id, cli, app,
             pkg.name(), pkg.version())
         emitter.publish(msg)
 
-        subcommand.install(pkg)
+        subcommand.install(pkg, global_)
 
         subcommand_paths = subcommand.get_package_commands(package_name)
         new_commands = [os.path.basename(p).replace('-', ' ', 1)

--- a/cli/tests/integrations/test_package.py
+++ b/cli/tests/integrations/test_package.py
@@ -669,6 +669,18 @@ def test_list_cli_only(env):
             stdout=helloworld_json)
 
 
+def test_cli_global():
+    helloworld_path = 'tests/data/package/json/test_list_helloworld_cli.json'
+    helloworld_json = file_json(helloworld_path)
+
+    with _helloworld_cli(global_=True):
+        assert os.path.exists(subcommand.global_package_dir("helloworld"))
+
+        assert_command(
+            cmd=['dcos', 'package', 'list', '--json', '--cli'],
+            stdout=helloworld_json)
+
+
 def test_uninstall_multiple_frameworknames(zk_znode):
     _install_chronos(
         args=['--yes', '--options=tests/data/package/chronos-1.json'])
@@ -959,9 +971,12 @@ def _helloworld():
                     uninstall_stderr=stderr)
 
 
-def _helloworld_cli():
+def _helloworld_cli(global_=False):
+    args = ['--yes', '--cli']
+    if global_:
+        args += ['--global']
     return _package(name='helloworld',
-                    args=['--yes', '--cli'],
+                    args=args,
                     stdout=HELLOWORLD_CLI_STDOUT,
                     uninstall_stderr=b'')
 

--- a/dcos/subcommand.py
+++ b/dcos/subcommand.py
@@ -142,7 +142,7 @@ def distributions():
     """
 
     cluster_packages = _find_distributions(_cluster_subcommand_dir())
-    global_packages = _find_distributions(_global_subcommand_dir())
+    global_packages = _find_distributions(global_subcommand_dir())
     return set(cluster_packages + global_packages)
 
 
@@ -355,16 +355,18 @@ def _install_cli(pkg, pkg_dir):
                 "Could not find a CLI subcommand for your platform")
 
 
-def install(pkg):
+def install(pkg, global_=False):
     """Installs the dcos cli subcommand
 
     :param pkg: the package to install
     :type pkg: Package
+    :param global_: whether to install the CLI globally
+    :type global_: bool
     :rtype: None
     """
 
-    if config.uses_deprecated_config():
-        pkg_dir = _global_package_dir(pkg.name())
+    if global_ or config.uses_deprecated_config():
+        pkg_dir = global_package_dir(pkg.name())
     else:
         pkg_dir = _cluster_package_dir(pkg.name())
 
@@ -375,7 +377,7 @@ def install(pkg):
     _install_cli(pkg, pkg_dir)
 
 
-def _global_subcommand_dir():
+def global_subcommand_dir():
     """ Returns global subcommand dir. defaults to ~/.dcos/subcommands """
 
     return os.path.join(config.get_config_dir_path(),
@@ -412,7 +414,7 @@ def _cluster_package_dir(name):
         return None
 
 
-def _global_package_dir(name):
+def global_package_dir(name):
     """Returns path to package directory in global config
 
     :param name: package name
@@ -420,7 +422,7 @@ def _global_package_dir(name):
     :rtype: str
     """
 
-    return os.path.join(_global_subcommand_dir(), name)
+    return os.path.join(global_subcommand_dir(), name)
 
 
 def _package_dir(name):
@@ -436,7 +438,7 @@ def _package_dir(name):
     if cluster_subcommand and os.path.exists(cluster_subcommand):
         return cluster_subcommand
     else:
-        return _global_package_dir(name)
+        return global_package_dir(name)
 
 
 def uninstall(package_name):


### PR DESCRIPTION
This allows you to install a CLI subcommand for all your clusters (ie
globally) or just for the attached cluster.