### PR TITLE
chmod 0600 tests/data/dcos.toml

### DIFF
--- a/cli/tests/integrations/test_config.py
+++ b/cli/tests/integrations/test_config.py
@@ -17,6 +17,7 @@ def env():
         constants.PATH_ENV: os.environ[constants.PATH_ENV],
         constants.DCOS_CONFIG_ENV: os.path.join("tests", "data", "dcos.toml"),
     })
+    os.chmod(r[constants.DCOS_CONFIG_ENV], 0o600)
 
     return r
 


### PR DESCRIPTION
Otherwise you get errors when running integration tests:

```
> /Users/abramowi/dev/git-repos/dcos-cli/cli/tests/integrations/test_config.py(336)_get_value()
-> assert returncode == 0
(Pdb) stderr
b"Permissions '0o644' for configuration file '/Users/abramowi/dev/git-repos/dcos-cli/cli/tests/data/dcos.toml (pointed to by tests/data/dcos.toml)' are too open.
File must only be accessible by owner. Aborting...
```

Cc: @tamarrow 