### PR TITLE
Add `dcos marathon task kill` command

### DIFF
--- a/cli/dcoscli/data/help/marathon.txt
+++ b/cli/dcoscli/data/help/marathon.txt
@@ -39,6 +39,7 @@ Usage:
     dcos marathon debug details <app-id> [--json]
     dcos marathon task list [--json <app-id>]
     dcos marathon task stop [--wipe] <task-id>
+    dcos marathon task kill [--scale] [--wipe] [<task-ids>...]
     dcos marathon task show <task-id>
 
 Commands:
@@ -109,6 +110,8 @@ Commands:
         List all tasks.
     task stop
         Stop a task.
+    task kill
+        Kill one or more tasks.
     task show
         List a specific task.
 
@@ -178,5 +181,7 @@ Positional Arguments:
         If omitted, properties are read from a JSON object provided on stdin.
     <task-id>
         The task ID.
+    <task_ids>
+        List of task IDs.
     <scale-factor>
         The factor to scale an application group by.

--- a/cli/dcoscli/data/help/marathon.txt
+++ b/cli/dcoscli/data/help/marathon.txt
@@ -39,7 +39,7 @@ Usage:
     dcos marathon debug details <app-id> [--json]
     dcos marathon task list [--json <app-id>]
     dcos marathon task stop [--wipe] <task-id>
-    dcos marathon task kill [--scale] [--wipe] [<task-ids>...]
+    dcos marathon task kill [--scale] [--wipe] [--json] [<task-ids>...]
     dcos marathon task show <task-id>
 
 Commands:

--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -882,11 +882,14 @@ class MarathonSubcommand(object):
         payload = client.kill_and_scale_tasks(task_ids, scale, wipe)
 
         # No deployment was started and no tasks were killed
-        if not scale and not payload:
-            emitter.publish('No tasks were killed and no deployment was triggered.')
-            return 1
-
-        emitter.publish(payload)
+        if scale:
+            emitter.publish("Started deployment: ")
+            emitter.publish(payload)
+        else:
+            emitter.publish('Killed tasks: ')
+            emitter.publish(payload['tasks'])
+            if len(payload['tasks']) == 0:
+                return 1
         return 0
 
     def task_show(self, task_id):

--- a/cli/tests/integrations/test_marathon.py
+++ b/cli/tests/integrations/test_marathon.py
@@ -813,7 +813,7 @@ def _stop_task(task_id, wipe=None, expect_success=True):
 
 
 def _kill_task(task_ids, scale=None, wipe=None, expect_success=True):
-    cmd = ['dcos', 'marathon', 'task', 'kill'] + task_ids
+    cmd = ['dcos', 'marathon', 'task', 'kill', '--json'] + task_ids
     if scale:
         cmd.append('--scale')
     if wipe:
@@ -823,13 +823,12 @@ def _kill_task(task_ids, scale=None, wipe=None, expect_success=True):
     if expect_success:
         assert returncode == 0
         assert stderr == b''
-        stdout = stdout.decode('utf-8')
-        payload = stdout[stdout.find(':') + 1:]  # Strip away help message
-        result = json.loads(payload)
+        result = json.loads(stdout.decode('utf-8'))
         if scale:
             assert 'deploymentId' in result
         else:
-            assert sorted([task['id'] for task in result]) == sorted(task_ids)
+            assert sorted(
+                [task['id'] for task in result['tasks']]) == sorted(task_ids)
 
     else:
         assert returncode == 1

--- a/cli/tests/integrations/test_marathon.py
+++ b/cli/tests/integrations/test_marathon.py
@@ -680,6 +680,16 @@ def test_kill_unknown_task():
         _kill_task(task_id, expect_success=False)
 
 
+def test_kill_task_wipe():
+    with _zero_instance_app():
+        start_app('zero-instance-app', 1)
+        watch_all_deployments()
+        task_list = _list_tasks(1, 'zero-instance-app')
+        task_id = [task_list[0]['id']]
+
+        _kill_task(task_id, wipe=True)
+
+
 def test_stop_unknown_task():
     with _zero_instance_app():
         start_app('zero-instance-app')

--- a/cli/tests/integrations/test_marathon.py
+++ b/cli/tests/integrations/test_marathon.py
@@ -823,7 +823,9 @@ def _kill_task(task_ids, scale=None, wipe=None, expect_success=True):
     if expect_success:
         assert returncode == 0
         assert stderr == b''
-        result = json.loads(stdout.decode('utf-8'))
+        stdout = stdout.decode('utf-8')
+        payload = stdout[stdout.find(':') + 1:]  # Strip away help message
+        result = json.loads(payload)
         if scale:
             assert 'deploymentId' in result
         else:

--- a/cli/tests/integrations/test_marathon.py
+++ b/cli/tests/integrations/test_marathon.py
@@ -639,6 +639,47 @@ def test_stop_task_wipe():
         _stop_task(task_id, '--wipe')
 
 
+def test_kill_one_task():
+    with _zero_instance_app():
+        start_app('zero-instance-app', 1)
+        watch_all_deployments()
+        task_list = _list_tasks(1, 'zero-instance-app')
+        task_id = [task_list[0]['id']]
+
+        _kill_task(task_id)
+
+
+def test_kill_two_tasks():
+    with _zero_instance_app():
+        start_app('zero-instance-app', 2)
+        watch_all_deployments()
+        task_list = _list_tasks(2, 'zero-instance-app')
+        task_ids = [task['id'] for task in task_list]
+
+        _kill_task(task_ids)
+
+
+def test_kill_and_scale_task():
+    with _zero_instance_app():
+        start_app('zero-instance-app', 2)
+        watch_all_deployments()
+        task_list = _list_tasks(2, 'zero-instance-app')
+        task_id = [task_list[0]['id']]
+
+        _kill_task(task_id, scale=True)
+
+        task_list = _list_tasks(1, 'zero-instance-app')
+
+
+def test_kill_unknown_task():
+    with _zero_instance_app():
+        start_app('zero-instance-app')
+        watch_all_deployments()
+        task_id = ['unknown-task-id']
+
+        _kill_task(task_id, expect_success=False)
+
+
 def test_stop_unknown_task():
     with _zero_instance_app():
         start_app('zero-instance-app')
@@ -757,6 +798,27 @@ def _stop_task(task_id, wipe=None, expect_success=True):
         assert stderr == b''
         result = json.loads(stdout.decode('utf-8'))
         assert result['id'] == task_id
+    else:
+        assert returncode == 1
+
+
+def _kill_task(task_ids, scale=None, wipe=None, expect_success=True):
+    cmd = ['dcos', 'marathon', 'task', 'kill'] + task_ids
+    if scale:
+        cmd.append('--scale')
+    if wipe:
+        cmd.append('--wipe')
+    returncode, stdout, stderr = exec_command(cmd)
+
+    if expect_success:
+        assert returncode == 0
+        assert stderr == b''
+        result = json.loads(stdout.decode('utf-8'))
+        if scale:
+            assert 'deploymentId' in result
+        else:
+            assert sorted([task['id'] for task in result]) == sorted(task_ids)
+
     else:
         assert returncode == 1
 

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -387,6 +387,40 @@ class Client(object):
         response = self._rpc.http_req(http.delete, path, params=params)
         return response.json()
 
+    def kill_and_scale_tasks(self, task_ids, scale=None, wipe=None):
+        """Kills the tasks for a given application,
+        and can target a given agent, with a future target scale
+
+        :param task_ids: a list of task ids to kill
+        :type task_ids: list
+        :param scale: Scale the app down after killing the specified tasks
+        :type scale: bool
+        :param wipe: whether remove reservations and persistent volumes.
+        :type wipe: bool
+        :returns: If scale=false, all tasks that were killed are returned.
+                  If scale=true, than a deployment is triggered and the
+                  deployment id and version returned.
+        :rtype: list | dict
+        """
+
+        params = {}
+        path = 'v2/tasks/delete'
+
+        if scale:
+            params['scale'] = scale
+        if wipe:
+            params['wipe'] = wipe
+
+        response = self._rpc.http_req(http.post,
+                                      path,
+                                      params=params,
+                                      json={'ids': task_ids})
+
+        if 'tasks' in response.json():
+            return response.json()['tasks']
+        else:
+            return response.json()
+
     def restart_app(self, app_id, force=False):
         """Performs a rolling restart of all of the tasks.
 

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -416,10 +416,7 @@ class Client(object):
                                       params=params,
                                       json={'ids': task_ids})
 
-        if 'tasks' in response.json():
-            return response.json()['tasks']
-        else:
-            return response.json()
+        return response.json()
 
     def restart_app(self, app_id, force=False):
         """Performs a rolling restart of all of the tasks.


### PR DESCRIPTION
- Using `v2/tasks/delete` marathon endpoint
- Possible to kill multiple tasks at once
- Setting `scale=True` will scale down the corresponding app