### PR TITLE
updating run job to return the run id.  

### DIFF
--- a/cli/dcoscli/data/help/job.txt
+++ b/cli/dcoscli/data/help/job.txt
@@ -11,7 +11,7 @@ Description:
         dcos job show <job-id>
         dcos job update <job-file>
         dcos job kill <job-id> [<run-id>][--all]
-        dcos job run <job-id>
+        dcos job run <job-id> [--json]
         dcos job list [--json]
         dcos job schedule add <job-id> <schedule-file>
         dcos job schedule show <job-id> [--json]

--- a/cli/dcoscli/job/main.py
+++ b/cli/dcoscli/job/main.py
@@ -76,7 +76,7 @@ def _cmds():
 
         cmds.Command(
             hierarchy=['job', 'run'],
-            arg_keys=['<job-id>'],
+            arg_keys=['<job-id>', '--json'],
             function=_run),
 
         cmds.Command(
@@ -398,7 +398,7 @@ def _get_runs(job_id, run_id=None):
         raise DCOSException(e)
 
 
-def _run(job_id):
+def _run(job_id, json_flag=False):
     """
     :param job_id: Id of the job
     :type job_id: str
@@ -408,12 +408,16 @@ def _run(job_id):
 
     try:
         client = metronome.create_client()
-        client.run_job(job_id)
+        run_job = client.run_job(job_id)
     except DCOSHTTPException as e:
         if e.response.status_code == 404:
             emitter.publish("Job ID: '{}' does not exist.".format(job_id))
         else:
             emitter.publish("Error running job: '{}'".format(job_id))
+    if json_flag:
+        emitter.publish(run_job)
+    else:
+        emitter.publish('Run ID: {}'.format(run_job['id']))
 
     return 0
 

--- a/cli/tests/integrations/test_job.py
+++ b/cli/tests/integrations/test_job.py
@@ -176,7 +176,11 @@ def test_show_runs():
 
 
 def _run_job(job_id):
-    assert_command(['dcos', 'job', 'run', job_id])
+    returncode, stdout, stderr = exec_command(
+        ['dcos', 'job', 'run', job_id])
+
+    assert returncode == 0
+    assert 'Run ID:' in stdout.decode('utf-8')
 
 
 @contextlib.contextmanager

--- a/dcos/metronome.py
+++ b/dcos/metronome.py
@@ -297,7 +297,9 @@ class Client(object):
 
         job_id = util.normalize_marathon_id_path(job_id)
         path = '/v1/jobs{}/runs'.format(job_id)
-        self._rpc.http_req(http.post, path)
+        response = self._rpc.http_req(http.post, path)
+
+        return response.json()
 
     def get_runs(self, job_id):
         """Gets the schedules for a given job


### PR DESCRIPTION
updated tests to support.

output is either:
```
$ dcos job run pikachu
Run ID: 20170419234147iDjEo
```
or
```
$ dcos job run pikachu --json
{
  "completedAt": null,
  "createdAt": "2017-04-19T23:42:14.097+0000",
  "id": "20170419234214aphte",
  "jobId": "pikachu",
  "status": "INITIAL",
  "tasks": []
}
```