### PR TITLE
cluster: ux improvements

### DIFF
--- a/cli/dcoscli/config/main.py
+++ b/cli/dcoscli/config/main.py
@@ -5,6 +5,7 @@ import docopt
 import dcoscli
 from dcos import cmds, config, emitting, http, util
 from dcos.errors import DCOSException, DefaultError
+from dcoscli.cluster.main import setup
 from dcoscli.subcommand import default_command_info, default_doc
 from dcoscli.util import decorate_docopt_usage
 
@@ -92,15 +93,26 @@ def _set(name, value):
         notice = "This config property has been deprecated."
         return DCOSException(notice)
     elif name == "core.dcos_url":
-        notice = ("This config property is being deprecated. "
-                  "To setup the CLI to talk to your cluster, please run "
-                  "`dcos cluster setup <dcos_url>`.")
-        emitter.publish(DefaultError(notice))
+        return _cluster_setup(value)
 
     toml, msg = config.set_val(name, value)
     emitter.publish(DefaultError(msg))
 
     return 0
+
+
+def _cluster_setup(dcos_url):
+    """
+    Setup a cluster using "cluster" directory instead "global" directory, until
+    we deprecate "global" config command: `dcos config set core.dcos_url x`
+    """
+
+    notice = ("This config property is being deprecated. "
+              "To setup the CLI to talk to your cluster, please run "
+              "`dcos cluster setup <dcos_url>`.")
+    emitter.publish(DefaultError(notice))
+
+    return setup(dcos_url)
 
 
 def _unset(name):

--- a/cli/dcoscli/data/help/cluster.txt
+++ b/cli/dcoscli/data/help/cluster.txt
@@ -6,7 +6,7 @@ Usage:
     dcos cluster --info
     dcos cluster --version
     dcos cluster attach <name>
-    dcos cluster list [--json]
+    dcos cluster list [--attached --json]
     dcos cluster remove <name>
     dcos cluster rename <name> <new_name>
     dcos cluster setup <dcos_url>
@@ -17,7 +17,7 @@ Usage:
 
 Commands:
     attach
-        Attach a configured cluster.
+        List only the currently attached cluster.
     list
         List CLI configured clusters.
     rename
@@ -28,6 +28,8 @@ Commands:
         Setup the CLI to talk to your DC/OS cluster.
 
 Options:
+    --attached
+        List only attached cluster.
     --ca-certs=<ca-certs>
         Specify the path to a list of trusted CAs to verify requests against.
     -h, --help
@@ -37,7 +39,7 @@ Options:
     --insecure
         Allow requests to bypass SSL certificate verification (insecure).
     --no-check
-        Do not check CA certficate downloaded from cluster (insecure).
+        Do not check CA certficate downloaded from cluster (insecure). Applies to Enterprise DC/OS only.
     --password=<password>
         Specify password on the command line (insecure).
     --password-env=<password_env>

--- a/cli/dcoscli/tables.py
+++ b/cli/dcoscli/tables.py
@@ -851,7 +851,7 @@ def clusters_table(clusters):
     def print_name(c):
         msg = c['name']
         if c['attached']:
-            msg += " (attached)"
+            msg += "*"
         return msg
 
     fields = OrderedDict([

--- a/cli/tests/integrations/test_job.py
+++ b/cli/tests/integrations/test_job.py
@@ -6,7 +6,7 @@ import pytest
 
 from dcos import constants
 
-from .helpers.common import assert_command, exec_command, update_config
+from .helpers.common import assert_command, exec_command
 from .helpers.job import job, show_job, show_job_schedule
 
 
@@ -32,16 +32,6 @@ def env():
     r.update({constants.PATH_ENV: os.environ[constants.PATH_ENV]})
 
     return r
-
-
-def test_missing_config(env):
-    with update_config("core.dcos_url", None, env):
-        assert_command(
-            ['dcos', 'job', 'list'],
-            returncode=1,
-            stderr=(b'Missing required config parameter: "core.dcos_url".  '
-                    b'Please run `dcos config set core.dcos_url <value>`.\n'),
-            env=env)
 
 
 def test_empty_list():

--- a/cli/tests/integrations/test_marathon.py
+++ b/cli/tests/integrations/test_marathon.py
@@ -55,16 +55,6 @@ def env():
     return r
 
 
-def test_missing_config(env):
-    with update_config("core.dcos_url", None, env):
-        assert_command(
-            ['dcos', 'marathon', 'app', 'list'],
-            returncode=1,
-            stderr=(b'Missing required config parameter: "core.dcos_url".  '
-                    b'Please run `dcos config set core.dcos_url <value>`.\n'),
-            env=env)
-
-
 def test_empty_list():
     list_apps()
 

--- a/cli/tests/integrations/test_package.py
+++ b/cli/tests/integrations/test_package.py
@@ -654,7 +654,7 @@ def test_list_cli_only(env):
     helloworld_json = file_json(helloworld_path)
 
     with _helloworld_cli(), \
-            update_config('core.dcos_url', 'http://nohost', env):
+            update_config('package.cosmos_url', 'http://nohost', env):
         assert_command(
             cmd=['dcos', 'package', 'list', '--json', '--cli'],
             stdout=helloworld_json)

--- a/cli/tests/integrations/test_ssl.py
+++ b/cli/tests/integrations/test_ssl.py
@@ -2,9 +2,9 @@ import os
 
 import pytest
 
-from dcos import config, constants
+from dcos import constants
 
-from .helpers.common import config_set, exec_command, update_config
+from .helpers.common import exec_command, update_config
 
 
 @pytest.fixture
@@ -13,23 +13,11 @@ def env():
     r.update({
         constants.PATH_ENV: os.environ[constants.PATH_ENV],
         'DCOS_SNAKEOIL_CRT_PATH': os.environ.get(
-            "DCOS_SNAKEOIL_CRT_PATH", "/dcos-cli/adminrouter/snakeoil.crt")
+            "DCOS_SNAKEOIL_CRT_PATH", "/dcos-cli/adminrouter/snakeoil.crt"),
+        'DCOS_URL': 'https://dcos.snakeoil.mesosphere.com'
     })
 
     return r
-
-
-@pytest.yield_fixture(autouse=True)
-def setup_env(env):
-    # token will be removed when we change dcos_url
-    token = config.get_config_val('core.dcos_acs_token')
-    config_set("core.dcos_url", "https://dcos.snakeoil.mesosphere.com", env)
-    config_set("core.dcos_acs_token", token, env)
-    try:
-        yield
-    finally:
-        config_set("core.dcos_url", "http://dcos.snakeoil.mesosphere.com", env)
-        config_set("core.dcos_acs_token", token, env)
 
 
 def test_dont_verify_ssl_with_env_var(env):


### PR DESCRIPTION
* open DC/OS clusters don't have a cluster cert, default to insecure requests
* add --attached param to `cluster list`
* improve error messages
* use current config for http._verify_ssl