### PR TITLE
More info when > 1 executable subcommand

### DIFF
--- a/dcos/subcommand.py
+++ b/dcos/subcommand.py
@@ -40,8 +40,8 @@ def command_executables(subcommand):
     ]
 
     if len(executables) > 1:
-        msg = 'Found more than one executable for command {!r}.'
-        raise DCOSException(msg.format(subcommand))
+        msg = 'Found more than one executable for command {!r}. {!r}'
+        raise DCOSException(msg.format(subcommand, executables))
 
     if len(executables) == 0:
         msg = "{!r} is not a dcos command."


### PR DESCRIPTION
I got this error and wanted to know what executables, it had found.

e.g.:

```
$ dcos fd image list
Found more than one executable for command 'fd'. ['/Users/abramowi/.dcos/subcommands/fd/env/bin/dcos-fd', '/Users/abramowi/.dcos/subcommands/flight-director/env/bin/dcos-fd']
```