### PR TITLE
Undo reverted changes that cause `dcos task exec` to break.

### DIFF
--- a/cli/dcoscli/task/main.py
+++ b/cli/dcoscli/task/main.py
@@ -584,7 +584,7 @@ def _metrics(summary, task_id, json_):
             'Error finding agent associated with task: {}'.format(task_id))
 
     slave_id = task['slave_id']
-    container_id = master.get_container_id(task_id)
+    container_id = master.get_container_id(task_id)["value"]
 
     endpoint = '/system/v1/agent/{}/metrics/v0/containers/{}'.format(
         slave_id, container_id

--- a/cli/tests/integrations/test_task.py
+++ b/cli/tests/integrations/test_task.py
@@ -323,8 +323,6 @@ def test_ls_completed():
     assert stderr == b''
 
 
-@pytest.mark.skipif('DCOS_DEBUGGING_ENABLED' not in os.environ,
-                    reason="Requires Agent Debugging APIs")
 def test_exec_non_interactive():
     with open('tests/data/tasks/lorem-ipsum.txt') as text:
         content = text.read()
@@ -337,8 +335,6 @@ def test_exec_non_interactive():
             stdout=bytes(content, 'UTF-8'))
 
 
-@pytest.mark.skipif('DCOS_DEBUGGING_ENABLED' not in os.environ,
-                    reason="Requires Agent Debugging APIs")
 def test_exec_interactive():
     with open('tests/data/tasks/lorem-ipsum.txt') as text:
         content = bytes(text.read(), 'UTF-8')

--- a/cli/tests/unit/test_task.py
+++ b/cli/tests/unit/test_task.py
@@ -158,7 +158,10 @@ def test_dcos_task_metrics_agent_details(mocked_get_config_val,
 
     mock_master = MagicMock()
     mock_master.task = lambda _: {'slave_id': 'slave_id'}
-    mock_master.get_container_id = lambda _: 'container_id'
+    mock_master.get_container_id = lambda _: {
+        'parent': {},
+        'value': 'container_id'
+    }
     mocked_get_master.return_value = mock_master
 
     _metrics(True, 'task_id', False)

--- a/dcos/mesos.py
+++ b/dcos/mesos.py
@@ -496,7 +496,7 @@ class Master(object):
         def _get_container_id(container_status):
             if 'container_id' in container_status:
                 if 'value' in container_status['container_id']:
-                    return container_status['container_id']['value']
+                    return container_status['container_id']
 
             raise DCOSException(
                 "No container found for the specified task."


### PR DESCRIPTION
This commit:
https://github.com/dcos/dcos-cli/commit/8971ccdb081f5b902387d72185fadb2cc6ed1fbd

Inadvertently undid changes originally introduced in this commit:
https://github.com/dcos/dcos-cli/commit/f33a45ee94377e2b4654d9d69812320e4b2b823b

Unfortunately, the integration tests didn't catch this because all
`task exec` integration tests were hidden behind an environment variable:

    @pytest.mark.skipif('DCOS_DEBUGGING_ENABLED' not in os.environ,
                        reason="Requires Agent Debugging APIs")

This commit reintroduces the changes that were inadvertently undone and
enables the `task exec` integration tests by default so that something
like this doesn't occur in the future.