### PR TITLE
The linkerd package has a syntax error; switch to hello-world

### DIFF
--- a/cli/tests/integrations/test_experimental.py
+++ b/cli/tests/integrations/test_experimental.py
@@ -221,7 +221,7 @@ def test_service_start_happy_path_json():
 
 
 def test_service_start_happy_path_from_universe():
-    package_name = 'linkerd'
+    package_name = 'hello-world'
     name, version = _package_add_universe(package_name)
     try:
         _service_start(name, version)


### PR DESCRIPTION
This is a quick fix to get the tests passing. I will file a separate JIRA to fix the problem with `linkerd`.