### PR TITLE
Update help links for dcos marathon add

### DIFF
--- a/cli/dcoscli/data/help/marathon.txt
+++ b/cli/dcoscli/data/help/marathon.txt
@@ -156,7 +156,7 @@ Positional Arguments:
         Path to a file or HTTP(S) URL that contains the app's JSON definition.
         If omitted, the definition is read from stdin. For a detailed
         description, see
-        https://docs.mesosphere.com/usage/marathon/rest-api/.
+        https://mesosphere.github.io/marathon/docs/rest-api.html#post-v2apps.
     <deployment-id>
         The deployment ID.
     <group-id>
@@ -165,7 +165,7 @@ Positional Arguments:
         Path to a file or HTTP(S) URL that contains the group's JSON definition.
         If omitted, the definition is read from stdin. For a detailed
         description, see
-        https://mesosphere.github.io/marathon/docs/rest-api.html#post-v2-groups.
+        https://mesosphere.github.io/marathon/docs/rest-api.html#post-v2groups.
     <instance-ids>
         List of one or more space-separated pod instance IDs.
     <instances>


### PR DESCRIPTION
The first one triggers a 404 and the second one has an unexisting anchor.