### PR TITLE
Updated 'test_ls_long()' to look for a range of lines.

### DIFF
--- a/cli/tests/integrations/helpers/common.py
+++ b/cli/tests/integrations/helpers/common.py
@@ -131,6 +131,27 @@ def assert_lines(cmd, num_lines, greater_than=False):
     assert lines == num_lines
 
 
+def assert_lines_range(cmd, num_lines_min, num_lines_max):
+    """ Assert stdout contains the expected number of lines in a range
+
+    :param cmd: program and arguments
+    :type cmd: [str]
+    :param num_lines_min: minimum expected number of lines for stdout
+    :param num_lines_max: maximum expected number of lines for stdout
+    :type num_lines_min: int
+    :type num_lines_max: int
+    :rtype: None
+    """
+
+    returncode, stdout, stderr = exec_command(cmd)
+
+    assert returncode == 0
+    assert stderr == b''
+    lines = len(stdout.decode('utf-8').split('\n')) - 1
+    assert lines >= num_lines_min
+    assert lines <= num_lines_max
+
+
 def file_json_ast(path):
     """Returns the JSON AST parsed from file
     :param path: path to file

--- a/cli/tests/integrations/test_task.py
+++ b/cli/tests/integrations/test_task.py
@@ -11,7 +11,8 @@ import pytest
 import dcos.util as util
 from dcos.util import create_schema
 
-from .helpers.common import (assert_command, assert_lines, exec_command)
+from .helpers.common import (assert_command, assert_lines,
+                             assert_lines_range, exec_command)
 from .helpers.marathon import (add_app, app, pod, remove_app,
                                watch_all_deployments)
 from ..fixtures.task import task_fixture
@@ -287,7 +288,7 @@ def test_ls_multiple_tasks():
 
 
 def test_ls_long():
-    assert_lines(['dcos', 'task', 'ls', '--long', 'test-app1'], 7)
+    assert_lines_range(['dcos', 'task', 'ls', '--long', 'test-app1'], 5, 7)
 
 
 def test_ls_path():


### PR DESCRIPTION
Previously, this test was flaky because sometime it would come up with 5
lines and other times 7. This flakiness is due to some idiosyncrasies
with 'logrotate' where sometimes it creates a '*.logrotate.state' file
during the test run, and other times it doesn't. When it does, there
will be 7 lines in the output. When it doesn't, there will be 5.