### PR TITLE
update error message for invalid subcommand usage

### DIFF
--- a/cli/dcoscli/util.py
+++ b/cli/dcoscli/util.py
@@ -23,7 +23,7 @@ def decorate_docopt_usage(func):
         try:
             result = func(*args, **kwargs)
         except docopt.DocoptExit as e:
-            emitter.publish("Command not recognized\n")
+            emitter.publish("Invalid subcommand usage\n")
             emitter.publish(e)
             return 1
         return result

--- a/cli/tests/integrations/test_experimental.py
+++ b/cli/tests/integrations/test_experimental.py
@@ -194,7 +194,7 @@ def test_package_add_argument_exclusion():
     assert err == b''
 
     stdout = out.decode()
-    not_recognized = 'Command not recognized'
+    not_recognized = 'Invalid subcommand usage'
     assert not_recognized in stdout
 
 

--- a/cli/tests/integrations/test_experimental.py
+++ b/cli/tests/integrations/test_experimental.py
@@ -185,7 +185,7 @@ def test_package_build_where_build_definition_has_badly_formed_reference():
                                stderr=stderr)
 
 
-def test_package_add_argument_exclussion():
+def test_package_add_argument_exclusion():
     command = command_base + ['package', 'add',
                               '--dcos-package', runnable_package_path(1),
                               '--package-version', '3.0']

--- a/cli/tests/integrations/test_job.py
+++ b/cli/tests/integrations/test_job.py
@@ -79,7 +79,7 @@ def test_show_job_with_blank_jobname():
         ['dcos', 'job', 'show'])
 
     assert returncode == 1
-    assert "Command not recognized" in stdout.decode('utf-8')
+    assert "Invalid subcommand usage" in stdout.decode('utf-8')
 
 
 def test_show_job_with_invalid_jobname():
@@ -103,7 +103,7 @@ def test_show_schedule_blank_jobname():
         ['dcos', 'job', 'schedule', 'show'])
 
     assert returncode == 1
-    assert stdout.decode('utf-8').startswith('Command not recognized')
+    assert stdout.decode('utf-8').startswith('Invalid subcommand usage')
 
 
 def test_show_schedule_invalid_jobname():

--- a/cli/tests/integrations/test_marathon_groups.py
+++ b/cli/tests/integrations/test_marathon_groups.py
@@ -94,7 +94,7 @@ def test_scale_group_when_scale_factor_negative():
     with group(SCALE_GROUP, 'scale-group'):
         returncode, stdout, stderr = exec_command(
             ['dcos', 'marathon', 'group', 'scale', 'scale-group', '-2'])
-        assert b'Command not recognized' in stdout
+        assert b'Invalid subcommand usage' in stdout
         assert returncode == 1
 
 

--- a/cli/tests/integrations/test_marathon_pod.py
+++ b/cli/tests/integrations/test_marathon_pod.py
@@ -45,7 +45,7 @@ def test_pod_update_does_not_support_properties():
     returncode, stdout, stderr = exec_command(cmd)
 
     assert returncode == 1
-    assert stdout.startswith(b'Command not recognized\n')
+    assert stdout.startswith(b'Invalid subcommand usage\n')
     assert stderr == b''
 
 


### PR DESCRIPTION
3e66e1246ff9d35afb275d083a9c96d2bd51776b added an explicit error message for invalid subcommand usage.

This change rephrases it to make it clear that the subcommand exists but is being misused.

https://jira.mesosphere.com/browse/DCOS_COMMUNITY-95