### PR TITLE
Add a message argument to DCOSAuthenticationException

### DIFF
--- a/dcos/errors.py
+++ b/dcos/errors.py
@@ -49,12 +49,19 @@ class DCOSAuthenticationException(DCOSHTTPException):
 
     :param response: requests Response object
     :type response: Response
+    :param message: An optional message for the exception. This can be useful
+                    to provide the user with more meaningful information.
+    :type message: str
     """
-    def __init__(self, response):
+    def __init__(self, response, message=None):
+        if message is None:
+            message = "Authentication failed. Please run `dcos auth login`"
+
         self.response = response
+        self.message = message
 
     def __str__(self):
-        return "Authentication failed. Please run `dcos auth login`"
+        return self.message
 
 
 class DCOSAuthorizationException(DCOSHTTPException):

--- a/dcos/http.py
+++ b/dcos/http.py
@@ -207,7 +207,7 @@ def request(method,
             if auth_token is not None:
                 msg = ("Your core.dcos_acs_token is invalid. "
                        "Please run: `dcos auth login`")
-                raise DCOSAuthenticationException(msg)
+                raise DCOSAuthenticationException(response, msg)
             else:
                 raise DCOSAuthenticationException(response)
     elif response.status_code == 422:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,20 @@
+import mock
+import requests
+
+from dcos import errors
+
+
+def test_dcos_auth_exception_as_string():
+    response = mock.create_autospec(requests.Response)
+    exception = errors.DCOSAuthenticationException(response)
+
+    assert (str(exception) ==
+            "Authentication failed. Please run `dcos auth login`")
+
+
+def test_dcos_auth_exception_with_message_as_string():
+    response = mock.create_autospec(requests.Response)
+    exception = errors.DCOSAuthenticationException(
+        response, "custom error message")
+
+    assert str(exception) == "custom error message"


### PR DESCRIPTION
This also fixes an issue where a string message is passed instead of a Response object.

cf. https://jira.mesosphere.com/browse/DCOS-16144