### PR TITLE
Add a test against infinite prompt during cluster setup

### DIFF
--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -372,7 +372,7 @@ def _bundle_download(bundle, location):
         msg = ('Diagnostics bundle size is {}, '
                'are you sure you want to download it?')
         if not confirm(msg.format(sizeof_fmt(bundle_size)), False):
-            return 0
+            return 1
 
     r = _do_request(url, 'GET', stream=True)
     try:

--- a/cli/dcoscli/package/main.py
+++ b/cli/dcoscli/package/main.py
@@ -351,7 +351,7 @@ def _install(package_name, package_version, options_path, app_id, cli,
 
     if not confirm('Continue installing?', yes):
         emitter.publish('Exiting installation.')
-        return 0
+        return 1
 
     if app and pkg.marathon_template():
 

--- a/cli/tests/integrations/test_cluster.py
+++ b/cli/tests/integrations/test_cluster.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 
 from .helpers.common import assert_command, exec_command
 
@@ -43,3 +44,24 @@ def test_rename():
 
     # rename back to original name
     assert_command(['dcos', 'cluster', 'rename', new_name, name])
+
+
+def test_setup_noninteractive():
+    """
+    Run "dcos cluster setup" command as non-interactive with a 30 sec timeout.
+    This makes sure the process doesn't prompt for input forever (DCOS-15590).
+    """
+
+    try:
+        returncode, stdout, _ = exec_command(
+            ['dcos',
+             'cluster',
+             'setup',
+             'https://dcos.snakeoil.mesosphere.com'],
+            timeout=30,
+            stdin=subprocess.DEVNULL)
+    except subprocess.TimeoutExpired:
+        assert False, 'timed out waiting for process to exit'
+
+    assert returncode == 1
+    assert b"'' is not a valid response" in stdout

--- a/cli/tests/integrations/test_package.py
+++ b/cli/tests/integrations/test_package.py
@@ -2,6 +2,7 @@ import base64
 import contextlib
 import json
 import os
+import subprocess
 import sys
 
 import pytest
@@ -416,6 +417,19 @@ def test_install_bad_package_version():
         stderr=stderr)
 
 
+def test_install_noninteractive():
+    try:
+        returncode, stdout, _ = exec_command(
+            ['dcos', 'package', 'install', 'hello-world'],
+            timeout=30,
+            stdin=subprocess.DEVNULL)
+    except subprocess.TimeoutExpired:
+        assert False, 'timed out waiting for process to exit'
+
+    assert returncode == 1
+    assert b"'' is not a valid response" in stdout
+
+
 def test_package_metadata():
     _install_helloworld()
 
@@ -683,7 +697,8 @@ def test_install_no():
                 b'catalog-terms-conditions/#community-services\n'
                 b'A sample pre-installation message\n'
                 b'Continue installing? [yes/no] Exiting installation.\n'
-            )
+            ),
+            returncode=1
         )
 
 


### PR DESCRIPTION
Prior to 1254a2f2b5210c68d86f4b16c4c6b16ad2e911ae and when running
"dcos cluster setup" command as non-interactive, the process would run
and ask for user input forever.

This adds an integration test which fails if the process doesn't exit by
itself with an error within 30 seconds.

https://jira.mesosphere.com/browse/DCOS-15590