### PR TITLE
[WIP] Revert "config set core.dcos_url" to its old behaviour

### DIFF
--- a/cli/dcoscli/config/main.py
+++ b/cli/dcoscli/config/main.py
@@ -5,7 +5,6 @@ import docopt
 import dcoscli
 from dcos import cmds, config, emitting, http, util
 from dcos.errors import DCOSException, DefaultError
-from dcoscli.cluster.main import setup
 from dcoscli.subcommand import default_command_info, default_doc
 from dcoscli.util import decorate_docopt_usage
 
@@ -86,26 +85,16 @@ def _set(name, value):
     """
 
     if name == "core.dcos_url":
-        return _cluster_setup(value)
+        notice = (
+            "This config property is being deprecated. "
+            "To setup the CLI to talk to your cluster, please run "
+            "`dcos cluster setup <dcos_url>`.")
+        emitter.publish(DefaultError(notice))
 
     toml, msg = config.set_val(name, value)
     emitter.publish(DefaultError(msg))
 
     return 0
-
-
-def _cluster_setup(dcos_url):
-    """
-    Setup a cluster using "cluster" directory instead "global" directory, until
-    we deprecate "global" config command: `dcos config set core.dcos_url x`
-    """
-
-    notice = ("This config property is being deprecated. "
-              "To setup the CLI to talk to your cluster, please run "
-              "`dcos cluster setup <dcos_url>`.")
-    emitter.publish(DefaultError(notice))
-
-    return setup(dcos_url)
 
 
 def _unset(name):


### PR DESCRIPTION
It nows only changes the config value and unsets the acs token, this
ensures backward compatibilty is preserved.

This command is still deprecated and users are encouraged to switch to
the "dcos cluster setup" command.

https://jira.mesosphere.com/browse/DCOS-16088