### PR TITLE
Revert "config set core.dcos_url" to its old behaviour

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -177,9 +177,6 @@ integration tests against. In the future we hope to remove this limitation::
 
     # With the variables set above, run the script below verbatim
     export DCOS_DIR=$(mktemp -d)
-    cp cli/tests/data/dcos.toml ${DCOS_DIR}
-    chmod 600 ${DCOS_DIR}/dcos.toml
-    export DCOS_CONFIG=${DCOS_DIR}/dcos.toml
     export CLI_TEST_MASTER_PROXY=true
 
     deactivate > /dev/null 2>&1 || true
@@ -190,6 +187,8 @@ integration tests against. In the future we hope to remove this limitation::
         --insecure \
         --username=bootstrapuser \
         --password=deleteme
+    dcos config set core.reporting false
+    dcos config set core.timeout 5
     deactivate
     cd -
 

--- a/ci/Jenkinsfile-linux-integration
+++ b/ci/Jenkinsfile-linux-integration
@@ -129,30 +129,6 @@ class TestCluster implements Serializable {
 
         return script.readFile("${platform}_dcos_url")
     }
-
-    /**
-     * Retrieves the ACS Token of a cluster previously created using `create()`.
-     */
-    def getAcsToken() {
-        def dcosUrl = this.getDcosUrl()
-
-        /* In the future, consider doing the following with curl / jq instead
-           of inline python (however, jq is not installed on our windows
-           machines at the moment). */
-        script.sh """
-            python -c \
-                'import requests; \
-                 requests.packages.urllib3.disable_warnings(); \
-                 js={"uid":"${script.env.DCOS_ADMIN_USERNAME}", \
-                     "password": "${script.env.DCOS_ADMIN_PASSWORD}"}; \
-                 r=requests.post("http://${dcosUrl}/acs/api/v1/auth/login", \
-                                 json=js, \
-                                 verify=False); \
-                 print(r.json()["token"], end="")' \
-            > ${platform}_acs_token"""
-
-        return script.readFile("${platform}_acs_token")
-    }
 }
 
 
@@ -175,7 +151,6 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
 
             try {
                 def dcosUrl = cluster.getDcosUrl()
-                def acsToken = cluster.getAcsToken()
 
                 node(nodeId) {
                     if (!workspace) {
@@ -199,8 +174,7 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
                               credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
                               variable: 'CLI_TEST_SSH_KEY_PATH']]) {
 
-                            withEnv(["DCOS_URL=${dcosUrl}",
-                                     "DCOS_ACS_TOKEN=${acsToken}"]) {
+                            withEnv(["DCOS_URL=${dcosUrl}"]) {
                                 try {
                                     body()
                                 } catch(InterruptedException | hudson.AbortException e) {
@@ -256,14 +230,14 @@ builders['linux-tests'] = testBuilder('linux', 'py35', '/workspace')({
         dir('dcos-cli/cli') {
             sh '''
                export PYTHONIOENCODING=utf-8; \
+               make binary; \
                export CLI_TEST_SSH_USER=centos; \
                export CLI_TEST_MASTER_PROXY=true; \
-               export DCOS_CONFIG=tests/data/dcos.toml; \
-               chmod 600 ${DCOS_CONFIG}; \
-               echo dcos_acs_token = \\\"${DCOS_ACS_TOKEN}\\\" >> ${DCOS_CONFIG}; \
-               cat ${DCOS_CONFIG}; \
-               unset DCOS_URL; \
-               unset DCOS_ACS_TOKEN; \
+               dist/dcos cluster setup dcos.snakeoil.mesosphere.com \
+                   --insecure --username=${DCOS_ADMIN_USERNAME} \
+                   --password-env=DCOS_ADMIN_PASSWORD; \
+               dist/dcos config set core.reporting false; \
+               dist/dcos config set core.timeout 5; \
                make test-binary'''
         }
     }

--- a/ci/Jenkinsfile-linux-integration
+++ b/ci/Jenkinsfile-linux-integration
@@ -113,9 +113,9 @@ class TestCluster implements Serializable {
     }
 
     /**
-     * Retrieves the URL of a cluster previously created using `create()`.
+     * Retrieves the IP of a cluster previously created using `create()`.
      */
-    def getDcosUrl() {
+    def getDcosIp() {
         /* In the future, consider doing the following with jq instead of
            inline python (however, jq is not installed on our windows machines
            at the moment). */
@@ -150,7 +150,7 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
             }
 
             try {
-                def dcosUrl = cluster.getDcosUrl()
+                def dcosIp = cluster.getDcosIp()
 
                 node(nodeId) {
                     if (!workspace) {
@@ -174,19 +174,19 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
                               credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
                               variable: 'CLI_TEST_SSH_KEY_PATH']]) {
 
-                            withEnv(["DCOS_URL=${dcosUrl}"]) {
+                            withEnv(["DCOS_IP=${dcosIp}"]) {
                                 try {
                                     body()
                                 } catch(InterruptedException | hudson.AbortException e) {
                                     echo(
                                         "Build interrupted. The DC/OS cluster at" +
-                                        " ${dcosUrl} will be destroyed.")
+                                        " ${dcosIp} will be destroyed.")
                                     destroyCluster = true
                                     throw e
                                 } catch (Exception e) {
                                     echo(
                                         "Build failed. The DC/OS cluster at" +
-                                        " ${dcosUrl} will remain temporarily" +
+                                        " ${dcosIp} will remain temporarily" +
                                         " active so you can debug what went" +
                                         " wrong.")
                                     destroyCluster = false
@@ -220,8 +220,8 @@ builders['linux-tests'] = testBuilder('linux', 'py35', '/workspace')({
         sh '''
            rm -rf ~/.dcos; \
            grep -q "^.* dcos.snakeoil.mesosphere.com$" /etc/hosts && \
-           sed -iold "s/^.* dcos.snakeoil.mesosphere.com$/${DCOS_URL} dcos.snakeoil.mesosphere.com/" /etc/hosts || \
-           echo ${DCOS_URL} dcos.snakeoil.mesosphere.com >> /etc/hosts'''
+           sed -iold "s/^.* dcos.snakeoil.mesosphere.com$/${DCOS_IP} dcos.snakeoil.mesosphere.com/" /etc/hosts || \
+           echo ${DCOS_IP} dcos.snakeoil.mesosphere.com >> /etc/hosts'''
 
         dir('dcos-cli') {
             sh 'make test'

--- a/ci/Jenkinsfile-mac-integration
+++ b/ci/Jenkinsfile-mac-integration
@@ -115,7 +115,7 @@ class TestCluster implements Serializable {
     /**
      * Retrieves the URL of a cluster previously created using `create()`.
      */
-    def getDcosUrl() {
+    def getDcosIp() {
         /* In the future, consider doing the following with jq instead of
            inline python (however, jq is not installed on our windows machines
            at the moment). */
@@ -149,7 +149,7 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
             }
 
             try {
-                def dcosUrl = cluster.getDcosUrl()
+                def dcosIp = cluster.getDcosIp()
 
                 node(nodeId) {
                     if (!workspace) {
@@ -173,19 +173,19 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
                               credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
                               variable: 'CLI_TEST_SSH_KEY_PATH']]) {
 
-                            withEnv(["DCOS_URL=${dcosUrl}"]) {
+                            withEnv(["DCOS_IP=${dcosIp}"]) {
                                 try {
                                     body()
                                 } catch(InterruptedException | hudson.AbortException e) {
                                     echo(
                                         "Build interrupted. The DC/OS cluster at" +
-                                        " ${dcosUrl} will be destroyed.")
+                                        " ${dcosIp} will be destroyed.")
                                     destroyCluster = true
                                     throw e
                                 } catch (Exception e) {
                                     echo(
                                         "Build failed. The DC/OS cluster at" +
-                                        " ${dcosUrl} will remain temporarily" +
+                                        " ${dcosIp} will remain temporarily" +
                                         " active so you can debug what went" +
                                         " wrong.")
                                     destroyCluster = false
@@ -220,8 +220,8 @@ builders['mac-tests'] = testBuilder('mac', 'mac')({
            rm -rf ~/.dcos; \
            cp /etc/hosts hosts.local; \
            grep -q "^.* dcos.snakeoil.mesosphere.com$" hosts.local && \
-           sed -iold "s/^.* dcos.snakeoil.mesosphere.com$/${DCOS_URL} dcos.snakeoil.mesosphere.com/" hosts.local || \
-           echo ${DCOS_URL} dcos.snakeoil.mesosphere.com >> hosts.local; \
+           sed -iold "s/^.* dcos.snakeoil.mesosphere.com$/${DCOS_IP} dcos.snakeoil.mesosphere.com/" hosts.local || \
+           echo ${DCOS_IP} dcos.snakeoil.mesosphere.com >> hosts.local; \
            sudo cp ./hosts.local /etc/hosts'''
 
         dir('dcos-cli') {

--- a/ci/Jenkinsfile-mac-integration
+++ b/ci/Jenkinsfile-mac-integration
@@ -129,30 +129,6 @@ class TestCluster implements Serializable {
 
         return script.readFile("${platform}_dcos_url")
     }
-
-    /**
-     * Retrieves the ACS Token of a cluster previously created using `create()`.
-     */
-    def getAcsToken() {
-        def dcosUrl = this.getDcosUrl()
-
-        /* In the future, consider doing the following with curl / jq instead
-           of inline python (however, jq is not installed on our windows
-           machines at the moment). */
-        script.sh """
-            python -c \
-                'import requests; \
-                 requests.packages.urllib3.disable_warnings(); \
-                 js={"uid":"${script.env.DCOS_ADMIN_USERNAME}", \
-                     "password": "${script.env.DCOS_ADMIN_PASSWORD}"}; \
-                 r=requests.post("http://${dcosUrl}/acs/api/v1/auth/login", \
-                                 json=js, \
-                                 verify=False); \
-                 print(r.json()["token"], end="")' \
-            > ${platform}_acs_token"""
-
-        return script.readFile("${platform}_acs_token")
-    }
 }
 
 
@@ -174,7 +150,6 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
 
             try {
                 def dcosUrl = cluster.getDcosUrl()
-                def acsToken = cluster.getAcsToken()
 
                 node(nodeId) {
                     if (!workspace) {
@@ -198,8 +173,7 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
                               credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
                               variable: 'CLI_TEST_SSH_KEY_PATH']]) {
 
-                            withEnv(["DCOS_URL=${dcosUrl}",
-                                     "DCOS_ACS_TOKEN=${acsToken}"]) {
+                            withEnv(["DCOS_URL=${dcosUrl}"]) {
                                 try {
                                     body()
                                 } catch(InterruptedException | hudson.AbortException e) {
@@ -257,14 +231,14 @@ builders['mac-tests'] = testBuilder('mac', 'mac')({
         dir('dcos-cli/cli') {
             sh '''
                export PYTHONIOENCODING=utf-8; \
+               make binary; \
                export CLI_TEST_SSH_USER=centos; \
                export CLI_TEST_MASTER_PROXY=true; \
-               export DCOS_CONFIG=tests/data/dcos.toml; \
-               chmod 600 ${DCOS_CONFIG}; \
-               echo dcos_acs_token = \\\"${DCOS_ACS_TOKEN}\\\" >> ${DCOS_CONFIG}; \
-               cat ${DCOS_CONFIG}; \
-               unset DCOS_URL; \
-               unset DCOS_ACS_TOKEN; \
+               dist/dcos cluster setup dcos.snakeoil.mesosphere.com \
+                   --insecure --username=${DCOS_ADMIN_USERNAME} \
+                   --password-env=DCOS_ADMIN_PASSWORD; \
+               dist/dcos config set core.reporting false; \
+               dist/dcos config set core.timeout 5; \
                make test-binary'''
         }
     }

--- a/ci/Jenkinsfile-windows-integration
+++ b/ci/Jenkinsfile-windows-integration
@@ -129,30 +129,6 @@ class TestCluster implements Serializable {
 
         return script.readFile("${platform}_dcos_url")
     }
-
-    /**
-     * Retrieves the ACS Token of a cluster previously created using `create()`.
-     */
-    def getAcsToken() {
-        def dcosUrl = this.getDcosUrl()
-
-        /* In the future, consider doing the following with curl / jq instead
-           of inline python (however, jq is not installed on our windows
-           machines at the moment). */
-        script.sh """
-            python -c \
-                'import requests; \
-                 requests.packages.urllib3.disable_warnings(); \
-                 js={"uid":"${script.env.DCOS_ADMIN_USERNAME}", \
-                     "password": "${script.env.DCOS_ADMIN_PASSWORD}"}; \
-                 r=requests.post("http://${dcosUrl}/acs/api/v1/auth/login", \
-                                 json=js, \
-                                 verify=False); \
-                 print(r.json()["token"], end="")' \
-            > ${platform}_acs_token"""
-
-        return script.readFile("${platform}_acs_token")
-    }
 }
 
 
@@ -174,7 +150,6 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
 
             try {
                 def dcosUrl = cluster.getDcosUrl()
-                def acsToken = cluster.getAcsToken()
 
                 node(nodeId) {
                     if (!workspace) {
@@ -198,8 +173,7 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
                               credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
                               variable: 'CLI_TEST_SSH_KEY_PATH']]) {
 
-                            withEnv(["DCOS_URL=${dcosUrl}",
-                                     "DCOS_ACS_TOKEN=${acsToken}"]) {
+                            withEnv(["DCOS_URL=${dcosUrl}"]) {
                                 try {
                                     body()
                                 } catch(InterruptedException | hudson.AbortException e) {
@@ -262,12 +236,14 @@ builders['windows-tests'] = testBuilder('windows', 'windows', 'C:\\windows\\work
             bat '''
                 bash -c " \
                 export PYTHONIOENCODING=utf-8; \
+                make binary; \
                 export CLI_TEST_SSH_USER=centos; \
                 export CLI_TEST_MASTER_PROXY=true; \
-                export DCOS_CONFIG=tests/data/dcos.toml; \
-                cat ${DCOS_CONFIG}; \
-                unset DCOS_URL; \
-                unset DCOS_ACS_TOKEN; \
+                dist/dcos cluster setup dcos.snakeoil.mesosphere.com \
+                    --insecure --username=${DCOS_ADMIN_USERNAME} \
+                    --password-env=DCOS_ADMIN_PASSWORD; \
+                dist/dcos config set core.reporting false; \
+                dist/dcos config set core.timeout 5; \
                 make test-binary"'''
         }
     }

--- a/ci/Jenkinsfile-windows-integration
+++ b/ci/Jenkinsfile-windows-integration
@@ -115,7 +115,7 @@ class TestCluster implements Serializable {
     /**
      * Retrieves the URL of a cluster previously created using `create()`.
      */
-    def getDcosUrl() {
+    def getDcosIp() {
         /* In the future, consider doing the following with jq instead of
            inline python (however, jq is not installed on our windows machines
            at the moment). */
@@ -149,7 +149,7 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
             }
 
             try {
-                def dcosUrl = cluster.getDcosUrl()
+                def dcosIp = cluster.getDcosIp()
 
                 node(nodeId) {
                     if (!workspace) {
@@ -173,19 +173,19 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
                               credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
                               variable: 'CLI_TEST_SSH_KEY_PATH']]) {
 
-                            withEnv(["DCOS_URL=${dcosUrl}"]) {
+                            withEnv(["DCOS_IP=${dcosIp}"]) {
                                 try {
                                     body()
                                 } catch(InterruptedException | hudson.AbortException e) {
                                     echo(
                                         "Build interrupted. The DC/OS cluster at" +
-                                        " ${dcosUrl} will be destroyed.")
+                                        " ${dcosIp} will be destroyed.")
                                     destroyCluster = true
                                     throw e
                                 } catch (Exception e) {
                                     echo(
                                         "Build failed. The DC/OS cluster at" +
-                                        " ${dcosUrl} will remain temporarily" +
+                                        " ${dcosIp} will remain temporarily" +
                                         " active so you can debug what went" +
                                         " wrong.")
                                     destroyCluster = false
@@ -224,7 +224,7 @@ builders['windows-tests'] = testBuilder('windows', 'windows', 'C:\\windows\\work
         bat '''
             bash -c " \
             sed \'/^.* dcos.snakeoil.mesosphere.com$/d\' /windows/system32/drivers/etc/hosts >/windows/system32/drivers/etc/hosts && \
-            echo ${DCOS_URL} dcos.snakeoil.mesosphere.com >> /windows/system32/drivers/etc/hosts"'''
+            echo ${DCOS_IP} dcos.snakeoil.mesosphere.com >> /windows/system32/drivers/etc/hosts"'''
 
         bat 'bash -c "cat /windows/system32/drivers/etc/hosts"'
 

--- a/cli/dcoscli/cluster/main.py
+++ b/cli/dcoscli/cluster/main.py
@@ -203,6 +203,13 @@ def setup(dcos_url,
         # set cluster as attached
         cluster.set_attached(temp_path)
 
+        # Make sure to ignore any environment variable.
+        # There is already a mandatory command argument for this.
+        if "DCOS_URL" in os.environ:
+            del os.environ["DCOS_URL"]
+        if "DCOS_DCOS_URL" in os.environ:
+            del os.environ["DCOS_DCOS_URL"]
+
         # authenticate
         config.set_val("core.dcos_url", dcos_url)
         # get validated dcos_url

--- a/cli/dcoscli/config/main.py
+++ b/cli/dcoscli/config/main.py
@@ -5,7 +5,6 @@ import docopt
 import dcoscli
 from dcos import cmds, config, emitting, http, util
 from dcos.errors import DCOSException, DefaultError
-from dcoscli.cluster.main import setup
 from dcoscli.subcommand import default_command_info, default_doc
 from dcoscli.util import decorate_docopt_usage
 
@@ -85,27 +84,17 @@ def _set(name, value):
     :rtype: int
     """
 
-    if name == "core.dcos_url":
-        return _cluster_setup(value)
-
     toml, msg = config.set_val(name, value)
     emitter.publish(DefaultError(msg))
 
+    if name == "core.dcos_url" and config.uses_deprecated_config():
+        notice = (
+            "Setting-up a cluster through this command is being deprecated. "
+            "To setup the CLI to talk to your cluster, please run "
+            "`dcos cluster setup <dcos_url>`.")
+        emitter.publish(DefaultError(notice))
+
     return 0
-
-
-def _cluster_setup(dcos_url):
-    """
-    Setup a cluster using "cluster" directory instead "global" directory, until
-    we deprecate "global" config command: `dcos config set core.dcos_url x`
-    """
-
-    notice = ("This config property is being deprecated. "
-              "To setup the CLI to talk to your cluster, please run "
-              "`dcos cluster setup <dcos_url>`.")
-    emitter.publish(DefaultError(notice))
-
-    return setup(dcos_url)
 
 
 def _unset(name):

--- a/cli/dcoscli/main.py
+++ b/cli/dcoscli/main.py
@@ -78,6 +78,12 @@ def _main():
         return dcos_help()
 
     if config.uses_deprecated_config():
+        if constants.DCOS_CONFIG_ENV in os.environ:
+            msg = ('{} is deprecated, please consider using '
+                   '`dcos cluster setup <dcos_url>`.')
+            err = errors.DefaultError(msg.format(constants.DCOS_CONFIG_ENV))
+            emitter.publish(err)
+
         cluster.move_to_cluster_config()
 
     if command in subcommand.default_subcommands():

--- a/cli/dcoscli/main.py
+++ b/cli/dcoscli/main.py
@@ -69,19 +69,16 @@ def _main():
 
     util.configure_process_from_environ()
 
-    if config.uses_deprecated_config():
-        cluster.move_to_cluster_config()
-
     if args['--version']:
         return _get_versions()
 
     command = args['<command>']
 
     if not command:
-        if args['--help']:
-            command = "help"
-        else:
-            return dcos_help()
+        return dcos_help()
+
+    if config.uses_deprecated_config():
+        cluster.move_to_cluster_config()
 
     if command in subcommand.default_subcommands():
         sc = SubcommandMain(command, args['<args>'])

--- a/cli/tests/data/cluster_migration/dcos.toml
+++ b/cli/tests/data/cluster_migration/dcos.toml
@@ -1,0 +1,5 @@
+[core]
+dcos_url = "http://dcos.snakeoil.mesosphere.com"
+ssl_verify = false
+timeout = 5
+reporting = false

--- a/cli/tests/data/dcos.toml
+++ b/cli/tests/data/dcos.toml
@@ -1,5 +1,0 @@
-[core]
-dcos_url = "http://dcos.snakeoil.mesosphere.com"
-ssl_verify = "false"
-timeout = 5
-reporting = false

--- a/cli/tests/integrations/helpers/common.py
+++ b/cli/tests/integrations/helpers/common.py
@@ -232,22 +232,15 @@ def update_config(name, value, env=None):
     :rtype: None
     """
 
-    returncode, stdout, _ = exec_command(
-        ['dcos', 'config', 'show', name], env)
+    toml_config = config.get_config(True)
+
+    result = toml_config.get(name)
 
     # when we change the dcos_url we remove the acs_token
     # we need to also restore the token if this occurs
     token = None
     if name == "core.dcos_url":
-        returncode_, token_val, _ = exec_command(
-            ['dcos', 'config', 'show', "core.dcos_acs_token"], env)
-        if returncode_ == 0:
-            token = token_val.decode('utf-8').strip()
-
-    result = None
-    # config param already exists
-    if returncode == 0:
-        result = json.loads('"' + stdout.decode('utf-8').strip() + '"')
+        token = toml_config.get("core.dcos_acs_token")
 
     # if we are setting a value
     if value is not None:
@@ -261,7 +254,7 @@ def update_config(name, value, env=None):
     finally:
         # return config to previous state
         if result is not None:
-            config_set(name, result, env)
+            config_set(name, str(result), env)
         else:
             exec_command(['dcos', 'config', 'unset', name], env)
 

--- a/cli/tests/integrations/test_cluster_migration.py
+++ b/cli/tests/integrations/test_cluster_migration.py
@@ -1,0 +1,184 @@
+import contextlib
+import json
+import os
+
+import pytest
+
+from dcos import config, constants, util
+
+from .helpers.common import assert_command, exec_command
+
+
+@pytest.fixture(scope="module")
+def acs_token():
+    return config.get_config().get('core.dcos_acs_token')
+
+
+@pytest.fixture
+def temp_dcos_dir():
+    with util.tempdir() as tempdir:
+        old_dcos_dir = os.environ.get(constants.DCOS_DIR_ENV)
+        os.environ[constants.DCOS_DIR_ENV] = tempdir
+        yield tempdir
+        if old_dcos_dir is None:
+            os.environ.pop(constants.DCOS_DIR_ENV)
+        else:
+            os.environ[constants.DCOS_DIR_ENV] = old_dcos_dir
+
+
+def test_dcos_dir_env_with_acs_token(acs_token, temp_dcos_dir):
+    _copy_config_to_dir('dcos.toml', temp_dcos_dir)
+
+    config.set_val('core.dcos_acs_token', acs_token)
+
+    returncode, stdout, _ = exec_command(['dcos', 'cluster', 'list', '--json'])
+    assert returncode == 0
+
+    cluster_list = json.loads(stdout.decode('utf-8'))
+    assert len(cluster_list) == 1
+    assert cluster_list[0]['url'] == "http://dcos.snakeoil.mesosphere.com"
+
+
+def test_dcos_dir_env_without_acs_token(acs_token, temp_dcos_dir):
+    _copy_config_to_dir('dcos.toml', temp_dcos_dir)
+
+    stderr = (
+        b"No clusters are currently configured. "
+        b"To configure one, run `dcos cluster setup <dcos_url>`\n"
+    )
+
+    # Without an ACS token, the migration shouldn't occur
+    assert_command(['dcos', 'cluster', 'list'], returncode=1, stderr=stderr)
+
+
+def test_dcos_config_env_with_acs_token(acs_token, temp_dcos_dir):
+    with _temp_dcos_config('dcos.toml', temp_dcos_dir):
+
+        config.set_val('core.dcos_acs_token', acs_token)
+
+        exp_stderr = (
+            b"DCOS_CONFIG is deprecated, please consider using "
+            b"`dcos cluster setup <dcos_url>`.\n"
+        )
+
+        returncode, stdout, stderr = exec_command(
+            ['dcos', 'cluster', 'list', '--json'])
+        assert returncode == 0
+        assert exp_stderr == stderr
+
+        cluster_list = json.loads(stdout.decode('utf-8'))
+        assert len(cluster_list) == 1
+        assert cluster_list[0]['url'] == "http://dcos.snakeoil.mesosphere.com"
+
+
+def test_dcos_config_env_without_acs_token(temp_dcos_dir):
+    with _temp_dcos_config('dcos.toml', temp_dcos_dir):
+
+        stderr = (
+            b"DCOS_CONFIG is deprecated, please consider using "
+            b"`dcos cluster setup <dcos_url>`.\n"
+            b"No clusters are currently configured. "
+            b"To configure one, run `dcos cluster setup <dcos_url>`\n"
+        )
+
+        # Without an ACS token, the migration shouldn't occur
+        assert_command(
+            ['dcos', 'cluster', 'list'], returncode=1, stderr=stderr)
+
+
+def test_setup_cluster_through_config_commands(acs_token, temp_dcos_dir):
+    returncode, _, stderr = exec_command(
+        ['dcos',
+         'config',
+         'set',
+         'core.dcos_url',
+         'http://dcos.snakeoil.mesosphere.com'])
+    assert returncode == 0
+    assert stderr == (
+        b"[core.dcos_url]: set to 'http://dcos.snakeoil.mesosphere.com'\n"
+        b"Setting-up a cluster through this command is being deprecated. "
+        b"To setup the CLI to talk to your cluster, please run "
+        b"`dcos cluster setup <dcos_url>`.\n")
+
+    returncode, _, _ = exec_command(
+        ['dcos', 'config', 'set', 'core.dcos_acs_token', acs_token])
+    assert returncode == 0
+
+    returncode, stdout, _ = exec_command(
+        ['dcos', 'cluster', 'list', '--json'])
+    assert returncode == 0
+
+    cluster_list = json.loads(stdout.decode('utf-8'))
+    assert len(cluster_list) == 1
+    assert cluster_list[0]['url'] == "http://dcos.snakeoil.mesosphere.com"
+
+
+def test_setup_cluster_through_auth_command(temp_dcos_dir):
+    if 'DCOS_ADMIN_USERNAME' not in os.environ:
+        pytest.skip('DCOS_ADMIN_USERNAME is not set.')
+
+    if 'DCOS_ADMIN_PASSWORD' not in os.environ:
+        pytest.skip('DCOS_ADMIN_PASSWORD is not set.')
+
+    returncode, _, stderr = exec_command(
+        ['dcos',
+         'config',
+         'set',
+         'core.dcos_url',
+         'http://dcos.snakeoil.mesosphere.com'])
+    assert returncode == 0
+    assert stderr == (
+        b"[core.dcos_url]: set to 'http://dcos.snakeoil.mesosphere.com'\n"
+        b"Setting-up a cluster through this command is being deprecated. "
+        b"To setup the CLI to talk to your cluster, please run "
+        b"`dcos cluster setup <dcos_url>`.\n")
+
+    returncode, _, _ = exec_command(
+        ['dcos',
+         'auth',
+         'login',
+         '--username',
+         os.environ['DCOS_ADMIN_USERNAME'],
+         '--password-env=DCOS_ADMIN_PASSWORD'])
+    assert returncode == 0
+
+    returncode, stdout, _ = exec_command(
+        ['dcos', 'cluster', 'list', '--json'])
+    assert returncode == 0
+
+    cluster_list = json.loads(stdout.decode('utf-8'))
+    assert len(cluster_list) == 1
+    assert cluster_list[0]['url'] == "http://dcos.snakeoil.mesosphere.com"
+
+
+def _copy_config_to_dir(name, dst_dir):
+    """
+    :param name: name of the config fixture to copy.
+    :type name: str
+    """
+
+    fixture_config = os.path.join(
+        os.path.dirname(__file__),
+        '../data/cluster_migration/{}'.format(name))
+
+    # make sure the config has the proper permission
+    os.chmod(fixture_config, 0o600)
+
+    dst = os.path.join(dst_dir, 'dcos.toml')
+
+    util.sh_copy(fixture_config, dst)
+
+
+@contextlib.contextmanager
+def _temp_dcos_config(name, dst_dir):
+    old_dcos_config = os.environ.get(constants.DCOS_CONFIG_ENV)
+    _copy_config_to_dir(name, dst_dir)
+    tempfile = os.path.join(dst_dir, name)
+    try:
+        os.environ[constants.DCOS_CONFIG_ENV] = tempfile
+        yield tempfile
+    finally:
+        if old_dcos_config is None:
+            os.environ.pop(constants.DCOS_CONFIG_ENV)
+        else:
+            os.environ[constants.DCOS_CONFIG_ENV] = old_dcos_config

--- a/cli/tests/integrations/test_config.py
+++ b/cli/tests/integrations/test_config.py
@@ -123,7 +123,6 @@ def test_unset_top_property(env):
 
 
 def test_validate(env):
-    os.environ['DCOS_CONFIG'] = env['DCOS_CONFIG']
     stdout = 'Validating %s ...\n' % config.get_config_path() + \
              'Congratulations, your configuration is valid!\n'
     stdout = stdout.encode('utf-8')

--- a/dcos/config.py
+++ b/dcos/config.py
@@ -137,12 +137,7 @@ def get_config(mutable=False):
 
     cluster_path = get_attached_cluster_path()
     if cluster_path is None:
-        if uses_deprecated_config():
-            return get_global_config(mutable)
-
-        msg = ("No cluster is attached. "
-               "Please run `dcos cluster attach <cluster-name>`")
-        raise DCOSException(msg)
+        return get_global_config(mutable)
 
     util.ensure_dir_exists(os.path.dirname(cluster_path))
 
@@ -296,6 +291,7 @@ def load_from_path(path, mutable=False):
     :rtype: Toml | MutableToml
     """
 
+    util.ensure_dir_exists(os.path.dirname(path))
     util.ensure_file_exists(path)
     util.enforce_file_permissions(path)
     with util.open_file(path, 'r') as config_file:


### PR DESCRIPTION
It nows only changes the config value and unsets the acs token, this
ensures backward compatibilty is preserved.

This command is still deprecated and users are encouraged to switch to
the "dcos cluster setup" command.

https://jira.mesosphere.com/browse/DCOS-16088

```
Setup flow for new users of the 0.4.x CLI:
$ export DCOS_CONFIG=<path/to/config> (optional)
  (default when not set is ~/.dcos/dcos.toml)
$ dcos config set core.dcos_url <url>
$ dcos config set core.ssl_verify [“true” | “false” | <path/to/ca_cert>]
$ dcos auth login
  (generates  / updates global config at $DCOS_CONFIG where all settings are set)

Setup flow for new users of the 0.5.x CLI:
$ export DCOS_DIR=<path/to/config_dir> (optional)
  (default when not set is ~/.dcos)
$ dcos cluster setup <url>
  (generates / updates per cluster config under $DCOS_DIR/clusters/<cluster_id> where all settings are set)
  (sets newly set up cluster config as the active one)

Automatic update of config when currently using the 0.4.x CLI and updating to new 0.5.x CLI:
$ export DCOS_CONFIG=<path/to/config> (optional)
  (default when not set is ~/.dcos/dcos.toml)
$ dcos <subcommand>

$ … download and install new dcos 0.5.x binary …

$ export DCOS_DIR=<path/to/config_dir> (optional)
  (default when not set is ~/.dcos)
$ dcos <subcommand>
  (triggers conversion from old config structure to new)
  (moves global config from $DCOS_CONFIG to $DCOS_DIR/clusters/<cluster_id>/dcos.toml)
  (sets newly converted cluster config as the active one)
  (DCOS_CONFIG is no longer honored)

Preserving backwards compatibility:
1. Before `dcos cluster setup <url>` is called, follow the old flow semantics
   and allow users to change the config pointed to by $DCOS_CONFIG
   (print warning message saying these calls are deprecated and recommend using `dcos cluster setup`)
2. After `dcos cluster setup` is called (or automatic conversion has occurred),
   update the ‘active’ cluster’s config whenever old flow commands are called
   (print different warning message saying the calls are deprecated and cluster config state may now be corrupted)
```