### PR TITLE
	Use a consistent case for http headers

### DIFF
--- a/cli/tests/unit/test_auth.py
+++ b/cli/tests/unit/test_auth.py
@@ -7,13 +7,13 @@ from dcos.errors import DCOSException
 
 
 def test_get_auth_scheme():
-    _get_auth_scheme({'www-authenticate': 'acsjwt'}, scheme='acsjwt')
-    _get_auth_scheme({'www-authenticate': 'oauthjwt'}, scheme='oauthjwt')
+    _get_auth_scheme({'WWW-Authenticate': 'acsjwt'}, scheme='acsjwt')
+    _get_auth_scheme({'WWW-Authenticate': 'oauthjwt'}, scheme='oauthjwt')
     _get_auth_scheme({}, scheme=None)
 
     msg = ("Server responded with an HTTP 'www-authenticate' field of "
            "'foobar', DC/OS only supports ['oauthjwt', 'acsjwt']")
-    _get_auth_scheme_exception({'www-authenticate': 'foobar'}, msg)
+    _get_auth_scheme_exception({'WWW-Authenticate': 'foobar'}, msg)
 
 
 def _get_auth_scheme(header, scheme):
@@ -53,7 +53,7 @@ def test_get_dcostoken_by_post_with_creds(config, req):
 def test_header_challenge_auth(cred_auth, oidc_auth, req):
     resp = create_autospec(requests.Response)
     resp.status_code = 401
-    resp.headers = {"www-authenticate": "oauthjwt"}
+    resp.headers = {"WWW-Authenticate": "oauthjwt"}
     req.return_value = resp
 
     auth.header_challenge_auth("url")
@@ -61,7 +61,7 @@ def test_header_challenge_auth(cred_auth, oidc_auth, req):
 
     resp2 = create_autospec(requests.Response)
     resp2.status_code = 401
-    resp2.headers = {"www-authenticate": "acsjwt"}
+    resp2.headers = {"WWW-Authenticate": "acsjwt"}
     req.return_value = resp2
 
     auth.header_challenge_auth("url")

--- a/dcos/auth.py
+++ b/dcos/auth.py
@@ -27,8 +27,8 @@ def _get_auth_scheme(response):
     :rtype: str | None
     """
 
-    if 'www-authenticate' in response.headers:
-        auths = response.headers['www-authenticate'].split(',')
+    if 'WWW-Authenticate' in response.headers:
+        auths = response.headers['WWW-Authenticate'].split(',')
         scheme = next((auth_type.rstrip().lower() for auth_type in auths
                        if auth_type.rstrip().lower().startswith("acsjwt") or
                        auth_type.rstrip().lower().startswith("oauthjwt")),
@@ -40,7 +40,7 @@ def _get_auth_scheme(response):
         else:
             msg = ("Server responded with an HTTP 'www-authenticate' field of "
                    "'{}', DC/OS only supports ['oauthjwt', 'acsjwt']".format(
-                       response.headers['www-authenticate']))
+                       response.headers['WWW-Authenticate']))
             raise DCOSException(msg)
     else:
         logger.debug("HTTP response: no www-authenticate field found")

--- a/dcos/packagemanager.py
+++ b/dcos/packagemanager.py
@@ -359,7 +359,7 @@ class CosmosPackageVersion():
         response = PackageManager(url).cosmos_post("describe", params)
 
         self._package_json = response.json()
-        self._content_type = response.headers['content-type']
+        self._content_type = response.headers['Content-Type']
 
     def version(self):
         """Returns the package version.


### PR DESCRIPTION
When running tests locally I'm getting the following error : 
```
self = <dcos.packagemanager.CosmosPackageVersion object at 0x7f5b6fcfb4e0>, name = 'fake_pkg', package_version = '0.0.1'
url = 'http://testserver/cosmos'

    def __init__(self, name, package_version, url):
        self._cosmos_url = url
    
        params = {"packageName": name}
        if package_version is not None:
            params["packageVersion"] = package_version
        response = PackageManager(url).cosmos_post("describe", params)
    
        self._package_json = response.json()
>       self._content_type = response.headers['content-type']
E       KeyError: 'content-type'

.tox/py35-unit/lib/python3.5/site-packages/dcos/packagemanager.py:362: KeyError
```

It seems like the content-type header is not lower-cased.

Right now these tests are not executed on CI, so that might be why we missed it (https://jira.mesosphere.com/browse/DCOS_OSS-1543).