### PR TITLE
Fix cluster cleanup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -381,7 +381,7 @@ node('py35') {
                         shallow: true,
                         depth: 0,
                         noTags: true,
-                        timeout: 30
+                        timeout: 10
                     ]
                 ]
             ])


### PR DESCRIPTION
- merge create & wait functions to a single while loop
- have create clean up after itself so testBuilder doesn't have to
- condense functions that were only being called from one place to improve readability

This resolves the bug where creation failure was causing two executions of `dcos-launch delete`.