### PR TITLE
Make a "dcos config" error message more explicit

### DIFF
--- a/cli/tests/integrations/test_config.py
+++ b/cli/tests/integrations/test_config.py
@@ -86,7 +86,8 @@ def test_set_nonexistent_subcommand(env):
     assert_command(
         ['dcos', 'config', 'set', 'foo.bar', 'baz'],
         stdout=b'',
-        stderr=b"'foo' is not a dcos command.\n",
+        stderr=(b"Config section 'foo' is invalid:"
+                b" 'foo' is not a dcos command.\n"),
         returncode=1,
         env=env)
 
@@ -135,7 +136,8 @@ def test_set_property_key(env):
     assert_command(
         ['dcos', 'config', 'set', 'path.to.value', 'cool new value'],
         returncode=1,
-        stderr=b"'path' is not a dcos command.\n",
+        stderr=(b"Config section 'path' is invalid:"
+                b" 'path' is not a dcos command.\n"),
         env=env)
 
 

--- a/cli/tests/integrations/test_config.py
+++ b/cli/tests/integrations/test_config.py
@@ -92,6 +92,15 @@ def test_set_nonexistent_subcommand(env):
         env=env)
 
 
+def test_set_nonconfigurable_subcommand(env):
+    assert_command(
+        ['dcos', 'config', 'set', 'help.bar', 'baz'],
+        stdout=b'',
+        stderr=(b"Subcommand 'help' is not configurable.\n"),
+        returncode=1,
+        env=env)
+
+
 def test_unset_property(env):
     with update_config("core.reporting", None, env):
         _get_missing_value('core.reporting', env)

--- a/dcos/config.py
+++ b/dcos/config.py
@@ -440,19 +440,16 @@ def get_config_schema(command):
     from dcos.subcommand import (
             command_executables, config_schema, default_subcommands)
 
-    # core.* config variables are special.  They're valid, but don't
-    # correspond to any particular subcommand, so we must handle them
-    # separately.
-    if command == "core":
-        return json.loads(
-            pkg_resources.resource_string(
-                'dcos',
-                'data/config-schema/core.json').decode('utf-8'))
-    elif command in default_subcommands():
-        return json.loads(
-            pkg_resources.resource_string(
-                'dcos',
-                'data/config-schema/{}.json'.format(command)).decode('utf-8'))
+    # handle config schema for core.* properties and built-in subcommands
+    if command == "core" or command in default_subcommands():
+        try:
+            schema = pkg_resources.resource_string(
+                    'dcos', 'data/config-schema/{}.json'.format(command))
+        except FileNotFoundError:
+            msg = "Subcommand '{}' is not configurable.".format(command)
+            raise DCOSException(msg)
+
+        return json.loads(schema.decode('utf-8'))
 
     try:
         executable = command_executables(command)

--- a/dcos/config.py
+++ b/dcos/config.py
@@ -453,9 +453,14 @@ def get_config_schema(command):
             pkg_resources.resource_string(
                 'dcos',
                 'data/config-schema/{}.json'.format(command)).decode('utf-8'))
-    else:
+
+    try:
         executable = command_executables(command)
-        return config_schema(executable, command)
+    except DCOSException as e:
+        msg = "Config section '{}' is invalid: {}".format(command, e)
+        raise DCOSException(msg)
+
+    return config_schema(executable, command)
 
 
 def get_property_description(section, subkey):


### PR DESCRIPTION
Without these changes, one can get the following :
``` shell
$ dcos config set coree.ssl_verify true
'coree' is not a dcos command.

$ dcos config set help.sf jhfshf
Traceback (most recent call last):
  File "cli/dcoscli/subcommand.py", line 103, in run_and_capture
  File "cli/dcoscli/config/main.py", line 18, in main
  File "cli/dcoscli/util.py", line 24, in wrapper
  File "cli/dcoscli/config/main.py", line 33, in _main
  File "dcos/cmds.py", line 43, in execute
  File "cli/dcoscli/config/main.py", line 91, in _set
  File "dcos/config.py", line 245, in set_val
  File "dcos/config.py", line 455, in get_config_schema
  File "cli/env/lib/python3.5/site-packages/pkg_resources/__init__.py", line 1173, in resource_string
  File "cli/env/lib/python3.5/site-packages/pkg_resources/__init__.py", line 1605, in get_resource_string
  File "cli/env/lib/python3.5/site-packages/pkg_resources/__init__.py", line 1683, in _get
  File "/jenkins/workspace/DCOS-CLI/Releases/linux-binary-release/DCOS_CHANNEL/testing/label/py35/cli/env/lib/python3.5/site-packages/PyInstaller/loader/pyimod03_importers.py", line 474, in get_data
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/_MEItETfZZ/dcos/data/config-schema/help.json'
```

This PR adds context to the first error message, for the second it displays an error message instead of a stack trace : 
``` shell
$ dcos config set coree.ssl_verify true
Config section 'coree' is invalid: 'coree' is not a dcos command.

$ dcos config set help.sf jhfshf
Subcommand 'help' is not configurable.
```