### PR TITLE
tests/ssh: use wait() instead of sleep()+poll()

### DIFF
--- a/cli/tests/integrations/helpers/common.py
+++ b/cli/tests/integrations/helpers/common.py
@@ -295,10 +295,8 @@ def ssh_output(cmd):
     # ssh must run with stdin attached to a tty
     proc, master = popen_tty(cmd)
 
-    # wait for the ssh connection
-    time.sleep(5)
-
-    proc.poll()
+    # wait for the ssh command to finish
+    proc.wait(30)
     returncode = proc.returncode
 
     # kill the whole process group

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -237,7 +237,7 @@ def test_node_ssh_slave_with_command():
                '/opt/mesosphere/bin/detect_ip'], 0, slave['hostname'])
 
 
-def _node_ssh_output(args):
+def _node_ssh_output(args, wait=False):
     cli_test_ssh_key_path = os.environ['CLI_TEST_SSH_KEY_PATH']
 
     cmd = ('ssh-agent /bin/bash -c "ssh-add {} 2> /dev/null && ' +
@@ -245,7 +245,7 @@ def _node_ssh_output(args):
         cli_test_ssh_key_path,
         ' '.join(args))
 
-    return ssh_output(cmd)
+    return ssh_output(cmd, wait)
 
 
 def _node_ssh(args, expected_returncode=None, expected_stdout=None):
@@ -253,7 +253,8 @@ def _node_ssh(args, expected_returncode=None, expected_stdout=None):
             '--master-proxy' not in args:
         args.append('--master-proxy')
 
-    stdout, stderr, returncode = _node_ssh_output(args)
+    wait = expected_returncode is not None
+    stdout, stderr, returncode = _node_ssh_output(args, wait)
     assert returncode is expected_returncode, \
         'returncode = %r; stdout: = %s; stderr = %s' % (
             returncode, stdout, stderr)


### PR DESCRIPTION
Was there a specific reason to use `poll()` instead of `wait()` here?

`poll()` would return immediately after the sleep period, even though the SSH command didn't finish. Using `wait()` with a timeout blocks for a given period for the command to finish, otherwise raises an exception.

Without this change I'm experiencing some random failures on `test_node_ssh_with_command()`, where return code is `None` instead of the expected `0`.