### PR TITLE
Clarifications about --all and --app-id

### DIFF
--- a/cli/dcoscli/data/help/package.txt
+++ b/cli/dcoscli/data/help/package.txt
@@ -44,7 +44,7 @@ Commands:
 
 Options:
     --all
-        All packages.
+        All applications.
     --app
         Application only.
     --app-id=<app-id>

--- a/cli/dcoscli/data/help/package.txt
+++ b/cli/dcoscli/data/help/package.txt
@@ -21,7 +21,7 @@ Usage:
     dcos package repo remove <repo-names>...
     dcos package search [<query> --json]
     dcos package uninstall <package-name>
-                           [--cli | [--app --app-id=<app-id> --all --yes]]
+                           [--cli | [--app [--app-id=<app-id> | --all] --yes]]
 
 Commands:
     describe


### PR DESCRIPTION
The first commit updates the `--all` option description, I think we mean `applications` instead of `packages` here.

The second one is about making those options mutually exclusive, as it doesn't make sense to use them together. So when using both of them, one would get an `Invalid subcommand usage` error printed out.