### PR TITLE
don't uninstall cli subcommand when there are remaining apps

### DIFF
--- a/cli/dcoscli/package/main.py
+++ b/cli/dcoscli/package/main.py
@@ -510,11 +510,8 @@ def _uninstall(package_name, remove_all, app_id, cli, app, skip_confirmation):
         return 0
 
     package_manager = get_package_manager()
-    err = package.uninstall(
+    package.uninstall(
         package_manager, package_name, remove_all, app_id, cli, app)
-    if err is not None:
-        emitter.publish(err)
-        return 1
 
     return 0
 

--- a/cli/tests/data/helloworld-v3-stub.json
+++ b/cli/tests/data/helloworld-v3-stub.json
@@ -26,7 +26,7 @@
           "containerPort": 80
         }
       ],
-      "image": "mesosphere/universe-server:20170518T235510Z-cli-test-v3-helloworld-ca5778937b",
+      "image": "mesosphere/universe-server:20170830T173030Z-pull-1393-c2e6119f08",
       "network": "BRIDGE"
     },
     "type": "DOCKER"

--- a/cli/tests/data/package/json/test_list_helloworld.json
+++ b/cli/tests/data/package/json/test_list_helloworld.json
@@ -10,6 +10,10 @@
       "$schema": "http://json-schema.org/schema#",
       "additionalProperties": false,
       "properties": {
+        "name": {
+          "default": "helloworld",
+          "type": "string"
+        },
         "port": {
           "default": 8080,
           "type": "integer"
@@ -21,7 +25,7 @@
     "framework": false,
     "maintainer": "support@mesosphere.io",
     "marathon": {
-      "v2AppMustacheTemplate": "ewogICJpZCI6ICJoZWxsb3dvcmxkIiwKICAiY3B1cyI6IDEuMCwKICAibWVtIjogNTEyLAogICJpbnN0YW5jZXMiOiAxLAogICJjbWQiOiAicHl0aG9uMyAtbSBodHRwLnNlcnZlciB7e3BvcnR9fSIsCiAgImNvbnRhaW5lciI6IHsKICAgICJ0eXBlIjogIkRPQ0tFUiIsCiAgICAiZG9ja2VyIjogewogICAgICAiaW1hZ2UiOiAicHl0aG9uOjMiLAogICAgICAibmV0d29yayI6ICJIT1NUIgogICAgfQogIH0KfQo="
+      "v2AppMustacheTemplate": "ewogICJpZCI6ICJ7e25hbWV9fSIsCiAgImNwdXMiOiAxLjAsCiAgIm1lbSI6IDUxMiwKICAiaW5zdGFuY2VzIjogMSwKICAiY21kIjogInB5dGhvbjMgLW0gaHR0cC5zZXJ2ZXIge3twb3J0fX0iLAogICJjb250YWluZXIiOiB7CiAgICAidHlwZSI6ICJET0NLRVIiLAogICAgImRvY2tlciI6IHsKICAgICAgImltYWdlIjogInB5dGhvbjozIiwKICAgICAgIm5ldHdvcmsiOiAiSE9TVCIKICAgIH0KICB9Cn0K"
     },
     "name": "helloworld",
     "packagingVersion": "3.0",

--- a/cli/tests/data/package/json/test_list_helloworld_cli.json
+++ b/cli/tests/data/package/json/test_list_helloworld_cli.json
@@ -7,6 +7,10 @@
       "$schema": "http://json-schema.org/schema#",
       "additionalProperties": false,
       "properties": {
+        "name": {
+          "default": "helloworld",
+          "type": "string"
+        },
         "port": {
           "default": 8080,
           "type": "integer"
@@ -17,7 +21,7 @@
     "description": "Example DCOS application package",
     "maintainer": "support@mesosphere.io",
     "marathon": {
-      "v2AppMustacheTemplate": "ewogICJpZCI6ICJoZWxsb3dvcmxkIiwKICAiY3B1cyI6IDEuMCwKICAibWVtIjogNTEyLAogICJpbnN0YW5jZXMiOiAxLAogICJjbWQiOiAicHl0aG9uMyAtbSBodHRwLnNlcnZlciB7e3BvcnR9fSIsCiAgImNvbnRhaW5lciI6IHsKICAgICJ0eXBlIjogIkRPQ0tFUiIsCiAgICAiZG9ja2VyIjogewogICAgICAiaW1hZ2UiOiAicHl0aG9uOjMiLAogICAgICAibmV0d29yayI6ICJIT1NUIgogICAgfQogIH0KfQo="
+      "v2AppMustacheTemplate": "ewogICJpZCI6ICJ7e25hbWV9fSIsCiAgImNwdXMiOiAxLjAsCiAgIm1lbSI6IDUxMiwKICAiaW5zdGFuY2VzIjogMSwKICAiY21kIjogInB5dGhvbjMgLW0gaHR0cC5zZXJ2ZXIge3twb3J0fX0iLAogICJjb250YWluZXIiOiB7CiAgICAidHlwZSI6ICJET0NLRVIiLAogICAgImRvY2tlciI6IHsKICAgICAgImltYWdlIjogInB5dGhvbjozIiwKICAgICAgIm5ldHdvcmsiOiAiSE9TVCIKICAgIH0KICB9Cn0K"
     },
     "name": "helloworld",
     "packagingVersion": "3.0",

--- a/cli/tests/data/package/json/test_package_metadata.json
+++ b/cli/tests/data/package/json/test_package_metadata.json
@@ -1,32 +1,40 @@
 {
-    "command": {
-        "pip": [
-            "dcos<1.0",
-            "git+https://github.com/mesosphere/dcos-helloworld.git#dcos-helloworld=0.1.0"
-         ]
-     },
-    "config": {
-        "$schema": "http://json-schema.org/schema#",
-        "additionalProperties": false,
-        "properties": {
-            "port": {
-                "default": 8080,
-                "type": "integer"
-             }
-        },
-        "type": "object"
-    },
-    "description": "Example DCOS application package",
-    "maintainer": "support@mesosphere.io",
-    "marathon": {
-        "v2AppMustacheTemplate": "ewogICJpZCI6ICJoZWxsb3dvcmxkIiwKICAiY3B1cyI6IDEuMCwKICAibWVtIjogNTEyLAogICJpbnN0YW5jZXMiOiAxLAogICJjbWQiOiAicHl0aG9uMyAtbSBodHRwLnNlcnZlciB7e3BvcnR9fSIsCiAgImNvbnRhaW5lciI6IHsKICAgICJ0eXBlIjogIkRPQ0tFUiIsCiAgICAiZG9ja2VyIjogewogICAgICAiaW1hZ2UiOiAicHl0aG9uOjMiLAogICAgICAibmV0d29yayI6ICJIT1NUIgogICAgfQogIH0KfQo="
-     },
-    "name": "helloworld",
     "packagingVersion": "3.0",
-    "postInstallNotes": "A sample post-installation message",
+    "tags": [
+      "mesosphere",
+      "example",
+      "subcommand"
+    ],
+    "name": "helloworld",
     "preInstallNotes": "A sample pre-installation message",
-    "releaseVersion": 0,
-    "tags": ["mesosphere", "example", "subcommand"],
+    "postInstallNotes": "A sample post-installation message",
+    "website": "https://github.com/mesosphere/dcos-helloworld",
     "version": "0.1.0",
-    "website": "https://github.com/mesosphere/dcos-helloworld"
-}
+    "maintainer": "support@mesosphere.io",
+    "releaseVersion": 0,
+    "command": {
+      "pip": [
+        "dcos<1.0",
+        "git+https://github.com/mesosphere/dcos-helloworld.git#dcos-helloworld=0.1.0"
+      ]
+    },
+    "config": {
+      "type": "object",
+      "properties": {
+        "port": {
+          "type": "integer",
+          "default": 8080
+        },
+        "name": {
+          "type": "string",
+          "default": "helloworld"
+        }
+      },
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/schema#"
+    },
+    "marathon": {
+      "v2AppMustacheTemplate": "ewogICJpZCI6ICJ7e25hbWV9fSIsCiAgImNwdXMiOiAxLjAsCiAgIm1lbSI6IDUxMiwKICAiaW5zdGFuY2VzIjogMSwKICAiY21kIjogInB5dGhvbjMgLW0gaHR0cC5zZXJ2ZXIge3twb3J0fX0iLAogICJjb250YWluZXIiOiB7CiAgICAidHlwZSI6ICJET0NLRVIiLAogICAgImRvY2tlciI6IHsKICAgICAgImltYWdlIjogInB5dGhvbjozIiwKICAgICAgIm5ldHdvcmsiOiAiSE9TVCIKICAgIH0KICB9Cn0K"
+    },
+    "description": "Example DCOS application package"
+  }

--- a/cli/tests/integrations/test_package.py
+++ b/cli/tests/integrations/test_package.py
@@ -1100,6 +1100,7 @@ def _helloworld_cli(global_=False):
 def _package(name,
              args,
              stdout=b'',
+             uninstall_app_id='',
              uninstall_stderr=b''):
     """Context manager that installs a package on entrance, and uninstalls it on
     exit.
@@ -1110,6 +1111,8 @@ def _package(name,
     :type args: [str]
     :param stdout: Expected stdout
     :type stdout: bytes
+    :param uninstall_app_id: App id for uninstallation
+    :type uninstall_app_id: string
     :param uninstall_stderr: Expected stderr
     :type uninstall_stderr: bytes
     :rtype: None
@@ -1128,9 +1131,10 @@ def _package(name,
         yield
     finally:
         if installed:
-            assert_command(
-                ['dcos', 'package', 'uninstall', name, '--yes'],
-                stderr=uninstall_stderr)
+            command = ['dcos', 'package', 'uninstall', name, '--yes']
+            if uninstall_app_id:
+                command.append('--app-id='+uninstall_app_id)
+            assert_command(command, stderr=uninstall_stderr)
             watch_all_deployments()
 
 

--- a/dcos/util.py
+++ b/dcos/util.py
@@ -51,19 +51,24 @@ def tempdir():
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
 
-
 @contextlib.contextmanager
-def temptext():
+def temptext(content=None):
     """A context manager for temporary files.
 
     The lifetime of the returned temporary file corresponds to the
     lexical scope of the returned file descriptor.
 
+    :param content: Content to populate the file with.
+    :type content: bytes
     :return: reference to a temporary file
     :rtype: (fd, str)
     """
 
     fd, path = tempfile.mkstemp()
+
+    if content:
+        os.write(fd, content)
+
     try:
         yield (fd, path)
     finally:


### PR DESCRIPTION
When there are multiple apps from a given package, which also happens to have a subcommand, uninstalling any of these app would remove the subcommand : 
```
$ dcos package install hello-world --yes --options /path/to/options1.json
$ dcos package install hello-world --yes --options /path/to/options2.json
$ dcos package list                                                             
NAME         VERSION       APP       COMMAND      DESCRIPTION                                                   
hello-world  2.0.0-0.30.0  /hello1  hello-world  An example implementation of a stateful service using the...  
                           /hello2
$ dcos package uninstall hello-world --yes --app-id=/hello1
# at this point, "dcos hello-world" is not available anymore, but /hello2 is still running
```

This PR changes the uninstall behaviour so that no subcommand is removed as long as there is at least one remaining app after uninstalling.

I'm not able to add tests for this at the moment as our integration tests use a `helloworld` package from a universe server which doesn't support the `--options` flag, I'm currently investigating this with @larioj and extracted these tests refactoring into https://github.com/dcos/dcos-cli/pull/1051.

https://jira.mesosphere.com/browse/DCOS-17880