### PR TITLE
allow metronome schedule updates to not require an array

### DIFF
--- a/cli/dcoscli/job/main.py
+++ b/cli/dcoscli/job/main.py
@@ -500,7 +500,7 @@ def _update_schedules(job_id, schedules_file):
     :rtype: int
     """
     schedules = _get_resource(schedules_file)
-    schedule = schedules[0]  # 1 update
+    schedule = parse_schedule_json(schedules)
     schedule_id = schedule['id']
 
     return _update_schedule(job_id, schedule_id, schedule)


### PR DESCRIPTION
fixes bug found on schedule update which force schedules to be in an array.  
now there can be 1 or 1 in an array.