### PR TITLE
fixes relative to test_setup_noninteractive

### DIFF
--- a/cli/dcoscli/cluster/main.py
+++ b/cli/dcoscli/cluster/main.py
@@ -269,11 +269,8 @@ def _store_cluster_cert(cert, no_check):
     :rtype: bool
     """
 
-    if not no_check:
-        if not _user_cert_validation(cert):
-            # we don't have a cert, but we still want to validate SSL
-            config.set_val("core.ssl_verify", "true")
-            return False
+    if not no_check and not _user_cert_validation(cert):
+        raise DCOSException("Couldn't get confirmation for the fingerprint.")
 
     with util.temptext() as temp_file:
         _, temp_path = temp_file

--- a/cli/tests/integrations/helpers/common.py
+++ b/cli/tests/integrations/helpers/common.py
@@ -21,10 +21,10 @@ def exec_command(cmd, env=None, stdin=None, timeout=None):
     :type env: dict | None
     :param stdin: File to use for stdin
     :type stdin: file
-    :param timeout: If the process doesn't terminate after this timeout,
-                    it will get killed and a subprocess.TimeoutExpired
-                    exception will be raised. The timeout is in seconds.
+    :param timeout: The timeout for the process to terminate.
     :type timeout: int
+    :raises: subprocess.TimeoutExpired when the timeout is reached
+             before the process finished.
     :returns: A tuple with the returncode, stdout and stderr
     :rtype: (int, bytes, bytes)
     """
@@ -46,7 +46,9 @@ def exec_command(cmd, env=None, stdin=None, timeout=None):
         # process and finish communication.
         # https://docs.python.org/3.5/library/subprocess.html#subprocess.Popen.communicate
         process.kill()
-        process.communicate()
+        stdout, stderr = process.communicate()
+        print('STDOUT: {}'.format(_truncate(stdout.decode('utf-8'))))
+        print('STDERR: {}'.format(_truncate(stderr.decode('utf-8'))))
         raise
 
     # This is needed to get rid of '\r' from Windows's lines endings.

--- a/cli/tests/integrations/test_cluster.py
+++ b/cli/tests/integrations/test_cluster.py
@@ -52,16 +52,13 @@ def test_setup_noninteractive():
     This makes sure the process doesn't prompt for input forever (DCOS-15590).
     """
 
-    try:
-        returncode, stdout, stderr = exec_command(
-            ['dcos',
-             'cluster',
-             'setup',
-             'https://dcos.snakeoil.mesosphere.com'],
-            timeout=30,
-            stdin=subprocess.DEVNULL)
-    except subprocess.TimeoutExpired:
-        assert False, 'timed out waiting for process to exit'
+    returncode, stdout, stderr = exec_command(
+        ['dcos',
+         'cluster',
+         'setup',
+         'https://dcos.snakeoil.mesosphere.com'],
+        timeout=30,
+        stdin=subprocess.DEVNULL)
 
     assert returncode == 1
     assert b"'' is not a valid response" in stdout

--- a/cli/tests/integrations/test_cluster.py
+++ b/cli/tests/integrations/test_cluster.py
@@ -53,7 +53,7 @@ def test_setup_noninteractive():
     """
 
     try:
-        returncode, stdout, _ = exec_command(
+        returncode, stdout, stderr = exec_command(
             ['dcos',
              'cluster',
              'setup',
@@ -65,3 +65,4 @@ def test_setup_noninteractive():
 
     assert returncode == 1
     assert b"'' is not a valid response" in stdout
+    assert b"Couldn't get confirmation for the fingerprint." in stderr


### PR DESCRIPTION
Here are a few fixes relative to `test_setup_noninteractive`, which we have seen failing occasionally on CI.

## Stopping the flow in case of non confirmation

The main problem here is that we were not stopping the flow whenever the user didn't confirm the certificate fingerprint : 

``` bash
$ dcos cluster setup http://dcos.snakeoil.mesosphere.com </dev/null
SHA256 fingerprint of cluster certificate bundle:
8B:C0:40:62:2F:45:52:3E:EA:7B:38:C0:CE:D8:AB:15:2A:A8:BA:2C:3F:D7:B7:D7:65:B5:03:37:D3:E4:D3:17 [yes/no] '' is not a valid response.
SHA256 fingerprint of cluster certificate bundle:
8B:C0:40:62:2F:45:52:3E:EA:7B:38:C0:CE:D8:AB:15:2A:A8:BA:2C:3F:D7:B7:D7:65:B5:03:37:D3:E4:D3:17 [yes/no] '' is not a valid response.
SHA256 fingerprint of cluster certificate bundle:
8B:C0:40:62:2F:45:52:3E:EA:7B:38:C0:CE:D8:AB:15:2A:A8:BA:2C:3F:D7:B7:D7:65:B5:03:37:D3:E4:D3:17 [yes/no] '' is not a valid response.
dcos.snakeoil.mesosphere.com's username: @dcos.snakeoil.mesosphere.com's password: 
```

At this point the user is prompted indefinitely for a password.

## Why the test was passing on unix?

We've seen this test passing on unix and occasionally failing on windows. The reason for this is that it was actually testing another failure. When there is no TTY, that command fails in another way : 

``` bash

$ setsid sh -c 'tty; dcos cluster setup http://dcos.snakeoil.mesosphere.com </dev/null; echo $?' < /dev/null > output 2>&1
$ cat output 
not a tty
SHA256 fingerprint of cluster certificate bundle:
8B:C0:40:62:2F:45:52:3E:EA:7B:38:C0:CE:D8:AB:15:2A:A8:BA:2C:3F:D7:B7:D7:65:B5:03:37:D3:E4:D3:17 [yes/no] '' is not a valid response.
SHA256 fingerprint of cluster certificate bundle:
8B:C0:40:62:2F:45:52:3E:EA:7B:38:C0:CE:D8:AB:15:2A:A8:BA:2C:3F:D7:B7:D7:65:B5:03:37:D3:E4:D3:17 [yes/no] '' is not a valid response.
SHA256 fingerprint of cluster certificate bundle:
8B:C0:40:62:2F:45:52:3E:EA:7B:38:C0:CE:D8:AB:15:2A:A8:BA:2C:3F:D7:B7:D7:65:B5:03:37:D3:E4:D3:17 [yes/no] '' is not a valid response.
dcos.snakeoil.mesosphere.com's username: /usr/lib/python3.5/getpass.py:92: GetPassWarning: Can not control echo on the terminal.
  passwd = fallback_getpass(prompt, stream)
Warning: Password input may be echoed.
@dcos.snakeoil.mesosphere.com's password: Traceback (most recent call last):
  File "/usr/lib/python3.5/getpass.py", line 70, in unix_getpass
    old = termios.tcgetattr(fd)     # a copy to save
termios.error: (25, 'Inappropriate ioctl for device')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/bamarni/dcos/dcos-cli/cli/dcoscli/subcommand.py", line 103, in run_and_capture
    exit_code = m.main([self._command] + self._args)
  File "/home/bamarni/dcos/dcos-cli/cli/dcoscli/cluster/main.py", line 25, in main
    return _main(argv)
  File "/home/bamarni/dcos/dcos-cli/cli/dcoscli/util.py", line 24, in wrapper
    result = func(*args, **kwargs)
  File "/home/bamarni/dcos/dcos-cli/cli/dcoscli/cluster/main.py", line 40, in _main
    return cmds.execute(_cmds(), args)
  File "/home/bamarni/dcos/dcos-cli/dcos/cmds.py", line 43, in execute
    return function(*params)
  File "/home/bamarni/dcos/dcos-cli/cli/dcoscli/cluster/main.py", line 228, in setup
    provider, username, key_path)
  File "/home/bamarni/dcos/dcos-cli/cli/dcoscli/auth/main.py", line 250, in login
    auth.header_challenge_auth(dcos_url)
  File "/home/bamarni/dcos/dcos-cli/dcos/auth.py", line 329, in header_challenge_auth
    token = _get_dcostoken_by_dcos_uid_password_auth(dcos_url)
  File "/home/bamarni/dcos/dcos-cli/dcos/auth.py", line 152, in _get_dcostoken_by_dcos_uid_password_auth
    username, password = _prompt_for_uid_password(username, hostname)
  File "/home/bamarni/dcos/dcos-cli/dcos/auth.py", line 126, in _prompt_for_uid_password
    password = getpass.getpass("{}@{}'s password: ".format(username, hostname))
  File "/usr/lib/python3.5/getpass.py", line 92, in unix_getpass
    passwd = fallback_getpass(prompt, stream)
  File "/usr/lib/python3.5/getpass.py", line 127, in fallback_getpass
    return _raw_input(prompt, stream)
  File "/usr/lib/python3.5/getpass.py", line 149, in _raw_input
    raise EOFError
EOFError
1
```

This happens in `unix_getpass`, so the windows version probably has another behaviour. In any case, fixing the previous problem should solve this.

## Print stdout/stderr in case of timeout

Lastly, printing stdout/stderr in case of a timeout would have allowed us to catch this problem earlier. This  PR also adds a commit which delays the timeout exception only after it has printed outputs.