### PR TITLE
Also migrate deprecated subcommand directories when migrating deprecated cluster configs.

### DIFF
--- a/dcos/cluster.py
+++ b/dcos/cluster.py
@@ -23,8 +23,8 @@ def move_to_cluster_config():
     :rtype: None
     """
 
-    global_config = config.get_global_config()
-    dcos_url = config.get_config_val("core.dcos_url", global_config)
+    deprecated_config = config.get_deprecated_config()
+    dcos_url = config.get_config_val("core.dcos_url", deprecated_config)
 
     # if no cluster is set, do not move the cluster yet
     if dcos_url is None:
@@ -49,9 +49,9 @@ def move_to_cluster_config():
 
     util.ensure_dir_exists(cluster_path)
 
-    # move config file to new location
-    global_config_path = config.get_global_config_path()
-    util.sh_copy(global_config_path, cluster_path)
+    # copy config file to new location
+    deprecated_config_path = config.get_deprecated_config_path()
+    util.sh_copy(deprecated_config_path, cluster_path)
 
     # set cluster as attached
     util.ensure_file_exists(os.path.join(

--- a/dcos/cluster.py
+++ b/dcos/cluster.py
@@ -6,7 +6,7 @@ import urllib
 
 from urllib.request import urlopen
 
-from dcos import config, constants, http, util
+from dcos import config, constants, http, subcommand, util
 from dcos.errors import DCOSException
 
 
@@ -52,6 +52,13 @@ def move_to_cluster_config():
     # copy config file to new location
     deprecated_config_path = config.get_deprecated_config_path()
     util.sh_copy(deprecated_config_path, cluster_path)
+
+    # copy subcommand directory to new location
+    deprecated_subcommand_dir = subcommand.deprecated_subcommand_dir()
+    if os.path.exists(deprecated_subcommand_dir):
+        subcommand_dir = os.path.join(
+            cluster_path, constants.DCOS_SUBCOMMAND_SUBDIR)
+        util.sh_copytree(deprecated_subcommand_dir, subcommand_dir)
 
     # set cluster as attached
     util.ensure_file_exists(os.path.join(

--- a/dcos/config.py
+++ b/dcos/config.py
@@ -18,13 +18,14 @@ def uses_deprecated_config():
     specific config
     """
 
-    global_config = get_global_config_path()
+    deprecated_config = get_deprecated_config_path()
     cluster_config = get_clusters_path()
-    return not os.path.exists(cluster_config) and os.path.exists(global_config)
+    return not os.path.exists(cluster_config) and \
+               os.path.exists(deprecated_config)
 
 
-def get_global_config_path():
-    """Returns the path to the deprecated global DCOS config file.
+def get_deprecated_config_path():
+    """Returns the path to the deprecated 'global' DCOS config file.
 
     :returns: path to the DCOS config file
     :rtype: str
@@ -34,8 +35,8 @@ def get_global_config_path():
     return os.environ.get(constants.DCOS_CONFIG_ENV, default_path)
 
 
-def get_global_config(mutable=False):
-    """Returns the deprecated global DCOS config file
+def get_deprecated_config(mutable=False):
+    """Returns the deprecated 'global' DCOS config file
 
     :param mutable: True if the returned Toml object should be mutable
     :type mutable: boolean
@@ -43,7 +44,7 @@ def get_global_config(mutable=False):
     :rtype: Toml | MutableToml
     """
 
-    return load_from_path(get_global_config_path(), mutable)
+    return load_from_path(get_deprecated_config_path(), mutable)
 
 
 def get_attached_cluster_path():
@@ -99,14 +100,14 @@ def get_clusters_path():
 
 def get_config_path():
     """Returns the path to the DCOS config file of the attached cluster.
-    If still using "global" config return that toml instead
+    If still using deprecated config return that toml instead
 
     :returns: path to the DCOS config file
     :rtype: str
     """
 
     if uses_deprecated_config():
-        return get_global_config_path()
+        return get_deprecated_config_path()
     else:
         cluster_path = get_attached_cluster_path()
         return os.path.join(cluster_path, "dcos.toml")
@@ -138,7 +139,7 @@ def get_config(mutable=False):
     cluster_path = get_attached_cluster_path()
     if cluster_path is None:
         if uses_deprecated_config():
-            return get_global_config(mutable)
+            return get_deprecated_config(mutable)
 
         msg = ("No cluster is attached. "
                "Please run `dcos cluster attach <cluster-name>`")

--- a/dcos/constants.py
+++ b/dcos/constants.py
@@ -14,12 +14,16 @@ DCOS_CLUSTER = 'DCOS_CLUSTER'
 DCOS_CLUSTER_ATTACHED_FILE = "attached"
 """Name of the file indicating the current attached cluster"""
 
-DCOS_SUBCOMMAND_ENV_SUBDIR = 'env'
-"""In a package's directory, this is the cli contents subdirectory."""
+DCOS_GLOBAL_SUBCOMMAND_SUBDIR = 'global_subcommands'
+"""Name of the subdirectory that contains all of the global subcommands. This
+is relative to the location of the executable."""
 
 DCOS_SUBCOMMAND_SUBDIR = 'subcommands'
 """Name of the subdirectory that contains all of the subcommands. This is
 relative to the location of the executable."""
+
+DCOS_SUBCOMMAND_ENV_SUBDIR = 'env'
+"""In a package's directory, this is the cli contents subdirectory."""
 
 DCOS_CONFIG_ENV = 'DCOS_CONFIG'
 """Name of the environment variable pointing to the DC/OS config."""

--- a/dcos/subcommand.py
+++ b/dcos/subcommand.py
@@ -377,11 +377,20 @@ def install(pkg, global_=False):
     _install_cli(pkg, pkg_dir)
 
 
-def global_subcommand_dir():
-    """ Returns global subcommand dir. defaults to ~/.dcos/subcommands """
+def deprecated_subcommand_dir():
+    """ Returns deprecated 'global' subcommand dir.
+        Defaults to ~/.dcos/subcommands """
 
     return os.path.join(config.get_config_dir_path(),
                         constants.DCOS_SUBCOMMAND_SUBDIR)
+
+
+def global_subcommand_dir():
+    """ Returns global subcommand dir.
+        Defaults to ~/.dcos/global_subcommands """
+
+    return os.path.join(config.get_config_dir_path(),
+                        constants.DCOS_GLOBAL_SUBCOMMAND_SUBDIR)
 
 
 def _cluster_subcommand_dir():

--- a/dcos/util.py
+++ b/dcos/util.py
@@ -117,6 +117,31 @@ def sh_copy(src, dst):
         raise DCOSException(e)
 
 
+def sh_copytree(src, dst):
+    """Copy src directory to dst directory.
+
+    :param src: source directory
+    :type src: str
+    :param dst: destination directory
+    :type dst: str
+    :rtype: None
+    """
+    try:
+        shutil.copytree(src, dst)
+    except EnvironmentError as e:
+        logger.exception('Unable to copy [%s] to [%s]', src, dst)
+        if e.strerror:
+            if e.filename:
+                raise DCOSException("{}: {}".format(e.strerror, e.filename))
+            else:
+                raise DCOSException(e.strerror)
+        else:
+            raise DCOSException(e)
+    except Exception as e:
+        logger.exception('Unknown error while coping [%s] to [%s]', src, dst)
+        raise DCOSException(e)
+
+
 def sh_move(src, dst):
     """Move file src to the file or directory dst.
 


### PR DESCRIPTION
The 0.5.x CLI will automatically migrate config files created by the the 0.4.x CLI from:
```
$DCOS_DIR/dcos.toml
to
$DCOS_DIR/clusters/<cluster-id>/dcos.toml
```

However, we were previously not migrating the `subcommands` folder from the old location to the new. The rationale for this was that the 0.5.x CLI still maintains the notion of "globally installed" subcommands, and we could just treat the legacy `subcommands` folder as our new global one.

The problem with this approach is that commands contained in the legacy `subcommands` folder may never have been intended for multiple clusters to use (in the 0.4.x CLI, there was no notion of multi-cluster support). As such, it is unreasonable to assume that the commands contained in this folder should be accessible globally.

A use case in the wild where this actually became a problem is outlined in the following ticket:
https://jira.mesosphere.com/browse/DCOS_OSS-1588

This PR fixes this by separating the concepts of a "global" subcommand folder from a "deprecated" subcommand folder and migrates the deprecated folder into the new config location at the same time it migrates the config itself.

When new subcommands are then added globally, they are added into the new "global" subcommands folder.

As before, both the deprecated `config.yaml` file and the deprecated `subcommand` folder remain untouched in case users ever want to downgrade from the 0.5.x CLI back to the 0.4.x CLI and still access the same cluster they had before the upgrade.