### PR TITLE
job list needs the schedules to determine if the status is scheduled

### DIFF
--- a/cli/dcoscli/job/main.py
+++ b/cli/dcoscli/job/main.py
@@ -31,6 +31,7 @@ EMBEDS_FOR_JOB_HISTORY = [
 # unknown number of jobs, using history summary
 EMBEDS_FOR_JOBS_HISTORY = [
     metronome.EMBED_ACTIVE_RUNS,
+    metronome.EMBED_SCHEDULES,
     metronome.EMBED_HISTORY_SUMMARY]
 
 


### PR DESCRIPTION
the job list query was missing the embedded schedules in order to determine if the job is scheduled or not.  fix.