### PR TITLE
fail in case the deprecated --app-id option is used for install (closes #463)

### DIFF
--- a/cli/dcoscli/package/main.py
+++ b/cli/dcoscli/package/main.py
@@ -362,8 +362,6 @@ def _install(package_name, package_version, options_path, app_id, cli,
         # Install in Marathon
         msg = 'Installing Marathon app for package [{}] version [{}]'.format(
             pkg.name(), pkg.version())
-        if app_id is not None:
-            msg += ' with app id [{}]'.format(app_id)
 
         emitter.publish(msg)
 
@@ -371,6 +369,7 @@ def _install(package_name, package_version, options_path, app_id, cli,
             msg = "Usage of --app-id is deprecated. Use --options instead " \
                   "and specify a file that contains [service.name] property"
             emitter.publish(msg)
+            return 1
 
         package_manager.install_app(pkg, user_options, app_id)
 

--- a/cli/tests/integrations/test_package.py
+++ b/cli/tests/integrations/test_package.py
@@ -545,41 +545,11 @@ def test_images_in_metadata():
     delete_zk_node('dcos-service-cassandra')
 
 
-def test_install_with_id(zk_znode):
-    args = ['--app-id=chronos-1', '--yes']
-    stdout = (
-        b'Installing Marathon app for package [chronos] version [3.0.1] with '
-        b'app id [chronos-1]\n'
-        b'Usage of --app-id is deprecated. Use --options instead and specify '
-        b'a file that contains [service.name] property\n'
-
-    )
-
-    _install_chronos(args=args, stdout=stdout)
-
-    args = ['--app-id=chronos-2', '--yes']
-    stdout = (
-        b'Installing Marathon app for package [chronos] version [3.0.1] with '
-        b'app id [chronos-2]\n'
-        b'Usage of --app-id is deprecated. Use --options instead and specify '
-        b'a file that contains [service.name] property\n'
-    )
-    _install_chronos(args=args, stdout=stdout)
-
-
 def test_install_missing_package():
     stderr = b'Package [missing-package] not found\n'
     assert_command(['dcos', 'package', 'install', 'missing-package'],
                    returncode=1,
                    stderr=stderr)
-
-
-def test_uninstall_with_id(zk_znode):
-    _uninstall_chronos(args=['--app-id=chronos-1'])
-
-
-def test_uninstall_all(zk_znode):
-    _uninstall_chronos(args=['--all'])
 
 
 def test_uninstall_missing():


### PR DESCRIPTION
This triggers a hard failure instead of the deprecation whenever `--app-id` is passed for installing a package, and updates the integration test suite accordingly.