### PR TITLE
[http] always use a timeout by default

### DIFF
--- a/dcos/http.py
+++ b/dcos/http.py
@@ -171,7 +171,7 @@ def _request(method,
 def request(method,
             url,
             is_success=_default_is_success,
-            timeout=None,
+            timeout=DEFAULT_TIMEOUT,
             verify=None,
             toml_config=None,
             **kwargs):


### PR DESCRIPTION
Currently, in case of an unreachable cluster, multiple commands would hang indefinitely (eg. "dcos node", "dcos package list", etc.).

This makes the default timeout for http.request() to be 5 seconds.

From http://docs.python-requests.org/en/master/user/quickstart/#timeouts : 
> Nearly all production code should use this parameter in nearly all requests. Failure to do so can cause your program to hang indefinitely.

I'd like to retry the CI a few times with this, as this might cause flakiness... Maybe we would need an environment variable to overwrite this default.