### PR TITLE
fix code style errors on dcos package

### DIFF
--- a/dcos/http.py
+++ b/dcos/http.py
@@ -27,6 +27,7 @@ def _default_is_success(status_code):
 
     return 200 <= status_code < 300
 
+
 def _is_request_to_dcos(url, toml_config=None):
     """Checks if a request is for the DC/OS cluster.
 
@@ -55,6 +56,7 @@ def _is_request_to_dcos(url, toml_config=None):
         _request_match(cosmos_url, parsed_url)
 
     return is_request_to_cluster
+
 
 def _verify_ssl(url, verify=None, toml_config=None):
     """Returns whether to verify ssl for the given url

--- a/dcos/util.py
+++ b/dcos/util.py
@@ -51,6 +51,7 @@ def tempdir():
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
 
+
 @contextlib.contextmanager
 def temptext(content=None):
     """A context manager for temporary files.


### PR DESCRIPTION
```
flake8.main.application   MainProcess    814 INFO     Reporting errors
dcos/http.py:30:1: E302 expected 2 blank lines, found 1
dcos/http.py:59:1: E302 expected 2 blank lines, found 1
dcos/util.py:54:1: E302 expected 2 blank lines, found 1
flake8.main.application   MainProcess    815 INFO     Found a total of 20 violations and reported 3
ERROR: InvocationError: '/home/bamarni/dcos/dcos-cli/.tox/py35-syntax/bin/flake8 --verbose dcos tests setup.py'
_____________________________________ summary _____________________________________
ERROR:   py35-syntax: commands failed
```

Once #1038 is addressed we will be able to add the dcos syntax/unit test suite to CI (cf. https://jira.mesosphere.com/browse/DCOS_OSS-1543).