### PR TITLE
Updated Jenkinsfiles to remove reliance on custom CF templates and fix `ssh` tests.

### DIFF
--- a/ci/Jenkinsfile-linux-integration
+++ b/ci/Jenkinsfile-linux-integration
@@ -21,19 +21,31 @@ def platforms = ["linux"]
 /**
  * This generates the `dcos_launch` config for a particular build.
  */
-def generateConfig(deploymentName, templateUrl) {
+def generateConfig(deploymentName, installerUrl, sshKeyPath) {
     return """
 ---
 launch_config_version: 1
 deployment_name: ${deploymentName}
-template_url: ${templateUrl}
-provider: aws
+installer_url: ${installerUrl}
+platform: aws
+provider: onprem
 aws_region: us-west-2
-template_parameters:
-    KeyName: default
-    AdminLocation: 0.0.0.0/0
-    PublicSlaveInstanceCount: 1
-    SlaveInstanceCount: 1
+aws_key_name: default
+ssh_private_key_filename: ${sshKeyPath}
+os_name: cent-os-7
+instance_type: m4.xlarge
+num_masters: 1
+num_private_agents: 1
+num_public_agents: 1
+dcos_config:
+    cluster_name: DC/OS CLI Integration Tests
+    resolvers:
+        - 10.10.0.2
+    dns_search: us-west-2.compute.internal
+    master_discovery: static
+    cosmos_config:
+      staged_package_storage_uri: file:///var/lib/dcos/cosmos/staged-packages
+      package_storage_uri: file:///var/lib/dcos/cosmos/packages
 """
 }
 
@@ -69,7 +81,8 @@ class TestCluster implements Serializable {
                         "file": "${platform}_config.yaml",
                         "text" : script.generateConfig(
                                 "dcos-cli-${platform}-${script.env.ghprbPullId}-${script.env.BUILD_ID}-${createAttempts}",
-                                "${script.env.CF_TEMPLATE_URL}")])
+                                "${script.env.DCOS_INSTALLER_URL}",
+                                "${script.env.CLI_TEST_SSH_KEY_PATH}")])
 
                 script.sh "./dcos-launch create -c ${platform}_config.yaml -i ${platform}_cluster_info.json"
                 script.sh "./dcos-launch wait -i ${platform}_cluster_info.json"
@@ -180,11 +193,11 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
 
                         withCredentials(
                             [[$class: 'FileBinding',
-                             credentialsId: '1c206779-acc0-4844-97f6-7b3ed081a456',
-                             variable: 'DCOS_SNAKEOIL_CRT_PATH'],
-                            [$class: 'FileBinding',
-                             credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
-                             variable: 'CLI_TEST_SSH_KEY_PATH']]) {
+                              credentialsId: '1c206779-acc0-4844-97f6-7b3ed081a456',
+                              variable: 'DCOS_SNAKEOIL_CRT_PATH'],
+                             [$class: 'FileBinding',
+                              credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
+                              variable: 'CLI_TEST_SSH_KEY_PATH']]) {
 
                             withEnv(["DCOS_URL=${dcosUrl}",
                                      "DCOS_ACS_TOKEN=${acsToken}"]) {
@@ -243,6 +256,7 @@ builders['linux-tests'] = testBuilder('linux', 'py35', '/workspace')({
         dir('dcos-cli/cli') {
             sh '''
                export PYTHONIOENCODING=utf-8; \
+               export CLI_TEST_SSH_USER=centos; \
                export DCOS_CONFIG=tests/data/dcos.toml; \
                chmod 600 ${DCOS_CONFIG}; \
                echo dcos_acs_token = \\\"${DCOS_ACS_TOKEN}\\\" >> ${DCOS_CONFIG}; \
@@ -305,9 +319,12 @@ throttle(['dcos-cli']) {
              credentialsId: '7155bd15-767d-4ae3-a375-e0d74c90a2c4',
              accessKeyVariable: 'AWS_ACCESS_KEY_ID',
              secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
+            [$class: 'FileBinding',
+             credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
+             variable: 'CLI_TEST_SSH_KEY_PATH'],
             [$class: 'StringBinding',
-             credentialsId: '8d7d3d95-fc1f-42f4-941a-ad43487fcff7',
-             variable: 'CF_TEMPLATE_URL'],
+             credentialsId: '0b513aad-e0e0-4a82-95f4-309a80a02ff9',
+             variable: 'DCOS_INSTALLER_URL'],
             [$class: 'UsernamePasswordMultiBinding',
              credentialsId: '323df884-742b-4099-b8b7-d764e5eb9674',
              usernameVariable: 'DCOS_ADMIN_USERNAME',

--- a/ci/Jenkinsfile-linux-integration
+++ b/ci/Jenkinsfile-linux-integration
@@ -257,6 +257,7 @@ builders['linux-tests'] = testBuilder('linux', 'py35', '/workspace')({
             sh '''
                export PYTHONIOENCODING=utf-8; \
                export CLI_TEST_SSH_USER=centos; \
+               export CLI_TEST_MASTER_PROXY=true; \
                export DCOS_CONFIG=tests/data/dcos.toml; \
                chmod 600 ${DCOS_CONFIG}; \
                echo dcos_acs_token = \\\"${DCOS_ACS_TOKEN}\\\" >> ${DCOS_CONFIG}; \

--- a/ci/Jenkinsfile-mac-integration
+++ b/ci/Jenkinsfile-mac-integration
@@ -258,6 +258,7 @@ builders['mac-tests'] = testBuilder('mac', 'mac')({
             sh '''
                export PYTHONIOENCODING=utf-8; \
                export CLI_TEST_SSH_USER=centos; \
+               export CLI_TEST_MASTER_PROXY=true; \
                export DCOS_CONFIG=tests/data/dcos.toml; \
                chmod 600 ${DCOS_CONFIG}; \
                echo dcos_acs_token = \\\"${DCOS_ACS_TOKEN}\\\" >> ${DCOS_CONFIG}; \

--- a/ci/Jenkinsfile-mac-integration
+++ b/ci/Jenkinsfile-mac-integration
@@ -21,19 +21,31 @@ def platforms = ["mac"]
 /**
  * This generates the `dcos_launch` config for a particular build.
  */
-def generateConfig(deploymentName, templateUrl) {
+def generateConfig(deploymentName, installerUrl, sshKeyPath) {
     return """
 ---
 launch_config_version: 1
 deployment_name: ${deploymentName}
-template_url: ${templateUrl}
-provider: aws
+installer_url: ${installerUrl}
+platform: aws
+provider: onprem
 aws_region: us-west-2
-template_parameters:
-    KeyName: default
-    AdminLocation: 0.0.0.0/0
-    PublicSlaveInstanceCount: 1
-    SlaveInstanceCount: 1
+aws_key_name: default
+ssh_private_key_filename: ${sshKeyPath}
+os_name: cent-os-7
+instance_type: m4.xlarge
+num_masters: 1
+num_private_agents: 1
+num_public_agents: 1
+dcos_config:
+    cluster_name: DC/OS CLI Integration Tests
+    resolvers:
+        - 10.10.0.2
+    dns_search: us-west-2.compute.internal
+    master_discovery: static
+    cosmos_config:
+      staged_package_storage_uri: file:///var/lib/dcos/cosmos/staged-packages
+      package_storage_uri: file:///var/lib/dcos/cosmos/packages
 """
 }
 
@@ -69,7 +81,8 @@ class TestCluster implements Serializable {
                         "file": "${platform}_config.yaml",
                         "text" : script.generateConfig(
                                 "dcos-cli-${platform}-${script.env.ghprbPullId}-${script.env.BUILD_ID}-${createAttempts}",
-                                "${script.env.CF_TEMPLATE_URL}")])
+                                "${script.env.DCOS_INSTALLER_URL}",
+                                "${script.env.CLI_TEST_SSH_KEY_PATH}")])
 
                 script.sh "./dcos-launch create -c ${platform}_config.yaml -i ${platform}_cluster_info.json"
                 script.sh "./dcos-launch wait -i ${platform}_cluster_info.json"
@@ -179,11 +192,11 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
 
                         withCredentials(
                             [[$class: 'FileBinding',
-                             credentialsId: '1c206779-acc0-4844-97f6-7b3ed081a456',
-                             variable: 'DCOS_SNAKEOIL_CRT_PATH'],
-                            [$class: 'FileBinding',
-                             credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
-                             variable: 'CLI_TEST_SSH_KEY_PATH']]) {
+                              credentialsId: '1c206779-acc0-4844-97f6-7b3ed081a456',
+                              variable: 'DCOS_SNAKEOIL_CRT_PATH'],
+                             [$class: 'FileBinding',
+                              credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
+                              variable: 'CLI_TEST_SSH_KEY_PATH']]) {
 
                             withEnv(["DCOS_URL=${dcosUrl}",
                                      "DCOS_ACS_TOKEN=${acsToken}"]) {
@@ -244,6 +257,7 @@ builders['mac-tests'] = testBuilder('mac', 'mac')({
         dir('dcos-cli/cli') {
             sh '''
                export PYTHONIOENCODING=utf-8; \
+               export CLI_TEST_SSH_USER=centos; \
                export DCOS_CONFIG=tests/data/dcos.toml; \
                chmod 600 ${DCOS_CONFIG}; \
                echo dcos_acs_token = \\\"${DCOS_ACS_TOKEN}\\\" >> ${DCOS_CONFIG}; \
@@ -306,9 +320,12 @@ throttle(['dcos-cli']) {
              credentialsId: '7155bd15-767d-4ae3-a375-e0d74c90a2c4',
              accessKeyVariable: 'AWS_ACCESS_KEY_ID',
              secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
+            [$class: 'FileBinding',
+             credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
+             variable: 'CLI_TEST_SSH_KEY_PATH'],
             [$class: 'StringBinding',
-             credentialsId: '8d7d3d95-fc1f-42f4-941a-ad43487fcff7',
-             variable: 'CF_TEMPLATE_URL'],
+             credentialsId: '0b513aad-e0e0-4a82-95f4-309a80a02ff9',
+             variable: 'DCOS_INSTALLER_URL'],
             [$class: 'UsernamePasswordMultiBinding',
              credentialsId: '323df884-742b-4099-b8b7-d764e5eb9674',
              usernameVariable: 'DCOS_ADMIN_USERNAME',

--- a/ci/Jenkinsfile-windows-integration
+++ b/ci/Jenkinsfile-windows-integration
@@ -21,19 +21,31 @@ def platforms = ["windows"]
 /**
  * This generates the `dcos_launch` config for a particular build.
  */
-def generateConfig(deploymentName, templateUrl) {
+def generateConfig(deploymentName, installerUrl, sshKeyPath) {
     return """
 ---
 launch_config_version: 1
 deployment_name: ${deploymentName}
-template_url: ${templateUrl}
-provider: aws
+installer_url: ${installerUrl}
+platform: aws
+provider: onprem
 aws_region: us-west-2
-template_parameters:
-    KeyName: default
-    AdminLocation: 0.0.0.0/0
-    PublicSlaveInstanceCount: 1
-    SlaveInstanceCount: 1
+aws_key_name: default
+ssh_private_key_filename: ${sshKeyPath}
+os_name: cent-os-7
+instance_type: m4.xlarge
+num_masters: 1
+num_private_agents: 1
+num_public_agents: 1
+dcos_config:
+    cluster_name: DC/OS CLI Integration Tests
+    resolvers:
+        - 10.10.0.2
+    dns_search: us-west-2.compute.internal
+    master_discovery: static
+    cosmos_config:
+      staged_package_storage_uri: file:///var/lib/dcos/cosmos/staged-packages
+      package_storage_uri: file:///var/lib/dcos/cosmos/packages
 """
 }
 
@@ -69,7 +81,8 @@ class TestCluster implements Serializable {
                         "file": "${platform}_config.yaml",
                         "text" : script.generateConfig(
                                 "dcos-cli-${platform}-${script.env.ghprbPullId}-${script.env.BUILD_ID}-${createAttempts}",
-                                "${script.env.CF_TEMPLATE_URL}")])
+                                "${script.env.DCOS_INSTALLER_URL}",
+                                "${script.env.CLI_TEST_SSH_KEY_PATH}")])
 
                 script.sh "./dcos-launch create -c ${platform}_config.yaml -i ${platform}_cluster_info.json"
                 script.sh "./dcos-launch wait -i ${platform}_cluster_info.json"
@@ -179,11 +192,11 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
 
                         withCredentials(
                             [[$class: 'FileBinding',
-                             credentialsId: '1c206779-acc0-4844-97f6-7b3ed081a456',
-                             variable: 'DCOS_SNAKEOIL_CRT_PATH'],
-                            [$class: 'FileBinding',
-                             credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
-                             variable: 'CLI_TEST_SSH_KEY_PATH']]) {
+                              credentialsId: '1c206779-acc0-4844-97f6-7b3ed081a456',
+                              variable: 'DCOS_SNAKEOIL_CRT_PATH'],
+                             [$class: 'FileBinding',
+                              credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
+                              variable: 'CLI_TEST_SSH_KEY_PATH']]) {
 
                             withEnv(["DCOS_URL=${dcosUrl}",
                                      "DCOS_ACS_TOKEN=${acsToken}"]) {
@@ -249,6 +262,7 @@ builders['windows-tests'] = testBuilder('windows', 'windows', 'C:\\windows\\work
             bat '''
                 bash -c " \
                 export PYTHONIOENCODING=utf-8; \
+                export CLI_TEST_SSH_USER=centos; \
                 export DCOS_CONFIG=tests/data/dcos.toml; \
                 cat ${DCOS_CONFIG}; \
                 unset DCOS_URL; \
@@ -309,9 +323,12 @@ throttle(['dcos-cli']) {
              credentialsId: '7155bd15-767d-4ae3-a375-e0d74c90a2c4',
              accessKeyVariable: 'AWS_ACCESS_KEY_ID',
              secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
+            [$class: 'FileBinding',
+             credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
+             variable: 'CLI_TEST_SSH_KEY_PATH'],
             [$class: 'StringBinding',
-             credentialsId: '8d7d3d95-fc1f-42f4-941a-ad43487fcff7',
-             variable: 'CF_TEMPLATE_URL'],
+             credentialsId: '0b513aad-e0e0-4a82-95f4-309a80a02ff9',
+             variable: 'DCOS_INSTALLER_URL'],
             [$class: 'UsernamePasswordMultiBinding',
              credentialsId: '323df884-742b-4099-b8b7-d764e5eb9674',
              usernameVariable: 'DCOS_ADMIN_USERNAME',

--- a/ci/Jenkinsfile-windows-integration
+++ b/ci/Jenkinsfile-windows-integration
@@ -263,6 +263,7 @@ builders['windows-tests'] = testBuilder('windows', 'windows', 'C:\\windows\\work
                 bash -c " \
                 export PYTHONIOENCODING=utf-8; \
                 export CLI_TEST_SSH_USER=centos; \
+                export CLI_TEST_MASTER_PROXY=true; \
                 export DCOS_CONFIG=tests/data/dcos.toml; \
                 cat ${DCOS_CONFIG}; \
                 unset DCOS_URL; \

--- a/cli/tests/integrations/helpers/common.py
+++ b/cli/tests/integrations/helpers/common.py
@@ -310,7 +310,7 @@ def ssh_output(cmd):
     proc, master = popen_tty(cmd)
 
     # wait for the ssh connection
-    time.sleep(5)
+    time.sleep(10)
 
     proc.poll()
     returncode = proc.returncode

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -240,6 +240,10 @@ def test_node_ssh_slave_with_command():
 def _node_ssh_output(args):
     cli_test_ssh_key_path = os.environ['CLI_TEST_SSH_KEY_PATH']
 
+    if os.environ.get('CLI_TEST_MASTER_PROXY') and \
+            '--master-proxy' not in args:
+        args.append('--master-proxy')
+
     cmd = ('ssh-agent /bin/bash -c "ssh-add {} 2> /dev/null && ' +
            'dcos node ssh --option StrictHostKeyChecking=no {}"').format(
         cli_test_ssh_key_path,
@@ -249,10 +253,6 @@ def _node_ssh_output(args):
 
 
 def _node_ssh(args, expected_returncode=None, expected_stdout=None):
-    if os.environ.get('CLI_TEST_MASTER_PROXY') and \
-            '--master-proxy' not in args:
-        args.append('--master-proxy')
-
     stdout, stderr, returncode = _node_ssh_output(args)
     assert returncode is expected_returncode, \
         'returncode = %r; stdout: = %s; stderr = %s' % (

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -240,6 +240,10 @@ def test_node_ssh_slave_with_command():
 def _node_ssh_output(args):
     cli_test_ssh_key_path = os.environ['CLI_TEST_SSH_KEY_PATH']
 
+    if os.environ.get('CLI_TEST_SSH_USER') and \
+            not any("--user" in a for a in args):
+        args.extend(['--user', os.environ.get('CLI_TEST_SSH_USER')])
+
     if os.environ.get('CLI_TEST_MASTER_PROXY') and \
             '--master-proxy' not in args:
         args.append('--master-proxy')

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -249,7 +249,8 @@ def _node_ssh_output(args):
         args.append('--master-proxy')
 
     cmd = ('ssh-agent /bin/bash -c "ssh-add {} 2> /dev/null && ' +
-           'dcos node ssh --option StrictHostKeyChecking=no {}"').format(
+           'dcos node ssh --option StrictHostKeyChecking=no ' +
+           '    --option ConnectTimeout=5 {}"').format(
         cli_test_ssh_key_path,
         ' '.join(args))
 


### PR DESCRIPTION
Previously, we relied on custom cloud formation templates to launch the DC/OS clusters required by our CI jobs. This commit updates all of our integration test Jenkinsfiles to instead use dcos-launch in "onprem" mode with the proper configuration setup instead of running against these custom templates.

As part of this PR, it became obvious that some extra work was needed to get our CI system working properly for our various SSH tests with this change. The commits that fix those issues are included in this PR.