### PR TITLE
Mention CLI_TEST_MASTER_PROXY=1 in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,6 +141,13 @@ environment appropriately.
     $ export CLI_TEST_SSH_KEY_PATH=<path-to-ssh-key>
 
 
+#. (optional) Enable :code:`CLI_TEST_MASTER_PROXY` in case your private agents
+   are not reachable from the machine you're running tests on. This will proxy
+   the SSH connection throught the master node during integration tests.
+
+    $ export CLI_TEST_MASTER_PROXY=1
+
+
 #. Add the following resolution to your :code:`/etc/hosts` file. The :code:`ssl`
    integration tests resolve :code:`dcos.snakeoil.mesosphere.com` to test SSL certs::
 


### PR DESCRIPTION
When running integration tests from a machine which cannot reach all
nodes through the network, one would get this failure :

    tests/integrations/test_node.py:257: AssertionError
    ------------------------------ Captured stdout call
    -------------------------------
    SSH COMMAND: ssh-agent /bin/bash -c "ssh-add
    /home/bamarni/.ssh/mesosphere_shared 2> /dev/null && dcos node ssh
    --option StrictHostKeyChecking=no --leader"
    SSH STDOUT:
    SSH STDERR: Running `ssh -t -o StrictHostKeyChecking=no core@10.0.6.194`

    If you are running this command from a separate network than DC/OS,
    consider using `--master-proxy` or `--proxy-ip`
    ssh: connect to host 10.0.6.194 port 22: Network is unreachable

This is for example the case when running integration tests locally with
the default cloudformation template.

https://jira.mesosphere.com/browse/DCOS_OSS-1624