### PR TITLE
CI: Run syntax / unit tests of the dcos package

### DIFF
--- a/ci/Jenkinsfile-linux-integration
+++ b/ci/Jenkinsfile-linux-integration
@@ -236,6 +236,10 @@ builders['linux-tests'] = testBuilder('linux', 'py35', '/workspace')({
            sed -iold "s/^.* dcos.snakeoil.mesosphere.com$/${DCOS_URL} dcos.snakeoil.mesosphere.com/" /etc/hosts || \
            echo ${DCOS_URL} dcos.snakeoil.mesosphere.com >> /etc/hosts'''
 
+        dir('dcos-cli') {
+            sh 'make test'
+        }
+
         dir('dcos-cli/cli') {
             sh '''
                export PYTHONIOENCODING=utf-8; \

--- a/ci/Jenkinsfile-mac-integration
+++ b/ci/Jenkinsfile-mac-integration
@@ -237,6 +237,10 @@ builders['mac-tests'] = testBuilder('mac', 'mac')({
            echo ${DCOS_URL} dcos.snakeoil.mesosphere.com >> hosts.local; \
            sudo cp ./hosts.local /etc/hosts'''
 
+        dir('dcos-cli') {
+            sh 'make test'
+        }
+
         dir('dcos-cli/cli') {
             sh '''
                export PYTHONIOENCODING=utf-8; \

--- a/ci/Jenkinsfile-windows-integration
+++ b/ci/Jenkinsfile-windows-integration
@@ -235,6 +235,10 @@ builders['windows-tests'] = testBuilder('windows', 'windows', 'C:\\windows\\work
             echo %DCOS_URL% dcos.snakeoil.mesosphere.com >> C:\\windows\\system32\\drivers\\etc\\hosts &
             echo dcos_acs_token = \"%DCOS_ACS_TOKEN%\" >> dcos-cli\\cli\\tests\\data\\dcos.toml'''
 
+        dir('dcos-cli') {
+            bat 'make test'
+        }
+
         dir('dcos-cli/cli') {
             bat '''
                 bash -c " \

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -85,7 +85,7 @@ def test_setup_cluster_config(mock_get):
             mock_get.return_value = mock_resp
             path = cluster.setup_cluster_config("fake_url", setup_temp, False)
             expected_path = os.path.join(
-                tempdir, constants.DCOS_CLUSTERS_SUBDIR + "/" + cluster_id)
+                tempdir, constants.DCOS_CLUSTERS_SUBDIR, cluster_id)
             assert path == expected_path
             assert os.path.exists(path)
             assert os.path.exists(os.path.join(path, "dcos.toml"))


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS_OSS-1543

Unit tests were not passing on windows because of a wrong directory separator used during an equality assertion.