### PR TITLE
show fault domain in node and task subcommand output

### DIFF
--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -468,12 +468,18 @@ def _list(json_, extra_field_names):
     for master in masters:
         if master['ip'] == master_state['hostname']:
             master['type'] = 'master (leader)'
+            region, zone = util.get_fault_domain(master_state)
+            master['region'] = region
+            master['zone'] = zone
             for key in ('id', 'pid', 'version'):
                 master[key] = master_state.get(key)
         else:
             master['type'] = 'master'
     for slave in slaves:
+        region, zone = util.get_fault_domain(slave)
         slave['type'] = 'agent'
+        slave['region'] = region
+        slave['zone'] = zone
     nodes = masters + slaves
     if json_:
         emitter.publish(nodes)

--- a/cli/dcoscli/tables.py
+++ b/cli/dcoscli/tables.py
@@ -42,6 +42,9 @@ def task_table(tasks):
         ("STATE", lambda t: t["state"].split("_")[-1][0]),
         ("ID", lambda t: t["id"]),
         ("MESOS ID", lambda t: t["slave_id"]),
+        ("REGION",
+            lambda t: util.get_fault_domain(t.slave())[0] or EMPTY_ENTRY),
+        ("ZONE", lambda t: util.get_fault_domain(t.slave())[1] or EMPTY_ENTRY),
     ])
 
     tb = table(fields, tasks, sortby="NAME")
@@ -911,6 +914,8 @@ def node_table(nodes, field_names=()):
         ('IP', lambda s: s.get('ip') or mesos.parse_pid(s['pid'])[1]),
         ('ID', lambda s: s['id']),
         ('TYPE', lambda s: s['type']),
+        ('REGION', lambda s: s['region']),
+        ('ZONE', lambda s: s['zone']),
     ])
 
     for field_name in field_names:

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -54,7 +54,8 @@ def test_node_table_field_option():
     assert stderr == b''
     lines = stdout.decode('utf-8').splitlines()
     assert len(lines) > 2
-    assert lines[0].split() == ['HOSTNAME', 'IP', 'ID', 'TYPE', 'DISK_USED']
+    assert lines[0].split() == ['HOSTNAME', 'IP', 'ID', 'TYPE', 'REGION',
+                                'ZONE', 'DISK_USED']
 
 
 def test_node_table_uppercase_field_option():
@@ -65,7 +66,8 @@ def test_node_table_uppercase_field_option():
     assert stderr == b''
     lines = stdout.decode('utf-8').splitlines()
     assert len(lines) > 2
-    assert lines[0].split() == ['HOSTNAME', 'IP', 'ID', 'TYPE', 'TASK_RUNNING']
+    assert lines[0].split() == ['HOSTNAME', 'IP', 'ID', 'TYPE', 'REGION',
+                                'ZONE', 'TASK_RUNNING']
 
 
 def test_node_log_empty():

--- a/cli/tests/unit/data/node.txt
+++ b/cli/tests/unit/data/node.txt
@@ -1,2 +1,2 @@
-HOSTNAME       IP                          ID                    TYPE   
-dcos-01   172.17.8.101  20150630-004309-1695027628-5050-1649-S0  agent  
+HOSTNAME       IP                          ID                    TYPE   REGION  ZONE  
+dcos-01   172.17.8.101  20150630-004309-1695027628-5050-1649-S0  agent   N/A    N/A   

--- a/cli/tests/unit/data/task.txt
+++ b/cli/tests/unit/data/task.txt
@@ -1,2 +1,2 @@
-NAME      HOST           USER  STATE  ID                                             MESOS ID                                
-test-app  mock-hostname  root    R    test-app.d44dd7f2-f9b7-11e4-bb43-56847afe9799  20150513-185808-177048842-5050-1220-S0  
+NAME      HOST           USER  STATE  ID                                             MESOS ID                                REGION  ZONE  
+test-app  mock-hostname  root    R    test-app.d44dd7f2-f9b7-11e4-bb43-56847afe9799  20150513-185808-177048842-5050-1220-S0   ---    ---   

--- a/dcos/util.py
+++ b/dcos/util.py
@@ -726,3 +726,19 @@ def read_file_json(path):
         path = os.path.expanduser(path)
         with open_file(path) as options_file:
             return load_json(options_file)
+
+
+def get_fault_domain(state):
+    """ Read mesos state json and return region and zone
+
+    :param state: mesos state json top level or a node item
+    :type state: dict
+    :returns: region and zone
+    :rtype: (str | None, str | None)
+    """
+    try:
+        region = state['domain']['fault_domain']['region']['name']
+        zone = state['domain']['fault_domain']['zone']['name']
+        return region, zone
+    except Exception:
+        return None, None


### PR DESCRIPTION
Add 2 new fields: `REGION` and `ZONE` to `dcos node` and `dcos task` output

[DCOS-17719](https://jira.mesosphere.com/browse/DCOS-17719)

<img width="1150" alt="screen shot 2017-09-27 at 3 25 34 pm" src="https://user-images.githubusercontent.com/1162766/30940993-32cfe9d0-a398-11e7-8dec-6aff839fc4a3.png">
