### PR TITLE
Post CI failures on slack

### DIFF
--- a/ci/Jenkinsfile-linux-integration
+++ b/ci/Jenkinsfile-linux-integration
@@ -13,10 +13,17 @@
  * tests.
  */
 
+@Library('sec_ci_libs@v2-latest') _
+
 /**
  * These are the platforms we are building against.
  */
 def platforms = ["linux"]
+
+/**
+ * These branches will trigger a Slack notification in case of failure.
+ */
+def master_branches = ["master", "0.4.x", "0.5.x", ] as String[]
 
 /**
  * This generates the `dcos_launch` config for a particular build.
@@ -137,7 +144,7 @@ class TestCluster implements Serializable {
  * This function returns a closure that prepares a test environment for a
  * specific platform on a specific node in a specific workspace.
  */
-def testBuilder(String platform, String nodeId, String workspace = null) {
+def testBuilder(String platform, String nodeId, String[] master_branches, String workspace = null) {
     return { Closure _body ->
         def body = _body
 
@@ -152,7 +159,7 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
             try {
                 def dcosIp = cluster.getDcosIp()
 
-                node(nodeId) {
+                task_wrapper(nodeId, master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89', '#dcos-cli-ci') {
                     if (!workspace) {
                         workspace = "${env.WORKSPACE}"
                     }
@@ -212,7 +219,7 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
 def builders = [:]
 
 
-builders['linux-tests'] = testBuilder('linux', 'py35', '/workspace')({
+builders['linux-tests'] = testBuilder('linux', 'py35', master_branches, '/workspace')({
     stage ("Run dcos-cli tests") {
         sh "rm -rf ~/.dcos"
 

--- a/ci/Jenkinsfile-mac-integration
+++ b/ci/Jenkinsfile-mac-integration
@@ -13,10 +13,17 @@
  * tests.
  */
 
+@Library('sec_ci_libs@v2-latest') _
+
 /**
  * These are the platforms we are building against.
  */
 def platforms = ["mac"]
+
+/**
+ * These branches will trigger a Slack notification in case of failure.
+ */
+def master_branches = ["master", "0.4.x", "0.5.x", ] as String[]
 
 /**
  * This generates the `dcos_launch` config for a particular build.
@@ -136,7 +143,7 @@ class TestCluster implements Serializable {
  * This function returns a closure that prepares a test environment for a
  * specific platform on a specific node in a specific workspace.
  */
-def testBuilder(String platform, String nodeId, String workspace = null) {
+def testBuilder(String platform, String nodeId, String[] master_branches, String workspace = null) {
     return { Closure _body ->
         def body = _body
 
@@ -151,7 +158,7 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
             try {
                 def dcosIp = cluster.getDcosIp()
 
-                node(nodeId) {
+                task_wrapper(nodeId, master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89', '#dcos-cli-ci') {
                     if (!workspace) {
                         workspace = "${env.WORKSPACE}"
                     }
@@ -211,7 +218,7 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
 def builders = [:]
 
 
-builders['mac-tests'] = testBuilder('mac', 'mac')({
+builders['mac-tests'] = testBuilder('mac', 'mac', master_branches)({
     try {
         stage ("Run dcos-cli tests") {
             sh "rm -rf ~/.dcos"

--- a/ci/Jenkinsfile-windows-integration
+++ b/ci/Jenkinsfile-windows-integration
@@ -13,10 +13,18 @@
  * tests.
  */
 
+@Library('sec_ci_libs@v2-latest') _
+
 /**
  * These are the platforms we are building against.
  */
 def platforms = ["windows"]
+
+/**
+ * These branches will trigger a Slack notification in case of failure.
+ */
+def master_branches = ["master", "0.4.x", "0.5.x", ] as String[]
+
 
 /**
  * This generates the `dcos_launch` config for a particular build.
@@ -136,7 +144,7 @@ class TestCluster implements Serializable {
  * This function returns a closure that prepares a test environment for a
  * specific platform on a specific node in a specific workspace.
  */
-def testBuilder(String platform, String nodeId, String workspace = null) {
+def testBuilder(String platform, String nodeId, String[] master_branches, String workspace = null) {
     return { Closure _body ->
         def body = _body
 
@@ -151,7 +159,7 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
             try {
                 def dcosIp = cluster.getDcosIp()
 
-                node(nodeId) {
+                task_wrapper(nodeId, master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89', '#dcos-cli-ci') {
                     if (!workspace) {
                         workspace = "${env.WORKSPACE}"
                     }
@@ -211,7 +219,7 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
 def builders = [:]
 
 
-builders['windows-tests'] = testBuilder('windows', 'windows', 'C:\\windows\\workspace')({
+builders['windows-tests'] = testBuilder('windows', 'windows', master_branches, 'C:\\windows\\workspace')({
     stage ("Run dcos-cli tests") {
         bat 'bash -c "rm -rf ${HOME}/.dcos"'
 


### PR DESCRIPTION
Whenever a Jenkins build for the main branches fails, a notification will be posted to the #dcos-cli-ci Slack channel