### PR TITLE
Update prompt for confirmation when uninstalling CLI only

### DIFF
--- a/cli/dcoscli/package/main.py
+++ b/cli/dcoscli/package/main.py
@@ -450,7 +450,7 @@ def _matches_app_id(app_id, pkg_info):
     :param pkg_info: the package description
     :type pkg_info: dict
     :returns: True if the app id is not defined or the package matches that app
-              id; False otherwize
+              id; False otherwise
     :rtype: bool
     """
 

--- a/cli/tests/integrations/test_package.py
+++ b/cli/tests/integrations/test_package.py
@@ -1112,7 +1112,7 @@ def _package(name,
 
     installed = False
     try:
-        returncode_, stdout_, stderr_ = exec_command(command)
+        returncode_, stdout_, stderr_ = exec_command(command, timeout=30)
         installed = (returncode_ == 0)
 
         assert installed

--- a/cli/tests/integrations/test_package.py
+++ b/cli/tests/integrations/test_package.py
@@ -1090,6 +1090,7 @@ def _helloworld_cli(global_=False):
 def _package(name,
              args,
              stdout=b'',
+             uninstall_confirmation=True,
              uninstall_app_id='',
              uninstall_stderr=b''):
     """Context manager that installs a package on entrance, and uninstalls it on
@@ -1121,7 +1122,9 @@ def _package(name,
         yield
     finally:
         if installed:
-            command = ['dcos', 'package', 'uninstall', name, '--yes']
+            command = ['dcos', 'package', 'uninstall', name]
+            if uninstall_confirmation:
+                command.append('--yes')
             if uninstall_app_id:
                 command.append('--app-id='+uninstall_app_id)
             assert_command(command, stderr=uninstall_stderr)

--- a/cli/tests/unit/test_package_uninstall.py
+++ b/cli/tests/unit/test_package_uninstall.py
@@ -9,7 +9,7 @@ def test_confirm_uninstall_remove_all_fail_challenge():
         return "hello-world"
 
     util._read_response = fake_read
-    result = package._confirm_uninstall('hello-world', True, '')
+    result = package._confirm_uninstall(_pkg_dict('hello-world'), True, '')
     util._read_response = real_read
 
     assert result is False
@@ -22,7 +22,7 @@ def test_confirm_uninstall_remove_all_pass_challenge():
         return "uninstall all hello-world"
 
     util._read_response = fake_read
-    result = package._confirm_uninstall('hello-world', True, '')
+    result = package._confirm_uninstall(_pkg_dict('hello-world'), True, '')
     util._read_response = real_read
 
     assert result is True
@@ -35,7 +35,8 @@ def test_confirm_uninstall_app_id_fail_challenge():
         return "hello-world"
 
     util._read_response = fake_read
-    result = package._confirm_uninstall('hello-world', False, 'goodbye')
+    pkg = _pkg_dict('hello-world')
+    result = package._confirm_uninstall(pkg, False, 'goodbye')
     util._read_response = real_read
 
     assert result is False
@@ -48,7 +49,8 @@ def test_confirm_uninstall_app_id_pass_challenge():
         return "goodbye"
 
     util._read_response = fake_read
-    result = package._confirm_uninstall('hello-world', False, 'goodbye')
+    pkg = _pkg_dict('hello-world')
+    result = package._confirm_uninstall(pkg, False, 'goodbye')
     util._read_response = real_read
 
     assert result is True
@@ -61,7 +63,7 @@ def test_confirm_uninstall_default_fail_challenge():
         return "kafka"
 
     util._read_response = fake_read
-    result = package._confirm_uninstall('hello-world', False, '')
+    result = package._confirm_uninstall(_pkg_dict('hello-world'), False, '')
     util._read_response = real_read
 
     assert result is False
@@ -74,7 +76,31 @@ def test_confirm_uninstall_default_pass_challenge():
         return "hello-world"
 
     util._read_response = fake_read
-    result = package._confirm_uninstall('hello-world', False, '')
+    result = package._confirm_uninstall(_pkg_dict('hello-world'), False, '')
     util._read_response = real_read
 
     assert result is True
+
+
+def test_confirm_uninstall_cli_only():
+    real_read = util._read_response
+
+    def fake_read():
+        return "hello-world"
+
+    util._read_response = fake_read
+    pkg = _pkg_dict('hello-world', app=False)
+    result = package._confirm_uninstall(pkg, False, '')
+    util._read_response = real_read
+
+    assert result is True
+
+
+def _pkg_dict(name, app=True, cli=True):
+    pkg = {"name": name}
+    if app:
+        pkg['apps'] = ['/' + name]
+    if cli:
+        pkg['command'] = {"name": name}
+
+    return pkg


### PR DESCRIPTION
By default the following message appears :

> WARNING: This action cannot be undone. This will uninstall [dcos-enterprise-cli] and delete all of its persistent data (logs, configurations, database artifacts, everything).

This is not accurate when uninstalling a CLI only package implicitly (without specifying the --cli flag).

https://jira.mesosphere.com/browse/DCOS-19010