### PR TITLE
Don't use custom CA if HTTPS works out of the box

### DIFF
--- a/cli/tests/unit/test_cluster.py
+++ b/cli/tests/unit/test_cluster.py
@@ -1,0 +1,29 @@
+import requests
+from mock import create_autospec, patch
+
+from dcoscli.cluster.main import _needs_cluster_cert
+
+
+@patch('requests.get')
+def test_needs_cluster_cert_because_ssl_error(req_mock):
+    req_mock.side_effect = requests.exceptions.SSLError()
+
+    assert _needs_cluster_cert('https://example.com')
+
+
+@patch('requests.get')
+def test_does_not_need_cluster_cert_because_non_https(req_mock):
+    resp = create_autospec(requests.Response)
+    resp.status_code = 200
+    req_mock.return_value = resp
+
+    assert _needs_cluster_cert('http://example.com') is False
+
+
+@patch('requests.get')
+def test_does_not_need_cluster_cert_because_https_works(req_mock):
+    resp = create_autospec(requests.Response)
+    resp.status_code = 200
+    req_mock.return_value = resp
+
+    assert _needs_cluster_cert('https://example.com') is False


### PR DESCRIPTION
If it works there is no need to download and use the custom CA. This usually happens when we're dealing with a load-balancer or when a custom CA has already been added to the system.

With the Python library we're using (requests), specifying a path to a custom CA would ignore the default CA bundle in the system, so setting-up a cluster through a load balancer endpoint with a well-known CA (eg. Digicert) was previously failing without this change.

https://jira.mesosphere.com/browse/DCOS-19040