### PR TITLE
 Fix Marathon Debug Test

### DIFF
--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -3,5 +3,6 @@ tox>=2.2, <3.0
 wheel>=0.24.0, <1.0
 pytest>=2.9.1
 teamcity-messages>=1.20
+retrying
 PyInstaller==3.2.1
 -e .. # Install the DC/OS package

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -3,6 +3,5 @@ tox>=2.2, <3.0
 wheel>=0.24.0, <1.0
 pytest>=2.9.1
 teamcity-messages>=1.20
-retrying
 PyInstaller==3.2.1
 -e .. # Install the DC/OS package

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -4,4 +4,5 @@ wheel>=0.24.0, <1.0
 pytest>=2.9.1
 teamcity-messages>=1.20
 PyInstaller==3.2.1
+retrying==1.3.3
 -e .. # Install the DC/OS package

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -70,7 +70,8 @@ setup(
         'toml>=0.9, <1.0',
         'virtualenv>=13.0, <16.0',
         'cryptography==2.0.2',
-        'sseclient==0.0.14'
+        'sseclient==0.0.14',
+        'retrying==1.3.3',
     ],
 
     # If there are data files included in your packages that need to be

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         'six>=1.9, <2.0',
         'toml>=0.9, <1.0',
         'sseclient==0.0.14',
-        'retrying',
+        'retrying==1.3.3',
     ],
 
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setup(
         'six>=1.9, <2.0',
         'toml>=0.9, <1.0',
         'sseclient==0.0.14',
-        'retrying==1.3.3',
     ],
 
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
         'six>=1.9, <2.0',
         'toml>=0.9, <1.0',
         'sseclient==0.0.14',
+        'retrying',
     ],
 
     extras_require={


### PR DESCRIPTION
fixing marathon_debug tests.  
reduce integration test time and tests retry assuming eventually true expectations.  
fixed regex to not be dependent on cluster sizes.  
added retrying lib
