### PR TITLE
Cluster search with fewer chars

### DIFF
--- a/dcos/cluster.py
+++ b/dcos/cluster.py
@@ -221,8 +221,16 @@ def get_cluster(name):
     :rtype: Cluster
     """
 
-    return next((c for c in get_clusters()
-                 if c.get_cluster_id() == name or c.get_name() == name), None)
+    clusters = [c for c in get_clusters()
+                if c.get_cluster_id().startswith(name)
+                or c.get_name().startswith(name)]
+
+    if len(clusters) == 0:
+        return None
+    elif len(clusters) == 1:
+        return clusters[0]
+    else:
+        raise DCOSException("Multiple clusters of [{}] exist".format(name))
 
 
 def remove(name):


### PR DESCRIPTION
* making attaching clusters much easier (as it should be!)

typically a cluster name is something like `ken-lm1juwj` and the cluster-id is `1c0c189e-650c-4caa-a759-4e4d395e4d17`.   These are challenging to type leading mostly to copy and paste when you want to attach to a different cluster.   It is common when using tools like git or docker to use a shorthand for the sha.  Usually requiring the minimum of characters to uniquely match the sha.   This change is designed a user to type `dcos cluster attach ken-l` assuming there is only one, it will attach.
