### PR TITLE
Don't flush C buffers in the silent_output contextmanager

### DIFF
--- a/dcos/util.py
+++ b/dcos/util.py
@@ -1,7 +1,6 @@
 import collections
 import concurrent.futures
 import contextlib
-import ctypes
 import functools
 import hashlib
 import json
@@ -104,13 +103,9 @@ def silent_output():
     """A context manager for suppressing stdout / stderr, it sets their file
     descriptors to os.devnull and then restores them.
 
-    This is helpful for inhibiting output from C code or subprocesses, as
+    This is helpful for inhibiting output from subprocesses, as
     replacing sys.stdout and sys.stderr wouldn't be enough.
     """
-
-    libc = ctypes.CDLL(None)
-    c_stdout = ctypes.c_void_p.in_dll(libc, 'stdout')
-    c_stderr = ctypes.c_void_p.in_dll(libc, 'stderr')
 
     # Original fds stdout/stderr point to. Usually 1 and 2 on POSIX systems.
     original_stdout_fd = sys.stdout.fileno()
@@ -125,9 +120,7 @@ def silent_output():
 
     def _redirect_outputs(stdout_to_fd, stderr_to_fd):
         """Redirect stdout/stderr to the given file descriptors."""
-        # Flush outputs, including C-level buffers
-        libc.fflush(c_stdout)
-        libc.fflush(c_stderr)
+        # Flush outputs buffers
         sys.stderr.flush()
         sys.stdout.flush()
 


### PR DESCRIPTION
Symbol names for outputs might differ from one OS to the other. While this works on Linux this was failing on a Macbook Pro, even though it passed on our Mac CI somehow.

As we don't really need this (it was made to make the silencing more robust), we can just remove it.

https://jira.mesosphere.com/browse/DCOS_OSS-1760