### PR TITLE
Remove the hardcoded 1 second timeout for some HTTP calls

### DIFF
--- a/cli/dcoscli/cluster/main.py
+++ b/cli/dcoscli/cluster/main.py
@@ -321,5 +321,10 @@ def _needs_cluster_cert(dcos_url):
             requests.get(dcos_url, timeout=http.DEFAULT_TIMEOUT)
         except requests.exceptions.SSLError:
             return True
+        except Exception as e:
+            logger.warning(
+                'Unexpected exception occurred while calling %s: %s',
+                dcos_url, e)
+            return True
 
     return False

--- a/cli/dcoscli/main.py
+++ b/cli/dcoscli/main.py
@@ -36,7 +36,7 @@ def _get_versions():
         dcos_url = config.get_config_val("core.dcos_url")
         url = urllib.parse.urljoin(
             dcos_url, 'dcos-metadata/dcos-version.json')
-        res = http.get(url, timeout=1)
+        res = http.get(url)
         if res.status_code == 200:
             dcos_info = res.json()
     except Exception as e:

--- a/cli/tests/integrations/test_cluster.py
+++ b/cli/tests/integrations/test_cluster.py
@@ -112,6 +112,25 @@ def test_setup_noninteractive():
     assert b"Couldn't get confirmation for the fingerprint." in stderr
 
 
+def test_setup_unreachable_url():
+    """
+    Run "dcos cluster setup" with an invalid URL.
+    This makes sure we don't print unexpected errors or hang for too long.
+    """
+
+    returncode, stdout, stderr = exec_command(
+        ['dcos',
+         'cluster',
+         'setup',
+         'https://will.never.exist.hopefully.BOFGY7tfb7doftd.mesosphere.com'],
+        timeout=10)
+
+    assert returncode == 1
+    msg = (b"Error downloading CA certificate from cluster."
+           b" Please check the provided DC/OS URL.\n")
+    assert msg == stderr
+
+
 def _num_of_clusters():
     _, stdout, _ = exec_command(
         ['dcos', 'cluster', 'list', '--json'])

--- a/cli/tests/unit/test_cluster.py
+++ b/cli/tests/unit/test_cluster.py
@@ -12,6 +12,13 @@ def test_needs_cluster_cert_because_ssl_error(req_mock):
 
 
 @patch('requests.get')
+def test_needs_cluster_cert_because_other_error(req_mock):
+    req_mock.side_effect = Exception
+
+    assert _needs_cluster_cert('https://example.com')
+
+
+@patch('requests.get')
 def test_does_not_need_cluster_cert_because_non_https(req_mock):
     resp = create_autospec(requests.Response)
     resp.status_code = 200

--- a/dcos/cluster.py
+++ b/dcos/cluster.py
@@ -33,7 +33,7 @@ def move_to_cluster_config():
     try:
         # find cluster id
         cluster_url = dcos_url.rstrip('/') + '/metadata'
-        res = http.get(cluster_url, timeout=1)
+        res = http.get(cluster_url)
         cluster_id = res.json().get("CLUSTER_ID")
 
     # don't move cluster if dcos_url is not valid
@@ -129,7 +129,7 @@ def setup_cluster_config(dcos_url, temp_path, stored_cert):
     cluster_name = cluster_id
     try:
         url = dcos_url.rstrip('/') + '/mesos/state-summary'
-        name_query = http.get(url, timeout=1, toml_config=cluster.get_config())
+        name_query = http.get(url, toml_config=cluster.get_config())
         cluster_name = name_query.json().get("cluster")
 
     except DCOSException:
@@ -278,7 +278,7 @@ class Cluster():
             url = os.path.join(
                 self.get_url(), "dcos-metadata/dcos-version.json")
             try:
-                resp = http.get(url, timeout=1, toml_config=self.get_config())
+                resp = http.get(url, toml_config=self.get_config())
                 return resp.json().get("version", "N/A")
             except DCOSException:
                 pass


### PR DESCRIPTION
This might be too short in case of network latency or if for any reason
the cluster is not very responsive but still works fine. In such cases
commands like "cluster setup" or "cluster --version" might fail.

There is already a 5 seconds timeout by default that we can rely on.

https://jira.mesosphere.com/browse/DCOS_OSS-1763