### PR TITLE
Cluster directory should tolerate external files

### DIFF
--- a/cli/tests/integrations/test_cluster.py
+++ b/cli/tests/integrations/test_cluster.py
@@ -59,9 +59,13 @@ def test_remove_all(dcos_dir_tmp_copy):
         if len(dirs) > 0:
             test_cluster = os.path.join(root, dirs[0])
             break
+
     # hacky way to create another cluster
-    test_cluster2 = "{}2".format(test_cluster)
-    copy_tree(test_cluster, test_cluster2)
+    test_cluster_2 = os.path.join(
+        os.path.dirname(test_cluster),
+        "a8b53513-63d4-4068-8b08-fde4fe1f1a83")
+
+    copy_tree(test_cluster, test_cluster_2)
 
     # confirm 2
     assert _num_of_clusters() == 2

--- a/dcos/cluster.py
+++ b/dcos/cluster.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+import re
 import shutil
 import ssl
 import urllib
@@ -209,7 +210,15 @@ def get_clusters():
 
     clusters_path = config.get_clusters_path()
     util.ensure_dir_exists(clusters_path)
-    clusters = os.listdir(clusters_path)
+    clusters = []
+
+    uuid_regex = re.compile((r'^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-'
+                             r'[89ab][a-f0-9]{3}-[a-f0-9]{12}\Z'))
+    for entry in os.listdir(clusters_path):
+        entry_path = os.path.join(clusters_path, entry)
+        if os.path.isdir(entry_path) and uuid_regex.match(entry):
+            clusters.append(entry)
+
     return [Cluster(cluster_id) for cluster_id in clusters]
 
 

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -39,9 +39,15 @@ def test_get_clusters():
         util.ensure_dir_exists(clusters_dir)
         assert cluster.get_clusters() == []
 
-        # one cluster
-        cluster_id = "fake_cluster"
+        # a valid cluster
+        cluster_id = "a8b53513-63d4-4059-8b08-fde4fe1f1a83"
         add_cluster_dir(cluster_id, tempdir)
+
+        # Make sure clusters dir can contain random files / folders
+        # cf. https://jira.mesosphere.com/browse/DCOS_OSS-1782
+        util.ensure_file_exists(os.path.join(clusters_dir, '.DS_Store'))
+        util.ensure_dir_exists(os.path.join(clusters_dir, 'not_a_cluster'))
+
         assert cluster.get_clusters() == [_cluster(cluster_id)]
 
 


### PR DESCRIPTION
get_clusters() shoudln't consider any entry inside the clusters dir as a potential cluster, this PR makes sure it only accepts directories with a proper uuid.

Currently : 

>$ dcos cluster list 
NAME CLUSTER ID VERSION URL
a8b53513-63d4-4059-8b08-fde4fe1f1a83* a8b53513-63d4-4059-8b08-fde4fe1f1a83 1.9.1 https://dcos.snakeoil.mesosphere.com
$ touch ~/.dcos/clusters/.DS_Store 
$ dcos 
Cannot create file [/home/bamarni/.dcos/clusters/.DS_Store/dcos.toml]: [Errno 20] Not a directory: '/home/bamarni/.dcos/clusters/.DS_Store/dcos.toml'

https://jira.mesosphere.com/browse/DCOS_OSS-1782