### PR TITLE
Remove bare except clauses (E722)

### DIFF
--- a/cli/dcoscli/marathon/main.py
+++ b/cli/dcoscli/marathon/main.py
@@ -754,7 +754,7 @@ class MarathonSubcommand(object):
             try:
                 response = client.ping()
                 consecutive_count = consecutive_count + 1
-            except:
+            except Exception:
                 consecutive_count = 0
 
             if consecutive_count < count:
@@ -765,7 +765,7 @@ class MarathonSubcommand(object):
 
         try:
             response = ping_for_each_master()
-        except:
+        except Exception:
             response = 'Unable to get ping for all {} masters in {}s'.format(
                 count, timeout
             )

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -35,7 +35,7 @@ passenv =
 
 [testenv:py35-syntax]
 deps =
-  flake8
+  flake8==3.5.0
   flake8-import-order==0.9.2
   pep8-naming
   ..

--- a/cli/tox.win.ini
+++ b/cli/tox.win.ini
@@ -20,7 +20,7 @@ deps =
 
 [testenv:syntax]
 deps =
-  flake8
+  flake8==3.5.0
   flake8-import-order==0.9.2
   pep8-naming
   ..

--- a/dcos/emitting.py
+++ b/dcos/emitting.py
@@ -166,7 +166,7 @@ def _page(output, pager_command=None):
 
     try:
         paginate = config.get_config_val("core.pagination")
-    except:
+    except Exception:
         paginate = True
     if exceeds_tty_height and paginate and \
             spawn.find_executable(pager_command.split(' ')[0]) is not None:

--- a/dcos/marathon.py
+++ b/dcos/marathon.py
@@ -825,7 +825,7 @@ class Client(object):
 
         try:
             return response.json()
-        except:
+        except Exception:
             template = ('Error: Response from Marathon was not in expected '
                         'JSON format:\n{}')
             raise DCOSException(template.format(response.text))

--- a/dcos/metronome.py
+++ b/dcos/metronome.py
@@ -391,7 +391,7 @@ class Client(object):
 
         try:
             return response.json()
-        except:
+        except Exception:
             template = ('Error: Response from Metronome was not in expected '
                         'JSON format:\n{}')
             raise DCOSException(template.format(response.text))

--- a/dcos/rpcclient.py
+++ b/dcos/rpcclient.py
@@ -132,7 +132,7 @@ class RpcClient(object):
 
             try:
                 json_body = e.response.json()
-            except:
+            except Exception:
                 logger.exception(
                     'Unable to decode response body as a JSON value: %r',
                     e.response)
@@ -151,7 +151,7 @@ class RpcClient(object):
 def _get_response_text(response):
     try:
         return response.text
-    except:
+    except Exception:
         return ''
 
 

--- a/dcos/util.py
+++ b/dcos/util.py
@@ -93,7 +93,7 @@ def remove_path_on_error(path):
 
     try:
         yield path
-    except:
+    except Exception:
         shutil.rmtree(path, ignore_errors=True)
         raise
 
@@ -404,7 +404,7 @@ def load_jsons(value):
 
     try:
         return json.loads(value)
-    except:
+    except Exception:
         logger.exception(
             'Unhandled exception while loading JSON: %r',
             value)
@@ -548,7 +548,7 @@ def parse_int(string):
 
     try:
         return int(string)
-    except:
+    except ValueError:
         logger.error(
             'Unhandled exception while parsing string as int: %r',
             string)
@@ -567,7 +567,7 @@ def parse_float(string):
 
     try:
         return float(string)
-    except:
+    except ValueError:
         logger.error(
             'Unhandled exception while parsing string as float: %r',
             string)

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ passenv =
 
 [testenv:py35-syntax]
 deps =
-  flake8
+  flake8==3.5.0
   flake8-import-order==0.9.2
   pep8-naming
 


### PR DESCRIPTION
A recent release of flake8 adds a rule check for this, which broke CI.

For safety, I've sticked to `Exception` when there is at least a nested function call in the try block.