### PR TITLE
Allow Python 3.6 in build scripts

### DIFF
--- a/bin/env.sh
+++ b/bin/env.sh
@@ -11,11 +11,13 @@ if [ ! -d "${BUILDDIR}/${VENV}" ]; then
       exit 1
     fi
 
+    # If no PYTHON variable is set, we assume python3.5 on Linux and MacOS (cf. common.sh).
+    # However, more recent versions of Python 3 are also supported.
     PYTHON_MAJOR=$(${PYTHON} -c 'import sys; print(sys.version_info[0])')
     PYTHON_MINOR=$(${PYTHON} -c 'import sys; print(sys.version_info[1])')
 
-    if [ "${PYTHON_MAJOR}" != "3" ] || [ "${PYTHON_MINOR}" != "5" ]; then
-        echo "Cannot find supported python version 3.5. Exiting..."
+    if [ "${PYTHON_MAJOR}" != "3" ] || [ "${PYTHON_MINOR}" \< "5" ]; then
+        echo "Cannot find supported python version +3.5. Exiting..."
         exit 1
     fi
     if [ "$(uname)" = "Windows_NT" ]; then

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -3,6 +3,6 @@ tox>=2.2, <3.0
 wheel>=0.24.0, <1.0
 pytest>=2.9.1
 teamcity-messages>=1.20
-PyInstaller==3.2.1
+PyInstaller==3.3
 retrying==1.3.3
 -e .. # Install the DC/OS package


### PR DESCRIPTION
This allows to run make commands with Python 3.6 by exporting PYTHON=python3.6 environment variable for example.

CI and actual releases would still rely on Python 3.5, however that'll let us play with it locally and start considering to bump the version in the future.