### PR TITLE
include region/zone in task subcommand with --json option

### DIFF
--- a/cli/tests/unit/test_task.py
+++ b/cli/tests/unit/test_task.py
@@ -194,3 +194,26 @@ def test_dcos_task_metrics_agent_missing_slave(mocked_get_config_val,
     # Should a task not have a slave ID, expect an error
     with pytest.raises(DCOSException):
         _metrics(True, 'task_id', False)
+
+
+def test_task_fault_domain():
+    fd = {
+        'domain': {
+            'fault_domain': {
+                'region': {
+                    'name': 'us-west-2'
+                },
+                'zone': {
+                    'name': 'us-west-2a'
+                }
+            }
+        }
+    }
+
+    state = {'prop1': 'value1'}
+    state.update(fd)
+    slave = mesos.Slave(state, None, None)
+    assert slave.fault_domain() == fd
+
+    slave = mesos.Slave({}, None, None)
+    assert not slave.fault_domain()

--- a/dcos/mesos.py
+++ b/dcos/mesos.py
@@ -664,6 +664,17 @@ class Slave(object):
                  for framework in self._framework_dicts()]
         return itertools.chain(*iters)
 
+    def fault_domain(self):
+        """ Fault domain for a given task e.g.
+
+        :returns: fault domain structure from state.json
+        :rtype: dict | None
+        """
+        if 'domain' not in self._short_state:
+            return None
+
+        return {'domain': self._short_state['domain']}
+
     def __getitem__(self, name):
         """Support the slave[attr] syntax
 
@@ -748,6 +759,13 @@ class Task(object):
         self._task = task
         self._master = master
 
+        if 'slave_id' not in self._task or not master:
+            return
+
+        fd = self.fault_domain()
+        if fd:
+            self._task.update(fd)
+
     def dict(self):
         """
         :returns: dictionary representation of this Task
@@ -806,6 +824,14 @@ class Task(object):
         """
 
         return self.executor()['directory']
+
+    def fault_domain(self):
+        """ Fault domain for a given task
+
+        :returns: fault domain structure
+        :rtype: dict | None
+        """
+        return self.slave().fault_domain()
 
     def __getitem__(self, name):
         """Support the task[attr] syntax


### PR DESCRIPTION
(DCOS-19379)[https://jira.mesosphere.com/browse/DCOS-19379]

with fault domain enabled
<img width="595" alt="screen shot 2017-11-02 at 11 57 32 am" src="https://user-images.githubusercontent.com/1162766/32344761-33538670-bfc5-11e7-9713-39c8842f37e6.png">

if fault domains are disabled, no additional fields will be added.

