### PR TITLE
Show executor metrics

### DIFF
--- a/cli/dcoscli/metrics.py
+++ b/cli/dcoscli/metrics.py
@@ -263,8 +263,18 @@ def print_task_metrics(url, app_url, summary, json_):
     :rtype: int
     """
 
-    datapoints = _fetch_metrics_datapoints(url) + _fetch_metrics_datapoints(
-        app_url)
+    container_datapoints = []
+    app_datapoints = []
+
+    # In the case of an executor, app data may exist when
+    # container data does not.
+    try:
+        container_datapoints = _fetch_metrics_datapoints(url)
+    except EmptyMetricsException:
+        pass
+
+    app_datapoints = _fetch_metrics_datapoints(app_url)
+    datapoints = container_datapoints + app_datapoints
 
     if summary:
         if json_:

--- a/cli/dcoscli/metrics.py
+++ b/cli/dcoscli/metrics.py
@@ -9,6 +9,11 @@ logger = util.get_logger(__name__)
 emitter = emitting.FlatEmitter()
 
 
+class EmptyMetricsException(DCOSException):
+    def __init__(self):
+        super().__init__('No metrics found')
+
+
 def _gib(n):
     return n * pow(2, -30)
 
@@ -30,7 +35,7 @@ def _fetch_metrics_datapoints(url):
     with contextlib.closing(http.get(url)) as r:
 
         if r.status_code == 204:
-            raise DCOSException('No metrics found')
+            raise EmptyMetricsException()
 
         if r.status_code != 200:
             raise DCOSHTTPException(r)

--- a/cli/tests/unit/test_task.py
+++ b/cli/tests/unit/test_task.py
@@ -178,6 +178,31 @@ def test_dcos_task_metrics_agent_details(mocked_get_config_val,
 @patch('dcos.http.get')
 @patch('dcos.mesos.get_master')
 @patch('dcos.config.get_config_val')
+def test_dcos_task_metrics_agent_missing_container(
+    mocked_get_config_val, mocked_get_master, mocked_http_get
+):
+    mocked_get_config_val.return_value = 'http://127.0.0.1'
+
+    mock_container_response = MagicMock()
+    mock_container_response.status_code = 204
+    mock_app_response = MagicMock()
+    mock_app_response.status_code = 200
+    mocked_http_get.side_effect = [mock_container_response, mock_app_response]
+
+    mock_master = MagicMock()
+    mock_master.task = lambda _: {'slave_id': 'slave_id'}
+    mock_master.get_container_id = lambda _: {
+        'parent': {},
+        'value': 'container_id'
+    }
+    mocked_get_master.return_value = mock_master
+
+    _metrics(True, 'task_id', False)
+
+
+@patch('dcos.http.get')
+@patch('dcos.mesos.get_master')
+@patch('dcos.config.get_config_val')
 def test_dcos_task_metrics_agent_missing_slave(mocked_get_config_val,
                                                mocked_get_master,
                                                mocked_http_get):


### PR DESCRIPTION
This PR fixes [DCOS-19009](https://jira.mesosphere.com/browse/DCOS-19009)

Running `dcos task metrics details <task-id>` does the following:

1. requests container metrics from `.../metrics/v0/containers/<container-id>`
1. requests app metrics from `.../metrics/v0/containers/<container-id>/app`
1. joins the two and prints them out in a table

In some cases, container metrics are not present and the dcos-metrics API returns a 204 empty. We were assuming in those cases that there were also no app metrics. Unfortunately, that is not correct in cases of executors, as in DC/OS SDK frameworks like cassandra and kafka. 

With this PR, we catch the empty case and poll app metrics as well. 