### PR TITLE
Lookup for DCOS_CLUSTER to determine if a cluster is attached

### DIFF
--- a/dcos/cluster.py
+++ b/dcos/cluster.py
@@ -295,6 +295,10 @@ class Cluster():
         return "N/A"
 
     def is_attached(self):
+        cluster_envvar = os.environ.get(constants.DCOS_CLUSTER)
+        if cluster_envvar:
+            return cluster_envvar in [self.cluster_id, self.get_name()]
+
         return os.path.exists(os.path.join(
             self.cluster_path, constants.DCOS_CLUSTER_ATTACHED_FILE))
 

--- a/dcos/constants.py
+++ b/dcos/constants.py
@@ -9,7 +9,8 @@ DCOS_CLUSTERS_SUBDIR = "clusters"
 clusters"""
 
 DCOS_CLUSTER = 'DCOS_CLUSTER'
-"""Name of the environment variable pointing to the DC/OS cluster id."""
+"""Name of the environment variable pointing to the DC/OS cluster name
+or id."""
 
 DCOS_CLUSTER_ATTACHED_FILE = "attached"
 """Name of the file indicating the current attached cluster"""

--- a/dcos/constants.py
+++ b/dcos/constants.py
@@ -2,18 +2,18 @@ DCOS_DIR = ".dcos"
 """DC/OS data directory. Can store subcommands and the config file."""
 
 DCOS_DIR_ENV = 'DCOS_DIR'
-"""Name of the environment variable pointing to the DC/OS data directory"""
+"""Name of the environment variable pointing to the DC/OS data directory."""
 
 DCOS_CLUSTERS_SUBDIR = "clusters"
 """Name of the subdirectory containing the configuration of all configured
-clusters"""
+clusters."""
 
 DCOS_CLUSTER = 'DCOS_CLUSTER'
 """Name of the environment variable pointing to the DC/OS cluster name
 or id."""
 
 DCOS_CLUSTER_ATTACHED_FILE = "attached"
-"""Name of the file indicating the current attached cluster"""
+"""Name of the file indicating the current attached cluster."""
 
 DCOS_SUBCOMMAND_ENV_SUBDIR = 'env'
 """In a package's directory, this is the cli contents subdirectory."""
@@ -26,13 +26,13 @@ DCOS_CONFIG_ENV = 'DCOS_CONFIG'
 """Name of the environment variable pointing to the DC/OS config."""
 
 DCOS_LOG_LEVEL_ENV = 'DCOS_LOG_LEVEL'
-"""Name of the environment variable for the DC/OS log level"""
+"""Name of the environment variable for the DC/OS log level."""
 
 DCOS_DEBUG_ENV = 'DCOS_DEBUG'
-"""Name of the environment variable to enable DC/OS debug messages"""
+"""Name of the environment variable to enable DC/OS debug messages."""
 
 DCOS_PAGER_COMMAND_ENV = 'PAGER'
-"""Command to use to page long command output (e.g. 'less -R')"""
+"""Command to use to page long command output (e.g. 'less -R')."""
 
 PATH_ENV = 'PATH'
 """Name of the environment variable pointing to the executable directories."""
@@ -41,4 +41,4 @@ DCOS_COMMAND_PREFIX = 'dcos-'
 """Prefix for all the DC/OS CLI commands."""
 
 VALID_LOG_LEVEL_VALUES = ['debug', 'info', 'warning', 'error', 'critical']
-"""List of all the supported log level values for the CLIs"""
+"""List of all the supported log level values for the CLIs."""


### PR DESCRIPTION
We support the DCOS_CLUSTER env variable since #994, we should take it into account when checking if a cluster is attached.

This is useful for automated scripts where one would want to attach to a cluster without affecting potential concurrent users (because of the shared attached file).

cf. https://github.com/dcos/dcos-cli/issues/595