### PR TITLE
Disable HTTP timeouts for dcos task requests

### DIFF
--- a/dcos/mesos.py
+++ b/dcos/mesos.py
@@ -1276,6 +1276,7 @@ class TaskIO(object):
         response = http.post(
             self.agent_url,
             data=json.dumps(message),
+            timeout=None,
             **req_extra_args)
 
         self._process_output_stream(response)
@@ -1394,6 +1395,7 @@ class TaskIO(object):
         http.post(
             self.agent_url,
             data=_input_streamer(),
+            timeout=None,
             **req_extra_args)
 
     def _input_thread(self):


### PR DESCRIPTION
As this command relies on a long-running HTTP connection using chuncked transfer encoding, it is common to have no data to read from the server for an undefined period of time.

This happens for example when opening a shell session and not typing anything.

https://jira.mesosphere.com/browse/DCOS_OSS-1827

This problem was introduced in #1052.