### PR TITLE
Add a command to mark an agent as gone

### DIFF
--- a/cli/dcoscli/data/help/node.txt
+++ b/cli/dcoscli/data/help/node.txt
@@ -6,6 +6,7 @@ Usage:
     dcos node --info
     dcos node [--json | --field=<field>...]
     dcos node --version
+    dcos node decommission <mesos-id>
     dcos node diagnostics (--list | --status | --cancel) [--json]
     dcos node diagnostics create (<nodes>)...
     dcos node diagnostics delete <bundle>
@@ -25,6 +26,8 @@ Usage:
                   [<command>]
 
 Commands:
+    decommission
+        Mark an agent as gone.
     diagnostics
         View the details of diagnostics bundles.
     diagnostics create

--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -109,6 +109,11 @@ def _cmds():
             function=_dns_lookup),
 
         cmds.Command(
+            hierarchy=['node', 'decommission'],
+            arg_keys=['<mesos-id>'],
+            function=_decommission),
+
+        cmds.Command(
             hierarchy=['node'],
             arg_keys=['--json', '--field'],
             function=_list)
@@ -899,3 +904,15 @@ def _ssh(leader, slave, option, config_file, user, master_proxy, proxy_ip,
                          "`--master-proxy` or `--proxy-ip`"))
 
     return subprocess.Subproc().call(cmd, shell=True)
+
+
+def _decommission(mesos_id):
+    try:
+        mesos.DCOSClient().mark_agent_gone(mesos_id)
+    except errors.DCOSException as e:
+        emitter.publish(
+            DefaultError("Couldn't mark agent {} as gone :\n\n{}".format(
+                mesos_id, e)))
+        return 1
+
+    emitter.publish("Agent {} has been marked as gone.".format(mesos_id))

--- a/dcos/mesos.py
+++ b/dcos/mesos.py
@@ -283,6 +283,26 @@ class DCOSClient(object):
                              'files/browse.json')
         return http.get(url, params={'path': path}).json()
 
+    def mark_agent_gone(self, agent_id):
+        """Mark an agent as gone.
+
+        :param agent_id: agent ID
+        :type agent_id: str
+        """
+        message = {
+            'type': "MARK_AGENT_GONE",
+            'mark_agent_gone': {
+                'agent_id': {'value': agent_id}}}
+
+        headers = {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'}
+
+        http.post(
+            self.master_url('api/v1'),
+            data=json.dumps(message),
+            headers=headers)
+
 
 class MesosDNSClient(object):
     """ Mesos-DNS client


### PR DESCRIPTION
This adds a `dcos node decommission` command which takes as argument an agent id. It will then mark it as gone using the Mesos operator API.

Currently the integration test is skipped because it requires the opposite of that action in order to put the cluster in a proper state again after that test.

cf. https://jira.mesosphere.com/browse/DCOS-18981