### PR TITLE
Remove verbose failure for the deprecated --app-id

### DIFF
--- a/cli/dcoscli/data/help/package.txt
+++ b/cli/dcoscli/data/help/package.txt
@@ -10,7 +10,7 @@ Usage:
                           [--package-version=<package-version>]
     dcos package describe <package-name> --package-versions
     dcos package install <package-name>
-                         [(--cli [--global]) | [--app --app-id=<app-id>]]
+                         [(--cli [--global]) | --app]
                          [--package-version=<package-version>]
                          [--options=<file>]
                          [--yes]

--- a/cli/dcoscli/package/main.py
+++ b/cli/dcoscli/package/main.py
@@ -73,7 +73,7 @@ def _cmds():
         cmds.Command(
             hierarchy=['package', 'install'],
             arg_keys=['<package-name>', '--package-version', '--options',
-                      '--app-id', '--cli', '--global', '--app', '--yes'],
+                      '--cli', '--global', '--app', '--yes'],
             function=_install),
 
         cmds.Command(
@@ -297,7 +297,7 @@ def _describe(package_name,
     return 0
 
 
-def _install(package_name, package_version, options_path, app_id, cli,
+def _install(package_name, package_version, options_path, cli,
              global_, app, yes):
     """Install the specified package.
 
@@ -307,8 +307,6 @@ def _install(package_name, package_version, options_path, app_id, cli,
     :type package_version: str
     :param options_path: path to file containing option values
     :type options_path: str
-    :param app_id: app ID for installation of this package
-    :type app_id: str
     :param cli: indicates if the cli should be installed
     :type cli: bool
     :param global_: indicates that the cli should be installed globally
@@ -365,13 +363,7 @@ def _install(package_name, package_version, options_path, app_id, cli,
 
         emitter.publish(msg)
 
-        if app_id is not None:
-            msg = "Usage of --app-id is deprecated. Use --options instead " \
-                  "and specify a file that contains [service.name] property"
-            emitter.publish(msg)
-            return 1
-
-        package_manager.install_app(pkg, user_options, app_id)
+        package_manager.install_app(pkg, user_options)
 
     if cli and pkg.cli_definition():
         # Install subcommand

--- a/dcos/auth.py
+++ b/dcos/auth.py
@@ -174,8 +174,6 @@ def dcos_uid_password_auth(dcos_url, username=None, password=None):
             dcos_url, username, password)
     if not dcos_token:
         raise DCOSException("Authentication failed")
-    else:
-        return
 
 
 def dcos_cred_auth(dcos_url, username=None, password=None):
@@ -197,8 +195,6 @@ def dcos_cred_auth(dcos_url, username=None, password=None):
             dcos_url, username, password)
     if not dcos_token:
         raise DCOSException("Authentication failed")
-    else:
-        return
 
 
 def oidc_implicit_flow_auth(dcos_url):
@@ -215,8 +211,6 @@ def oidc_implicit_flow_auth(dcos_url):
     dcos_auth_token = _get_dcostoken_by_oidc_implicit_flow(dcos_url)
     if not dcos_auth_token:
         raise DCOSException("Authentication failed")
-    else:
-        return
 
 
 def _get_dcostoken_by_oidc_implicit_flow(dcos_url):
@@ -267,8 +261,6 @@ def servicecred_auth(dcos_url, username, key_path):
     dcos_token = _get_dcostoken_by_post_with_creds(dcos_url, creds)
     if not dcos_token:
         raise DCOSException("Authentication failed")
-    else:
-        return
 
 
 def browser_prompt_auth(dcos_url, provider_info):

--- a/dcos/packagemanager.py
+++ b/dcos/packagemanager.py
@@ -96,23 +96,19 @@ class PackageManager:
         """
         return self.cosmos.enabled()
 
-    def install_app(self, pkg, options, app_id):
+    def install_app(self, pkg, options):
         """Installs a package's application
 
         :param pkg: the package to install
         :type pkg: CosmosPackageVersion
         :param options: user supplied package parameters
         :type options: dict
-        :param app_id: app ID for installation of this package
-        :type app_id: str
         :rtype: None
         """
 
         params = {"packageName": pkg.name(), "packageVersion": pkg.version()}
         if options is not None:
             params["options"] = options
-        if app_id is not None:
-            params["appId"] = app_id
 
         self.cosmos_post("install", params)
 

--- a/dcos/subcommand.py
+++ b/dcos/subcommand.py
@@ -209,7 +209,7 @@ def noun(executable_path):
     """Extracts the subcommand single noun from the path to the executable.
     E.g for :code:`bin/dcos-subcommand` this method returns :code:`subcommand`.
 
-    :param executable_path: real pth to the dcos subcommand
+    :param executable_path: real path to the dcos subcommand
     :type executable_path: str
     :returns: the subcommand
     :rtype: str

--- a/tests/test_packagemanager.py
+++ b/tests/test_packagemanager.py
@@ -94,7 +94,7 @@ def test_install(post_fn, pkg_mgr, fake_pkg):
     post_fn.return_value = mock_response(
         200, install_response_headers(pkg_mgr),
     )
-    pkg_mgr.install_app(fake_pkg, options=None, app_id=None)
+    pkg_mgr.install_app(fake_pkg, options=None)
     post_fn.assert_called_with(
         'http://testserver/package/install',
         data=None,


### PR DESCRIPTION
For the `package install` command, the --app-id flag used to trigger a warning, it then failed with an explicit error. This PR removes it completely.