### PR TITLE
add support for dcos-log v2

### DIFF
--- a/cli/dcoscli/log.py
+++ b/cli/dcoscli/log.py
@@ -221,7 +221,19 @@ def has_journald_capability():
         get_cosmos_url()).has_capability('LOGGING')
 
 
-def dcos_log_enabled():
+def has_log_v2_capability():
+    """ function checks thec cosmos capability LOGGING_V2
+        to know if `dcos-log` suppports v2 on the cluster.
+
+        :return: cosmos has LOGGING_V2 capability.
+        :rtype: bool
+    """
+
+    return packagemanager.PackageManager(
+        get_cosmos_url()).has_capability('LOGGING_V2')
+
+
+def dcos_log_enabled(version=1):
     """ functions checks the cosmos capability LOGGING
         to know if `dcos-log` is enabled on the cluster.
 
@@ -230,7 +242,12 @@ def dcos_log_enabled():
     """
 
     # https://github.com/dcos/dcos/blob/master/gen/calc.py#L151
-    return logging_strategy() == 'journald'
+    if version == 1:
+        return logging_strategy() == 'journald'
+    elif version == 2:
+        return has_log_v2_capability()
+    raise DCOSException(
+        "invalid dcos-log version {}. Must be 1 or 2".format(version))
 
 
 def logging_strategy():

--- a/cli/dcoscli/log.py
+++ b/cli/dcoscli/log.py
@@ -222,7 +222,7 @@ def has_journald_capability():
 
 
 def has_log_v2_capability():
-    """ function checks thec cosmos capability LOGGING_V2
+    """ function checks the cosmos capability LOGGING_V2
         to know if `dcos-log` suppports v2 on the cluster.
 
         :return: cosmos has LOGGING_V2 capability.

--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -729,7 +729,7 @@ def _build_leader_url(component, version=1):
     :rtype: str
     """
 
-    if version < 1 and version > 2:
+    if version < 1 or version > 2:
         raise DCOSException('valid API versions: 1, 2.Used {}'.format(version))
 
     leaders_map = {

--- a/cli/dcoscli/node/main.py
+++ b/cli/dcoscli/node/main.py
@@ -557,6 +557,10 @@ def _log(follow, lines, leader, slave, component, filters):
 
     lines = util.parse_int(lines)
 
+    if log.dcos_log_enabled(version=2):
+        _dcos_log_v2(follow, lines, leader, slave, component, filters)
+        return 0
+
     if not log.has_journald_capability():
         if component or filters:
             raise DCOSException('--component or --filter is not '
@@ -714,14 +718,19 @@ def _get_unit_type(unit_name):
     return '{}.service'.format(unit_name)
 
 
-def _build_leader_url(component):
+def _build_leader_url(component, version=1):
     """ Return a leader URL based on passed component name.
 
     :param component: DC/OS component name
     :type component: str
+    :param version: Use logging API version. Default to 1.
+    :rtype: int
     :return: leader logs url
     :rtype: str
     """
+
+    if version < 1 and version > 2:
+        raise DCOSException('valid API versions: 1, 2.Used {}'.format(version))
 
     leaders_map = {
         'dcos-marathon.service': 'marathon',
@@ -730,15 +739,69 @@ def _build_leader_url(component):
 
     # set default leader to 'mesos' to be consistent with files API
     leader_prefix = 'mesos'
-
+    component_name = ''
     if component:
         component_name = _get_unit_type(component)
         leader_prefix = leaders_map.get(component_name)
         if not leader_prefix:
             raise DCOSException('Component {} does not have a leader'.format(
                 component))
+    endpoint = '/leader/{}/logs/v{}/'.format(leader_prefix, version)
+    if version == 1:
+        return endpoint
 
-    return '/leader/{}/logs/v1/'.format(leader_prefix)
+    if component_name:
+        return endpoint + 'component/{}'.format(component_name)
+    return endpoint + 'component'
+
+
+def _dcos_log_v2(follow, lines, leader, slave, component, filters):
+    """ Print logs from dcos-log v2 backend.
+
+    :param follow: same as unix tail's -f
+    :type follow: bool
+    :param lines: number of lines to print
+    :type lines: int
+    :param leader: whether to print the leading master's log
+    :type leader: bool
+    :param slave: the slave ID to print
+    :type slave: str | None
+    :param component: DC/OS component name
+    :type component: string
+    :param filters: a list of filters ["key:value", ...]
+    :type filters: list
+    """
+
+    filter_query = ''
+    for f in filters:
+        key_value = f.split(':')
+        if len(key_value) != 2:
+            raise DCOSException('Invalid filter parameter {}. '
+                                'Must be --filter=key:value'.format(f))
+        filter_query += '&filter={}'.format(f)
+
+    endpoint = '/system/v1'
+    if leader:
+        endpoint += _build_leader_url(component, version=2)
+    elif slave:
+        endpoint += '/agent/{}/logs/v2/component'.format(slave)
+        if component:
+            component_with_type = _get_unit_type(component)
+            endpoint += '/{}'.format(component_with_type)
+
+    dcos_url = config.get_config_val('core.dcos_url').rstrip("/")
+    if not dcos_url:
+        raise config.missing_config_exception(['core.dcos_url'])
+
+    # dcos-log v2 required the skip option be a negative integer
+    if lines > 0:
+        lines *= -1
+
+    url = dcos_url + endpoint + '?skip={}'.format(lines) + filter_query
+
+    if follow:
+        return log.follow_logs(url)
+    return log.print_logs_range(url)
 
 
 def _dcos_log(follow, lines, leader, slave, component, filters):

--- a/cli/dcoscli/service/main.py
+++ b/cli/dcoscli/service/main.py
@@ -174,15 +174,16 @@ def _log_service(follow, lines, service, file_):
     task = _get_service_task(service)
 
     # if journald logging is disabled, read from files API.
-    if not log.dcos_log_enabled():
-        return _log_task(task['id'], follow, lines, file_)
+    if log.dcos_log_enabled() or log.dcos_log_enabled(version=2):
+        if 'id' not in task:
+            raise DCOSException('Missing `id` in task. {}'.format(task))
 
-    if 'id' not in task:
-        raise DCOSException('Missing `id` in task. {}'.format(task))
+        task_id = task['id']
+        task_main._log(True, follow, False, lines, task_id, file_)
+        return 0
 
-    task_id = task['id']
-    task_main._log(follow, False, lines, task_id, file_)
-    return 0
+    # else use the files API directly.
+    return _log_task(task['id'], follow, lines, file_)
 
 
 def _log_task(task_id, follow, lines, file_):

--- a/cli/dcoscli/task/main.py
+++ b/cli/dcoscli/task/main.py
@@ -246,6 +246,11 @@ def _log(all_, follow, completed, lines, task, file_):
                 raise DCOSException(msg)
         raise DCOSException('No matching tasks. Exiting.')
 
+    # check for dcos-log v2
+    if log.dcos_log_enabled(version=2):
+        _dcos_log_v2(follow, tasks, lines, file_)
+        return 0
+
     # if journald logging is disabled, read files API and exit.
     if not log.dcos_log_enabled():
         mesos_files = _mesos_files(tasks, file_, client)
@@ -334,6 +339,45 @@ def get_nested_container_id(task):
             container_id = container_id['parent']
 
     return '.'.join(reversed(container_ids))
+
+
+def _dcos_log_v2(follow, tasks, lines, file_):
+    """ a client to dcos-log v2
+
+    :param follow: same as unix tail's -f
+    :type follow: bool
+    :param task: task pattern to match
+    :type task: str
+    :param lines: number of lines to print
+    :type lines: int
+    :param file_: file path to read
+    :type file_: str
+    """
+
+    if len(tasks) != 1:
+        raise DCOSException(
+            "found more then one task with the same name: {}. Please provide "
+            "a unique task name.".format([task['id'] for task in tasks]))
+
+    task = tasks[0]
+    endpoint = '/system/v1/logs/v2/task/{}/file/{}'.format(task['id'], file_)
+    dcos_url = config.get_config_val('core.dcos_url').rstrip('/')
+    if not dcos_url:
+        raise config.missing_config_exception(['core.dcos_url'])
+
+    if lines:
+        # according to dcos-log v2 API the skip parameter must be negative
+        # integer. dcos-cli uses positive int to limit the number of last lines
+        # use "lines * -1" to make it negative.
+        if lines > 0:
+            lines *= -1
+
+        endpoint += '?cursor=END&skip={}'.format(lines)
+
+    url = dcos_url + endpoint
+    if follow:
+        return log.follow_logs(url)
+    return log.print_logs_range(url)
 
 
 def _dcos_log(follow, tasks, lines, file_, completed):

--- a/cli/dcoscli/task/main.py
+++ b/cli/dcoscli/task/main.py
@@ -346,8 +346,8 @@ def _dcos_log_v2(follow, tasks, lines, file_):
 
     :param follow: same as unix tail's -f
     :type follow: bool
-    :param task: task pattern to match
-    :type task: str
+    :param tasks: tasks pattern to match
+    :type tasks: list of str
     :param lines: number of lines to print
     :type lines: int
     :param file_: file path to read
@@ -356,7 +356,7 @@ def _dcos_log_v2(follow, tasks, lines, file_):
 
     if len(tasks) != 1:
         raise DCOSException(
-            "found more then one task with the same name: {}. Please provide "
+            "found more than one task with the same name: {}. Please provide "
             "a unique task name.".format([task['id'] for task in tasks]))
 
     task = tasks[0]

--- a/cli/tests/unit/test_node.py
+++ b/cli/tests/unit/test_node.py
@@ -194,6 +194,87 @@ def test_node_diagnostics_download(mock_get_diagnostics_list, mock_do_request,
 @mock.patch('dcos.config.get_config_val')
 @mock.patch('dcos.http.get')
 @mock.patch('dcoscli.log.dcos_log_enabled')
+def test_dcos_log_v2_leader_mesos(mocked_dcos_log_enabked, mocked_http_get,
+                                  mocked_get_config_val):
+    mocked_dcos_log_enabked.return_value = True
+
+    m = mock.MagicMock()
+    m.status_code = 200
+    mocked_http_get.return_value = m
+
+    mocked_get_config_val.return_value = 'http://127.0.0.1'
+
+    main._dcos_log_v2(False, 10, True, '', None, [])
+    mocked_http_get.assert_called_with(
+        'http://127.0.0.1/system/v1/leader/mesos/logs/v2/component?skip=-10',
+        headers={'Accept': 'text/plain'})
+
+
+@mock.patch('dcos.config.get_config_val')
+@mock.patch('dcos.http.get')
+@mock.patch('dcoscli.log.dcos_log_enabled')
+def test_dcos_log_v2_leader_marathon(mocked_dcos_log_enabked, mocked_http_get,
+                                     mocked_get_config_val):
+    mocked_dcos_log_enabked.return_value = True
+
+    m = mock.MagicMock()
+    m.status_code = 200
+    mocked_http_get.return_value = m
+
+    mocked_get_config_val.return_value = 'http://127.0.0.1'
+
+    main._dcos_log_v2(False, 10, True, '', 'dcos-marathon', [])
+    mocked_http_get.assert_called_with(
+        'http://127.0.0.1/system/v1/leader/marathon/logs/v2/component/'
+        'dcos-marathon.service?skip=-10',
+        headers={'Accept': 'text/plain'})
+
+
+@mock.patch('dcoscli.log.follow_logs')
+@mock.patch('dcos.config.get_config_val')
+@mock.patch('dcos.http.get')
+@mock.patch('dcoscli.log.dcos_log_enabled')
+def test_dcos_log_v2_sse(mocked_dcos_log_enabked, mocked_http_get,
+                         mocked_get_config_val, mocked_follow_logs):
+    mocked_dcos_log_enabked.return_value = True
+
+    m = mock.MagicMock()
+    m.status_code = 200
+    mocked_http_get.return_value = m
+
+    mocked_get_config_val.return_value = 'http://127.0.0.1'
+
+    main._dcos_log_v2(True, 20, False, 'mesos-id', None, [])
+    mocked_follow_logs.assert_called_with(
+        'http://127.0.0.1/system/v1/agent/mesos-id/logs/v2/component?skip=-20')
+
+
+@mock.patch('dcoscli.log.follow_logs')
+@mock.patch('dcos.config.get_config_val')
+@mock.patch('dcos.http.get')
+@mock.patch('dcoscli.log.dcos_log_enabled')
+def test_dcos_log_v2_filters(mocked_dcos_log_enabked, mocked_http_get,
+                             mocked_get_config_val, mocked_follow_logs):
+    mocked_dcos_log_enabked.return_value = True
+
+    m = mock.MagicMock()
+    m.status_code = 200
+    mocked_http_get.return_value = m
+
+    mocked_get_config_val.return_value = 'http://127.0.0.1'
+
+    main._dcos_log_v2(True, 20, False, 'mesos-id', 'dcos-mesos-master',
+                      ['key1:value1', 'key2:value2'])
+
+    mocked_follow_logs.assert_called_with(
+        'http://127.0.0.1/system/v1/agent/mesos-id/logs/v2/component/'
+        'dcos-mesos-master.service?skip=-20&filter=key1:value1&'
+        'filter=key2:value2')
+
+
+@mock.patch('dcos.config.get_config_val')
+@mock.patch('dcos.http.get')
+@mock.patch('dcoscli.log.dcos_log_enabled')
 def test_dcos_log_leader_mesos(mocked_dcos_log_enabked, mocked_http_get,
                                mocked_get_config_val):
     mocked_dcos_log_enabked.return_value = True

--- a/cli/tests/unit/test_node.py
+++ b/cli/tests/unit/test_node.py
@@ -194,9 +194,9 @@ def test_node_diagnostics_download(mock_get_diagnostics_list, mock_do_request,
 @mock.patch('dcos.config.get_config_val')
 @mock.patch('dcos.http.get')
 @mock.patch('dcoscli.log.dcos_log_enabled')
-def test_dcos_log_v2_leader_mesos(mocked_dcos_log_enabked, mocked_http_get,
+def test_dcos_log_v2_leader_mesos(mocked_dcos_log_enabled, mocked_http_get,
                                   mocked_get_config_val):
-    mocked_dcos_log_enabked.return_value = True
+    mocked_dcos_log_enabled.return_value = True
 
     m = mock.MagicMock()
     m.status_code = 200
@@ -213,9 +213,9 @@ def test_dcos_log_v2_leader_mesos(mocked_dcos_log_enabked, mocked_http_get,
 @mock.patch('dcos.config.get_config_val')
 @mock.patch('dcos.http.get')
 @mock.patch('dcoscli.log.dcos_log_enabled')
-def test_dcos_log_v2_leader_marathon(mocked_dcos_log_enabked, mocked_http_get,
+def test_dcos_log_v2_leader_marathon(mocked_dcos_log_enabled, mocked_http_get,
                                      mocked_get_config_val):
-    mocked_dcos_log_enabked.return_value = True
+    mocked_dcos_log_enabled.return_value = True
 
     m = mock.MagicMock()
     m.status_code = 200
@@ -234,9 +234,9 @@ def test_dcos_log_v2_leader_marathon(mocked_dcos_log_enabked, mocked_http_get,
 @mock.patch('dcos.config.get_config_val')
 @mock.patch('dcos.http.get')
 @mock.patch('dcoscli.log.dcos_log_enabled')
-def test_dcos_log_v2_sse(mocked_dcos_log_enabked, mocked_http_get,
+def test_dcos_log_v2_sse(mocked_dcos_log_enabled, mocked_http_get,
                          mocked_get_config_val, mocked_follow_logs):
-    mocked_dcos_log_enabked.return_value = True
+    mocked_dcos_log_enabled.return_value = True
 
     m = mock.MagicMock()
     m.status_code = 200
@@ -253,9 +253,9 @@ def test_dcos_log_v2_sse(mocked_dcos_log_enabked, mocked_http_get,
 @mock.patch('dcos.config.get_config_val')
 @mock.patch('dcos.http.get')
 @mock.patch('dcoscli.log.dcos_log_enabled')
-def test_dcos_log_v2_filters(mocked_dcos_log_enabked, mocked_http_get,
+def test_dcos_log_v2_filters(mocked_dcos_log_enabled, mocked_http_get,
                              mocked_get_config_val, mocked_follow_logs):
-    mocked_dcos_log_enabked.return_value = True
+    mocked_dcos_log_enabled.return_value = True
 
     m = mock.MagicMock()
     m.status_code = 200
@@ -275,9 +275,9 @@ def test_dcos_log_v2_filters(mocked_dcos_log_enabked, mocked_http_get,
 @mock.patch('dcos.config.get_config_val')
 @mock.patch('dcos.http.get')
 @mock.patch('dcoscli.log.dcos_log_enabled')
-def test_dcos_log_leader_mesos(mocked_dcos_log_enabked, mocked_http_get,
+def test_dcos_log_leader_mesos(mocked_dcos_log_enabled, mocked_http_get,
                                mocked_get_config_val):
-    mocked_dcos_log_enabked.return_value = True
+    mocked_dcos_log_enabled.return_value = True
 
     m = mock.MagicMock()
     m.status_code = 200
@@ -294,9 +294,9 @@ def test_dcos_log_leader_mesos(mocked_dcos_log_enabked, mocked_http_get,
 @mock.patch('dcos.config.get_config_val')
 @mock.patch('dcos.http.get')
 @mock.patch('dcoscli.log.dcos_log_enabled')
-def test_dcos_log_leader_marathon(mocked_dcos_log_enabked, mocked_http_get,
+def test_dcos_log_leader_marathon(mocked_dcos_log_enabled, mocked_http_get,
                                   mocked_get_config_val):
-    mocked_dcos_log_enabked.return_value = True
+    mocked_dcos_log_enabled.return_value = True
 
     m = mock.MagicMock()
     m.status_code = 200
@@ -315,9 +315,9 @@ def test_dcos_log_leader_marathon(mocked_dcos_log_enabked, mocked_http_get,
 @mock.patch('dcos.config.get_config_val')
 @mock.patch('dcos.http.get')
 @mock.patch('dcoscli.log.dcos_log_enabled')
-def test_dcos_log_stream(mocked_dcos_log_enabked, mocked_http_get,
+def test_dcos_log_stream(mocked_dcos_log_enabled, mocked_http_get,
                          mocked_get_config_val, mocked_follow_logs):
-    mocked_dcos_log_enabked.return_value = True
+    mocked_dcos_log_enabled.return_value = True
 
     m = mock.MagicMock()
     m.status_code = 200
@@ -335,9 +335,9 @@ def test_dcos_log_stream(mocked_dcos_log_enabked, mocked_http_get,
 @mock.patch('dcos.config.get_config_val')
 @mock.patch('dcos.http.get')
 @mock.patch('dcoscli.log.dcos_log_enabled')
-def test_dcos_log_filters(mocked_dcos_log_enabked, mocked_http_get,
+def test_dcos_log_filters(mocked_dcos_log_enabled, mocked_http_get,
                           mocked_get_config_val, mocked_follow_logs):
-    mocked_dcos_log_enabked.return_value = True
+    mocked_dcos_log_enabled.return_value = True
 
     m = mock.MagicMock()
     m.status_code = 200

--- a/cli/tests/unit/test_task.py
+++ b/cli/tests/unit/test_task.py
@@ -4,7 +4,7 @@ from mock import MagicMock, patch
 from dcos import mesos
 from dcos.errors import DCOSException
 from dcoscli.log import log_files
-from dcoscli.task.main import _dcos_log, _metrics, main
+from dcoscli.task.main import _dcos_log, _dcos_log_v2, _metrics, main
 
 from .common import assert_mock
 
@@ -56,6 +56,19 @@ def test_log_file_unavailable():
 
 def _mock_exception(contents='exception'):
     return MagicMock(side_effect=DCOSException(contents))
+
+
+@patch('dcoscli.log.follow_logs')
+@patch('dcos.config.get_config_val')
+def test_dcos_log_v2(mocked_get_config_val, mocked_follow_logs):
+    mocked_get_config_val.return_value = 'http://127.0.0.1'
+
+    task = {'id': 'test-task'}
+
+    _dcos_log_v2(True, [task], 10, 'stdout')
+    mocked_follow_logs.assert_called_with(
+        'http://127.0.0.1/system/v1/logs/v2/task/test-task/file/stdout?'
+        'cursor=END&skip=-10')
 
 
 @patch('dcos.http.get')


### PR DESCRIPTION
affected subcommands:
- [X] `dcos task <name> log`
- [X]  `dcos node log ...`
- [X] `dcos service log <name>`
- [X] unittests

If DC/OS cluster has the `LOGGING_V2` capability, dcos-cli should use [dcos-log v2](https://docs.google.com/document/d/1Z2gWi1H7lc3nNGqLUU9Hecvm9EyPLI-6t3uK1ANlHyA/edit#), otherwise based on the logging strategy mesos files API or dcos-log v1 will be used.