### PR TITLE
 Accept an URL argument to `dcos auth list-providers`

### DIFF
--- a/cli/dcoscli/auth/main.py
+++ b/cli/dcoscli/auth/main.py
@@ -43,7 +43,7 @@ def _cmds():
     return [
         cmds.Command(
             hierarchy=['auth', 'list-providers'],
-            arg_keys=['--json'],
+            arg_keys=['--json', '<dcos_url>'],
             function=_list_providers),
 
         cmds.Command(
@@ -76,13 +76,13 @@ def _info(info):
     return 0
 
 
-def _list_providers(json_):
+def _list_providers(json_, dcos_url):
     """
     :returns: providers available for configured cluster
     :rtype: dict
     """
 
-    providers = auth.get_providers()
+    providers = auth.get_providers(dcos_url)
     if providers or json_:
         emitting.publish_table(
             emitter, providers, tables.auth_provider_table, json_)

--- a/cli/dcoscli/data/help/auth.txt
+++ b/cli/dcoscli/data/help/auth.txt
@@ -5,7 +5,7 @@ Usage:
     dcos auth --help
     dcos auth --info
     dcos auth --version
-    dcos auth list-providers [--json]
+    dcos auth list-providers [--json] [<dcos_url>]
     dcos auth login
         [--provider=<provider_id>] [--username=<username>]
         [--password=<password> | --password-file=<password_file>
@@ -39,3 +39,7 @@ Options:
         Specify the username for login.
     --version
         Print version information.
+
+Positional Arguments:
+    dcos_url
+        The public master of the DC/OS cluster.

--- a/cli/tests/unit/test_auth.py
+++ b/cli/tests/unit/test_auth.py
@@ -78,14 +78,18 @@ def test_get_providers(config, req_mock):
 
     auth.get_providers()
     req_mock.assert_called_with(
-        "http://localhost/acs/api/v1/auth/providers")
+        "http://localhost/acs/api/v1/auth/providers", verify=None)
 
     # test url construction valid with trailing slash
     config.return_value = "http://localhost/"
 
     auth.get_providers()
     req_mock.assert_called_with(
-        "http://localhost/acs/api/v1/auth/providers")
+        "http://localhost/acs/api/v1/auth/providers", verify=None)
+
+    auth.get_providers("http://example.com/")
+    req_mock.assert_called_with(
+        "http://example.com/acs/api/v1/auth/providers", verify=False)
 
 
 @patch('dcos.http._request')

--- a/dcos/http.py
+++ b/dcos/http.py
@@ -71,15 +71,15 @@ def _verify_ssl(url, verify=None, toml_config=None):
     :rtype: bool | str
     """
 
-    if not _is_request_to_dcos(url, toml_config):
-        # Leave verify to None if URL is outside the DC/OS cluster
-        # https://jira.mesosphere.com/browse/DCOS_OSS-618
-        return None
-
-    if toml_config is None:
-        toml_config = config.get_config()
-
     if verify is None:
+        if toml_config is None:
+            toml_config = config.get_config()
+
+        if not _is_request_to_dcos(url, toml_config):
+            # Leave verify to None if URL is outside the DC/OS cluster
+            # https://jira.mesosphere.com/browse/DCOS_OSS-618
+            return None
+
         verify = config.get_config_val("core.ssl_verify", toml_config)
         if verify and verify.lower() == "true":
             verify = True


### PR DESCRIPTION
The `dcos cluster setup` command accepts a `--provider` argument, however it is currently not possible to see all available providers for a given cluster, as the command for this assumes an already configured cluster.

This adds an optional `dcos_url` argument to `dcos auth list-providers`.

https://jira.mesosphere.com/browse/DCOS_OSS-1817