### PR TITLE
Never print a comment in `dcos config show [name]`

### DIFF
--- a/cli/dcoscli/config/main.py
+++ b/cli/dcoscli/config/main.py
@@ -199,10 +199,8 @@ def _show(name):
 
         if effective_value is None:
             raise DCOSException("Property {!r} doesn't exist".format(name))
-        else:
-            msg = _format_config(file_value, effective_value,
-                                 envvar_name=envvar_name)
-            emitter.publish(msg)
+
+        emitter.publish(effective_value)
 
     else:
         # Let's list all of the values

--- a/cli/tests/integrations/test_config.py
+++ b/cli/tests/integrations/test_config.py
@@ -204,11 +204,10 @@ def test_dcos_url_env_var(env):
     env['DCOS_URL'] = 'http://foobar'
 
     returncode, stdout, stderr = exec_command(
-        ['dcos', 'service'], env=env)
-    assert returncode == 1
-    assert stdout == b''
-    assert stderr.startswith(
-        b'URL [http://foobar/mesos/master/state.json] is unreachable')
+        ['dcos', 'config', 'show', 'core.dcos_url'], env=env)
+    assert returncode == 0
+    assert stdout == b"http://foobar\n"
+    assert stderr == b''
 
     env.pop('DCOS_URL')
 
@@ -217,11 +216,10 @@ def test_dcos_dcos_url_env_var(env):
     env['DCOS_DCOS_URL'] = 'http://foobar'
 
     returncode, stdout, stderr = exec_command(
-        ['dcos', 'service'], env=env)
-    assert returncode == 1
-    assert stdout == b''
-    assert stderr.startswith(
-        b'URL [http://foobar/mesos/master/state.json] is unreachable')
+        ['dcos', 'config', 'show', 'core.dcos_url'], env=env)
+    assert returncode == 0
+    assert stdout == b"http://foobar\n"
+    assert stderr == b''
 
     env.pop('DCOS_DCOS_URL')
 


### PR DESCRIPTION
When an environment variable overrides a config value, that command prints a comment. This causes problems if the consumer is trying to parse the output. For example : 
```
$ dcos config show core.ssl_verify
/Users/joergschad/.dcos/clusters/9e500174-57b2-4c91-b445-ef7ee99fcb5a/dcos_ca.crt

$ DCOS_SSL_VERIFY=false dcos config show core.ssl_verify
false          # overwritten by environment var DCOS_SSL_VERIFY; config file value: /Users/joergschad/.dcos/clusters/9e500174-57b2-4c91-b445-ef7ee99fcb5a/dcos_ca.crt
```

These comments would only get printed when no config name is passed. 

Fixes #1104 
