### PR TITLE
Fix for missing task metrics with dockerized applications

### DIFF
--- a/cli/dcoscli/metrics.py
+++ b/cli/dcoscli/metrics.py
@@ -263,16 +263,7 @@ def print_task_metrics(url, app_url, summary, json_):
     :rtype: int
     """
 
-    container_datapoints = []
-    app_datapoints = []
-
-    # In the case of an executor, app data may exist when
-    # container data does not.
-    try:
-        container_datapoints = _fetch_metrics_datapoints(url)
-    except EmptyMetricsException:
-        pass
-
+    container_datapoints = _fetch_metrics_datapoints(url)
     app_datapoints = _fetch_metrics_datapoints(app_url)
     datapoints = container_datapoints + app_datapoints
     if len(datapoints) == 0:

--- a/cli/dcoscli/metrics.py
+++ b/cli/dcoscli/metrics.py
@@ -35,7 +35,7 @@ def _fetch_metrics_datapoints(url):
     with contextlib.closing(http.get(url)) as r:
 
         if r.status_code == 204:
-            raise EmptyMetricsException()
+            return []
 
         if r.status_code != 200:
             raise DCOSHTTPException(r)
@@ -275,6 +275,8 @@ def print_task_metrics(url, app_url, summary, json_):
 
     app_datapoints = _fetch_metrics_datapoints(app_url)
     datapoints = container_datapoints + app_datapoints
+    if len(datapoints) == 0:
+        raise EmptyMetricsException()
 
     if summary:
         if json_:

--- a/cli/tests/unit/test_task.py
+++ b/cli/tests/unit/test_task.py
@@ -4,6 +4,7 @@ from mock import MagicMock, patch
 from dcos import mesos
 from dcos.errors import DCOSException
 from dcoscli.log import log_files
+from dcoscli.metrics import EmptyMetricsException
 from dcoscli.task.main import _dcos_log, _dcos_log_v2, _metrics, main
 
 from .common import assert_mock
@@ -272,11 +273,8 @@ def test_dcos_task_metrics_agent_missing_both(
     }
     mocked_get_master.return_value = mock_response
 
-    try:
+    with pytest.raises(EmptyMetricsException):
         _metrics(True, 'task_id', False)
-        raise Exception('Expected EmptyMetricsException was not raised')
-    except DCOSException:
-        pass
 
 
 @patch('dcos.http.get')

--- a/cli/tests/unit/test_task.py
+++ b/cli/tests/unit/test_task.py
@@ -264,6 +264,7 @@ def test_dcos_task_metrics_agent_missing_both(
 
     mock_response = MagicMock()
     mock_response.status_code = 204
+    mocked_http_get.return_value = mock_response
 
     mock_master = MagicMock()
     mock_master.task = lambda _: {'slave_id': 'slave_id'}
@@ -271,7 +272,7 @@ def test_dcos_task_metrics_agent_missing_both(
         'parent': {},
         'value': 'container_id'
     }
-    mocked_get_master.return_value = mock_response
+    mocked_get_master.return_value = mock_master
 
     with pytest.raises(EmptyMetricsException):
         _metrics(True, 'task_id', False)

--- a/cli/tests/unit/test_task.py
+++ b/cli/tests/unit/test_task.py
@@ -253,6 +253,35 @@ def test_dcos_task_metrics_agent_missing_app(
     _metrics(True, 'task_id', False)
 
 
+@patch('dcos.http.get')
+@patch('dcos.mesos.get_master')
+@patch('dcos.config.get_config_val')
+def test_dcos_task_metrics_agent_missing_both(
+    mocked_get_config_val, mocked_get_master, mocked_http_get
+):
+    mocked_get_config_val.return_value = 'http://127.0.0.1'
+
+    mock_response = MagicMock()
+    mock_response.status_code = 204
+
+    mock_master = MagicMock()
+    mock_master.task = lambda _: {'slave_id': 'slave_id'}
+    mock_master.get_container_id = lambda _: {
+        'parent': {},
+        'value': 'container_id'
+    }
+    mocked_get_master.return_value = mock_response
+
+    try:
+        _metrics(True, 'task_id', False)
+        raise Exception('Expected EmptyMetricsException was not raised')
+    except DCOSException:
+        pass
+
+
+@patch('dcos.http.get')
+@patch('dcos.mesos.get_master')
+@patch('dcos.config.get_config_val')
 def test_dcos_task_metrics_agent_missing_slave(mocked_get_config_val,
                                                mocked_get_master,
                                                mocked_http_get):

--- a/cli/tests/unit/test_task.py
+++ b/cli/tests/unit/test_task.py
@@ -228,6 +228,29 @@ def test_dcos_task_metrics_agent_missing_container(
 @patch('dcos.http.get')
 @patch('dcos.mesos.get_master')
 @patch('dcos.config.get_config_val')
+def test_dcos_task_metrics_agent_missing_app(
+    mocked_get_config_val, mocked_get_master, mocked_http_get
+):
+    mocked_get_config_val.return_value = 'http://127.0.0.1'
+
+    mock_container_response = MagicMock()
+    mock_container_response.status_code = 200
+    mock_container_response.json = lambda: metrics_message
+    mock_app_response = MagicMock()
+    mock_app_response.status_code = 204
+    mocked_http_get.side_effect = [mock_container_response, mock_app_response]
+
+    mock_master = MagicMock()
+    mock_master.task = lambda _: {'slave_id': 'slave_id'}
+    mock_master.get_container_id = lambda _: {
+        'parent': {},
+        'value': 'container_id'
+    }
+    mocked_get_master.return_value = mock_master
+
+    _metrics(True, 'task_id', False)
+
+
 def test_dcos_task_metrics_agent_missing_slave(mocked_get_config_val,
                                                mocked_get_master,
                                                mocked_http_get):

--- a/cli/tests/unit/test_task.py
+++ b/cli/tests/unit/test_task.py
@@ -212,6 +212,8 @@ def test_dcos_task_metrics_agent_missing_container(
     mock_container_response.status_code = 204
     mock_app_response = MagicMock()
     mock_app_response.status_code = 200
+    mock_app_response.json = lambda: metrics_message
+
     mocked_http_get.side_effect = [mock_container_response, mock_app_response]
 
     mock_master = MagicMock()

--- a/cli/tests/unit/test_task.py
+++ b/cli/tests/unit/test_task.py
@@ -9,6 +9,17 @@ from dcoscli.task.main import _dcos_log, _dcos_log_v2, _metrics, main
 from .common import assert_mock
 
 
+# metrics_messages is a minimal fixture for mocking non-empty API responses
+metrics_message = {
+    'datapoints': [
+        {
+            'name': 'statsd_tester.time.uptime',
+            'value': 1234,
+        }
+    ]
+}
+
+
 @patch('dcos.config.get_config')
 def test_log_master_unavailable(config_mock):
     config_mock.return_value = {'core.dcos_url': 'foo'}
@@ -167,6 +178,7 @@ def test_dcos_task_metrics_agent_details(mocked_get_config_val,
 
     mock_http_response = MagicMock()
     mock_http_response.status_code = 200
+    mock_http_response.json = lambda: metrics_message
     mocked_http_get.return_value = mock_http_response
 
     mock_master = MagicMock()


### PR DESCRIPTION
This PR fixes [DCOS_OSS-1828](https://jira.mesosphere.com/browse/DCOS_OSS-1828)

Previously, when the `/metrics/v0/containers/<container-id>/app` endpoint returned a 204 No Content response, we would print `No metrics found` and exit. This PR removes the error case treatment from a 204 response. Instead we check to see if any metrics were found at all and print them instead. 

This test script shows the fix working: (on master `dcos task metrics details statsd-emitter-docker` yields `No metrics found`)
```
$ dcos marathon app add https://gist.githubusercontent.com/philipnrmn/cc59c6eb92e0744552a92c941ec78fa2/raw/5edd33344b25bacd6c51f072b420ba7649e59be1/statsd-emitter-ucr.json
$ dcos marathon app add https://gist.githubusercontent.com/philipnrmn/c9a86746460cdaef6a4084badfad687d/raw/2ea920999bc7984da8e4fa58949d9742c2f9ab59/statsd-emitter-docker.json
# wait a minute to be sure the tasks have started and metrics have been gathered
$ dcos task
NAME                   ...
statsd-emitter-docker  ...
statsd-emitter-ucr     ...
$ dcos task metrics details statsd-emitter-ucr
NAME                       VALUE
mem.limit                  0.16GiB
net.tx.errors              0
disk.limit                 0.00GiB
cpus.user.time             0.11
net.rx.bytes               0.00GiB
net.tx.dropped             0
disk.used                  0.00GiB
cpus.throttled.time        1.89
cpus.limit                 0.10
mem.total                  0.01GiB
net.rx.dropped             0
net.rx.errors              0
net.tx.packets             0
net.tx.bytes               0.00GiB
cpus.system.time           0.01
net.rx.packets             0
statsd_tester.time.uptime  57013
$ dcos task metrics details statsd-emitter-docker
NAME                 VALUE
net.rx.bytes         0.00GiB
mem.limit            0.16GiB
cpus.system.time     0
net.rx.dropped       0
net.tx.bytes         0.00GiB
net.rx.packets       0
mem.total            0.00GiB
net.rx.errors        0
disk.limit           0.00GiB
cpus.throttled.time  4.33
cpus.limit           0.10
net.tx.errors        0
net.tx.packets       0
cpus.user.time       0.01
disk.used            0.00GiB
net.tx.dropped       0
```

Reported by @bergerx earlier today.