### PR TITLE
Remove reliance on dcos.snakeoil.mesosphere.com in tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,12 +182,6 @@ integration tests against. In the future we hope to remove this limitation::
     deactivate
     cd -
 
-    cp /etc/hosts ${DCOS_DIR}/hosts.local
-    grep -q "^.* dcos.snakeoil.mesosphere.com$" ${DCOS_DIR}/hosts.local && \
-        sed -iold "s/^.* dcos.snakeoil.mesosphere.com$/${CLI_TEST_DCOS_URL} dcos.snakeoil.mesosphere.com/" ${DCOS_DIR}/hosts.local || \
-        echo ${CLI_TEST_DCOS_URL} dcos.snakeoil.mesosphere.com >> ${DCOS_DIR}/hosts.local
-    sudo mv ${DCOS_DIR}/hosts.local /etc/hosts
-
 **CLI_TEST_DCOS_URL**: Holds the URL or IP address of the cluster you
 are testing against. If you used :code:`dcos-launch` to launch the cluster,
 you can get the IP of the cluster by running :code:`dcos-launch describe`.

--- a/ci/Jenkinsfile-linux-integration
+++ b/ci/Jenkinsfile-linux-integration
@@ -165,13 +165,10 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
 
                         withCredentials(
                             [[$class: 'FileBinding',
-                              credentialsId: '1c206779-acc0-4844-97f6-7b3ed081a456',
-                              variable: 'DCOS_SNAKEOIL_CRT_PATH'],
-                             [$class: 'FileBinding',
                               credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
                               variable: 'CLI_TEST_SSH_KEY_PATH']]) {
 
-                            withEnv(["DCOS_IP=${dcosIp}"]) {
+                            withEnv(["CLI_TEST_DCOS_URL=https://${dcosIp}"]) {
                                 try {
                                     body()
                                 } catch(InterruptedException | hudson.AbortException e) {
@@ -214,11 +211,7 @@ def builders = [:]
 
 builders['linux-tests'] = testBuilder('linux', 'py35', '/workspace')({
     stage ("Run dcos-cli tests") {
-        sh '''
-           rm -rf ~/.dcos; \
-           grep -q "^.* dcos.snakeoil.mesosphere.com$" /etc/hosts && \
-           sed -iold "s/^.* dcos.snakeoil.mesosphere.com$/${DCOS_IP} dcos.snakeoil.mesosphere.com/" /etc/hosts || \
-           echo ${DCOS_IP} dcos.snakeoil.mesosphere.com >> /etc/hosts'''
+        sh "rm -rf ~/.dcos"
 
         dir('dcos-cli') {
             sh 'make test'
@@ -230,7 +223,7 @@ builders['linux-tests'] = testBuilder('linux', 'py35', '/workspace')({
                make binary; \
                export CLI_TEST_SSH_USER=centos; \
                export CLI_TEST_MASTER_PROXY=true; \
-               dist/dcos cluster setup dcos.snakeoil.mesosphere.com \
+               dist/dcos cluster setup ${CLI_TEST_DCOS_URL} \
                    --insecure --username=${DCOS_ADMIN_USERNAME} \
                    --password-env=DCOS_ADMIN_PASSWORD; \
                dist/dcos config set core.reporting false; \

--- a/ci/Jenkinsfile-mac-integration
+++ b/ci/Jenkinsfile-mac-integration
@@ -164,13 +164,10 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
 
                         withCredentials(
                             [[$class: 'FileBinding',
-                              credentialsId: '1c206779-acc0-4844-97f6-7b3ed081a456',
-                              variable: 'DCOS_SNAKEOIL_CRT_PATH'],
-                             [$class: 'FileBinding',
                               credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
                               variable: 'CLI_TEST_SSH_KEY_PATH']]) {
 
-                            withEnv(["DCOS_IP=${dcosIp}"]) {
+                            withEnv(["CLI_TEST_DCOS_URL=https://${dcosIp}"]) {
                                 try {
                                     body()
                                 } catch(InterruptedException | hudson.AbortException e) {
@@ -214,13 +211,7 @@ def builders = [:]
 builders['mac-tests'] = testBuilder('mac', 'mac')({
     try {
         stage ("Run dcos-cli tests") {
-            sh '''
-               rm -rf ~/.dcos; \
-               cp /etc/hosts hosts.local; \
-               grep -q "^.* dcos.snakeoil.mesosphere.com$" hosts.local && \
-               sed -iold "s/^.* dcos.snakeoil.mesosphere.com$/${DCOS_IP} dcos.snakeoil.mesosphere.com/" hosts.local || \
-               echo ${DCOS_IP} dcos.snakeoil.mesosphere.com >> hosts.local; \
-               sudo cp ./hosts.local /etc/hosts'''
+            sh "rm -rf ~/.dcos"
 
             dir('dcos-cli') {
                 sh 'make test'
@@ -232,7 +223,7 @@ builders['mac-tests'] = testBuilder('mac', 'mac')({
                    make binary; \
                    export CLI_TEST_SSH_USER=centos; \
                    export CLI_TEST_MASTER_PROXY=true; \
-                   dist/dcos cluster setup dcos.snakeoil.mesosphere.com \
+                   dist/dcos cluster setup ${CLI_TEST_DCOS_URL} \
                      --insecure --username=${DCOS_ADMIN_USERNAME} \
                      --password-env=DCOS_ADMIN_PASSWORD; \
                    dist/dcos config set core.reporting false; \
@@ -241,14 +232,8 @@ builders['mac-tests'] = testBuilder('mac', 'mac')({
             }
         }
     } finally {
-        stage ("Cleaning up \$DCOS_DIR and /etc/hosts") {
-            sh '''
-               rm -rf ~/.dcos; \
-               cp /etc/hosts hosts.local; \
-               cat hosts.local; \
-               sed -i "" "/dcos.snakeoil.mesosphere.com/d" hosts.local; \
-               cat hosts.local; \
-               sudo cp ./hosts.local /etc/hosts'''
+        stage ("Cleaning up \$DCOS_DIR") {
+            sh "rm -rf ~/.dcos"
         }
     }
 })

--- a/ci/Jenkinsfile-windows-integration
+++ b/ci/Jenkinsfile-windows-integration
@@ -164,13 +164,10 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
 
                         withCredentials(
                             [[$class: 'FileBinding',
-                              credentialsId: '1c206779-acc0-4844-97f6-7b3ed081a456',
-                              variable: 'DCOS_SNAKEOIL_CRT_PATH'],
-                             [$class: 'FileBinding',
                               credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
                               variable: 'CLI_TEST_SSH_KEY_PATH']]) {
 
-                            withEnv(["DCOS_IP=${dcosIp}"]) {
+                            withEnv(["CLI_TEST_DCOS_URL=https://${dcosIp}"]) {
                                 try {
                                     body()
                                 } catch(InterruptedException | hudson.AbortException e) {
@@ -213,13 +210,7 @@ def builders = [:]
 
 builders['windows-tests'] = testBuilder('windows', 'windows', 'C:\\windows\\workspace')({
     stage ("Run dcos-cli tests") {
-        bat '''
-            bash -c " \
-            rm -rf ${HOME}/.dcos && \
-            sed \'/^.* dcos.snakeoil.mesosphere.com$/d\' /windows/system32/drivers/etc/hosts >/windows/system32/drivers/etc/hosts && \
-            echo ${DCOS_IP} dcos.snakeoil.mesosphere.com >> /windows/system32/drivers/etc/hosts"'''
-
-        bat 'bash -c "cat /windows/system32/drivers/etc/hosts"'
+        bat 'bash -c "rm -rf ${HOME}/.dcos"'
 
         dir('dcos-cli') {
             bat 'make test'
@@ -232,7 +223,7 @@ builders['windows-tests'] = testBuilder('windows', 'windows', 'C:\\windows\\work
                 make binary; \
                 export CLI_TEST_SSH_USER=centos; \
                 export CLI_TEST_MASTER_PROXY=true; \
-                dist/dcos cluster setup dcos.snakeoil.mesosphere.com \
+                dist/dcos cluster setup ${CLI_TEST_DCOS_URL} \
                     --insecure --username=${DCOS_ADMIN_USERNAME} \
                     --password-env=DCOS_ADMIN_PASSWORD; \
                 dist/dcos config set core.reporting false; \

--- a/cli/dcoscli/test/common.py
+++ b/cli/dcoscli/test/common.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import time
 
+import pytest
 import six
 from six.moves import urllib
 
@@ -369,3 +370,15 @@ def base64_to_dict(byte_string):
     :rtype dict
     """
     return json.loads(base64.b64decode(byte_string).decode('utf-8'))
+
+
+def skip_if_env_missing(env_vars):
+    """Skip a test if some environment variable are missing.
+
+    :param env_vars: environment variables that should be present
+    :type env_vars: list of str
+    """
+
+    for env_var in env_vars:
+        if env_var not in os.environ:
+            pytest.skip(env_var + ' is not set.')

--- a/cli/dcoscli/test/constants.py
+++ b/cli/dcoscli/test/constants.py
@@ -1,0 +1,9 @@
+DCOS_TEST_URL_ENV = 'CLI_TEST_DCOS_URL'
+"""Environment variable containing the URL of the DC/OS cluster master node
+for integration tests."""
+
+DCOS_TEST_USER_ENV = 'DCOS_ADMIN_USERNAME'
+"""Environment variable containing the user for integration tests."""
+
+DCOS_TEST_PASS_ENV = 'DCOS_ADMIN_PASSWORD'
+"""Environment variable containing the password for integration tests."""

--- a/cli/tests/data/cluster_migration/dcos.toml
+++ b/cli/tests/data/cluster_migration/dcos.toml
@@ -1,5 +1,4 @@
 [core]
-dcos_url = "http://dcos.snakeoil.mesosphere.com"
 ssl_verify = false
 timeout = 5
 reporting = false

--- a/cli/tests/integrations/test_cluster.py
+++ b/cli/tests/integrations/test_cluster.py
@@ -6,7 +6,9 @@ from distutils.dir_util import copy_tree
 import pytest
 
 from dcos import config, constants, util
-from dcoscli.test.common import assert_command, exec_command
+from dcoscli.test.common import (assert_command, exec_command,
+                                 skip_if_env_missing)
+from dcoscli.test.constants import (DCOS_TEST_URL_ENV)
 
 
 @pytest.fixture
@@ -103,11 +105,13 @@ def test_setup_noninteractive():
     This makes sure the process doesn't prompt for input forever (DCOS-15590).
     """
 
+    skip_if_env_missing([DCOS_TEST_URL_ENV])
+
     returncode, stdout, stderr = exec_command(
         ['dcos',
          'cluster',
          'setup',
-         'https://dcos.snakeoil.mesosphere.com'],
+         os.environ.get(DCOS_TEST_URL_ENV)],
         timeout=30,
         stdin=subprocess.DEVNULL)
 

--- a/cli/tests/integrations/test_ssl.py
+++ b/cli/tests/integrations/test_ssl.py
@@ -2,22 +2,12 @@ import os
 
 import pytest
 
-from dcos import constants
-
 from dcoscli.test.common import exec_command, update_config
 
 
 @pytest.fixture
 def env():
-    r = os.environ.copy()
-    r.update({
-        constants.PATH_ENV: os.environ[constants.PATH_ENV],
-        'DCOS_SNAKEOIL_CRT_PATH': os.environ.get(
-            "DCOS_SNAKEOIL_CRT_PATH", "/dcos-cli/adminrouter/snakeoil.crt"),
-        'DCOS_URL': 'https://dcos.snakeoil.mesosphere.com'
-    })
-
-    return r
+    return os.environ.copy()
 
 
 def test_dont_verify_ssl_with_env_var(env):
@@ -76,29 +66,6 @@ def test_verify_ssl_with_bad_cert_config(env):
             ['dcos', 'marathon', 'app', 'list'], env)
         assert returncode == 1
         assert stderr.decode('utf-8') == _ssl_error_msg()
-
-
-@pytest.mark.skipif(True, reason='Need to resolve DCOS-9273 to validate certs')
-def test_verify_ssl_with_good_cert_env_var(env):
-    env['DCOS_SSL_VERIFY'] = env['DCOS_SNAKEOIL_CRT_PATH']
-
-    with update_config('core.ssl_verify', None, env):
-        returncode, stdout, stderr = exec_command(
-            ['dcos', 'marathon', 'app', 'list'], env)
-        assert returncode == 0
-        assert stderr == b''
-
-    env.pop('DCOS_SSL_VERIFY')
-
-
-@pytest.mark.skipif(True, reason='Need to resolve DCOS-9273 to validate certs')
-def test_verify_ssl_with_good_cert_config(env):
-    with update_config(
-            'core.ssl_verify', env['DCOS_SNAKEOIL_CRT_PATH'], env):
-        returncode, stdout, stderr = exec_command(
-            ['dcos', 'marathon', 'app', 'list'], env)
-        assert returncode == 0
-        assert stderr == b''
 
 
 def _ssl_error_msg():


### PR DESCRIPTION
dcos.snakeoil.mesosphere.com was expected to be pointing to the master's IP address (in /etc/hosts). This makes use of the IP directly through the `CLI_TEST_DCOS_URL` environment variable, which is already documented.