### PR TITLE
Increase default HTTP timeout to 180 seconds

### DIFF
--- a/cli/dcoscli/job/main.py
+++ b/cli/dcoscli/job/main.py
@@ -796,7 +796,7 @@ def _get_api_url(path):
 
 def _get_timeout():
     """
-    :returns: timout value for API calls
+    :returns: timeout value for API calls
     :rtype: str
     """
     # if timeout is not passed, try to read `core.timeout`

--- a/dcos/http.py
+++ b/dcos/http.py
@@ -13,7 +13,7 @@ from dcos.errors import (DCOSAuthenticationException,
 
 logger = util.get_logger(__name__)
 
-DEFAULT_TIMEOUT = 5
+DEFAULT_TIMEOUT = 180
 
 
 def _default_is_success(status_code):


### PR DESCRIPTION
See https://jira.mesosphere.com/browse/DCOS_OSS-1957

5 seconds is too slow to pull the universe on my current network connection.
As per the JIRA issue, this matches the documented default.

https://jira.mesosphere.com/browse/DCOS_OSS-1956 may cover using the value from the config but this is an improvement anyways, in my opinion.