### PR TITLE
Skip show_bad_app_version Marathon test

### DIFF
--- a/cli/tests/integrations/test_marathon.py
+++ b/cli/tests/integrations/test_marathon.py
@@ -158,6 +158,7 @@ def test_show_missing_absolute_app_version():
             "Error: App '/zero-instance-app' does not exist")
 
 
+@pytest.mark.skipif(True, reason=('MARATHON-7954'))
 def test_show_bad_app_version():
     with _zero_instance_app():
         _update_app(


### PR DESCRIPTION
Marathon changed the error message for invalid versions.

A ticket has been opened : https://jira.mesosphere.com/browse/MARATHON-7954

Until this is resolved that test should be skipped.