### PR TITLE
Cluster linker improvements

### DIFF
--- a/cli/dcoscli/cluster/main.py
+++ b/cli/dcoscli/cluster/main.py
@@ -158,10 +158,7 @@ def _list(json_, attached, linked=False):
         if attached:
             msg = ("No cluster is attached. "
                    "Please run `dcos cluster attach <cluster-name>")
-        else:
-            msg = ("No clusters are currently configured. "
-                   "To configure one, run `dcos cluster setup <dcos_url>`")
-        raise DCOSException(msg)
+            raise DCOSException(msg)
     else:
         emitter.publish(clusters_table(clusters))
 

--- a/cli/dcoscli/cluster/main.py
+++ b/cli/dcoscli/cluster/main.py
@@ -181,7 +181,7 @@ def _attach(name):
     if not c:
         raise DCOSException("Cluster [{}] does not exist".format(name))
 
-    if isinstance(c, cluster.LinkedCluster):
+    if c.get_status() == cluster.STATUS_UNCONFIGURED:
         return setup(c.get_url(), provider=c.get_provider().get('id'))
 
     return cluster.set_attached(c.get_cluster_path())

--- a/cli/dcoscli/cluster/main.py
+++ b/cli/dcoscli/cluster/main.py
@@ -471,7 +471,7 @@ def _prompt_for_login_provider(providers):
 
     choices = []
     descriptions = []
-    for idx in providers.keys():
+    for idx in sorted(providers.keys()):
         provider_type = providers[idx].get('authentication-type')
         if provider_type not in [
                 auth.AUTH_TYPE_DCOS_UID_PASSWORD,

--- a/cli/dcoscli/data/help/cluster_ee.txt
+++ b/cli/dcoscli/data/help/cluster_ee.txt
@@ -8,7 +8,7 @@ Usage:
     dcos cluster attach <name>
     dcos cluster link <dcos_url> [--provider=<provider_id>]
     dcos cluster unlink <name>
-    dcos cluster list [--attached --json]
+    dcos cluster list [--attached --linked --json]
     dcos cluster remove [<name> | --all]
     dcos cluster rename <name> <new_name>
     dcos cluster setup <dcos_url>
@@ -44,6 +44,8 @@ Options:
         Print a short description of this subcommand.
     --insecure
         Allow requests to bypass SSL certificate verification (insecure).
+    --linked
+        List only linked clusters.
     --no-check
         Do not check CA certficate downloaded from cluster (insecure). Applies to Enterprise DC/OS only.
     --password=<password>

--- a/cli/tests/integrations/test_cluster_migration.py
+++ b/cli/tests/integrations/test_cluster_migration.py
@@ -42,13 +42,8 @@ def test_dcos_dir_env_with_acs_token(acs_token, temp_dcos_dir):
 def test_dcos_dir_env_without_acs_token(acs_token, temp_dcos_dir):
     _copy_config_to_dir('dcos.toml', temp_dcos_dir)
 
-    stderr = (
-        b"No clusters are currently configured. "
-        b"To configure one, run `dcos cluster setup <dcos_url>`\n"
-    )
-
     # Without an ACS token, the migration shouldn't occur
-    assert_command(['dcos', 'cluster', 'list'], returncode=1, stderr=stderr)
+    assert_command(['dcos', 'cluster', 'list'])
 
 
 def test_dcos_config_env_with_acs_token(acs_token, temp_dcos_dir):
@@ -80,13 +75,11 @@ def test_dcos_config_env_without_acs_token(temp_dcos_dir):
         stderr = (
             b"DCOS_CONFIG is deprecated, please consider using "
             b"`dcos cluster setup <dcos_url>`.\n"
-            b"No clusters are currently configured. "
-            b"To configure one, run `dcos cluster setup <dcos_url>`\n"
         )
 
         # Without an ACS token, the migration shouldn't occur
         assert_command(
-            ['dcos', 'cluster', 'list'], returncode=1, stderr=stderr)
+            ['dcos', 'cluster', 'list'], stderr=stderr)
 
 
 def test_setup_cluster_through_config_commands(acs_token, temp_dcos_dir):

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -45,7 +45,7 @@ commands =
 
 [testenv:py35-integration]
 commands =
-  py.test -p no:cacheprovider -vv -x {env:CI_FLAGS:} tests/integrations{posargs}
+  py.test --durations=0 -p no:cacheprovider -vv -x {env:CI_FLAGS:} tests/integrations{posargs}
 
 [testenv:py35-unit]
 commands =

--- a/dcos/cluster.py
+++ b/dcos/cluster.py
@@ -409,19 +409,11 @@ class LinkedCluster(Cluster):
     """Representation of a linked cluster"""
 
     def __init__(self, cluster_url, cluster_id, cluster_name, provider):
-        self.cluster_id = cluster_id
         self.cluster_name = cluster_name
         self.cluster_url = cluster_url
         self.provider = provider
 
-    def get_cluster_path(self):
-        return None
-
-    def get_config_path(self):
-        return None
-
-    def get_config(self, mutable=False):
-        return None
+        super().__init__(cluster_id)
 
     def get_name(self):
         return self.cluster_name
@@ -430,9 +422,15 @@ class LinkedCluster(Cluster):
         return self.cluster_url
 
     def is_attached(self):
-        return False
+        if self.get_status() == STATUS_UNCONFIGURED:
+            return False
+
+        return super().is_attached()
 
     def get_status(self):
+        if os.path.exists(self.get_cluster_path()):
+            return super().get_status()
+
         return STATUS_UNCONFIGURED
 
     def get_provider(self):


### PR DESCRIPTION
- Sort login providers during the `cluster link` prompt
- A LinkedCluster object might be a configured cluster
- Add --linked flag to `dcos cluster list`
- Don't error out in case no cluster is listed
- Don't rely on the http module to get cluster version 