### PR TITLE
HTTP timeout improvements

### DIFF
--- a/cli/tests/integrations/test_package.py
+++ b/cli/tests/integrations/test_package.py
@@ -8,7 +8,7 @@ import sys
 import pytest
 import six
 
-from dcos import config, constants, errors, subcommand, util
+from dcos import config, constants, errors, http, subcommand, util
 
 from dcoscli.test.common import (assert_command, assert_lines, base64_to_dict,
                                  delete_zk_node,
@@ -1095,8 +1095,9 @@ def _package(name,
     command = ['dcos', 'package', 'install', name] + args
 
     installed = False
+    timeout = http.DEFAULT_READ_TIMEOUT
     try:
-        returncode_, stdout_, stderr_ = exec_command(command, timeout=30)
+        returncode_, stdout_, _ = exec_command(command, timeout=timeout)
         installed = (returncode_ == 0)
 
         assert installed

--- a/dcos/cluster.py
+++ b/dcos/cluster.py
@@ -106,7 +106,9 @@ def setup_cluster_config(dcos_url, temp_path, stored_cert):
     try:
         # find cluster id
         cluster_url = dcos_url.rstrip('/') + '/metadata'
-        res = http.get(cluster_url, timeout=1)
+        # This is an informational request,
+        # a 5 seconds read timeout is enough.
+        res = http.get(cluster_url, timeout=5)
         cluster_id = res.json().get("CLUSTER_ID")
 
     except DCOSException as e:
@@ -138,7 +140,11 @@ def setup_cluster_config(dcos_url, temp_path, stored_cert):
     cluster_name = cluster_id
     try:
         url = dcos_url.rstrip('/') + '/mesos/state-summary'
-        name_query = http.get(url, toml_config=cluster.get_config())
+        # This is an informational request,
+        # a 5 seconds read timeout is enough.
+        name_query = http.get(url,
+                              toml_config=cluster.get_config(),
+                              timeout=5)
         cluster_name = name_query.json().get("cluster")
 
     except DCOSException:
@@ -378,6 +384,8 @@ class Cluster():
             self.get_url(), "dcos-metadata/dcos-version.json")
 
         try:
+            # This is an informational request,
+            # a 5 seconds read timeout is enough.
             resp = requests.request(
                 'GET',
                 url=endpoint,

--- a/dcos/cluster.py
+++ b/dcos/cluster.py
@@ -389,7 +389,7 @@ class Cluster():
             resp = requests.request(
                 'GET',
                 url=endpoint,
-                timeout=http.DEFAULT_TIMEOUT,
+                timeout=5,
                 verify=False)
         except Exception as e:
             return VERSION_UNKNOWN

--- a/dcos/http.py
+++ b/dcos/http.py
@@ -238,7 +238,7 @@ def request(method,
     dcos_url = urlparse(config.get_config_val("core.dcos_url", toml_config))
 
     # only request with DC/OS Auth if request is to DC/OS cluster
-    if auth_token and _is_request_to_dcos(url):
+    if auth_token and _is_request_to_dcos(url, toml_config=toml_config):
         auth = DCOSAcsAuth(auth_token)
     else:
         auth = None

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,81 @@
+from mock import patch
+
+from requests import Response
+
+from dcos import config, http
+
+
+@patch('requests.request')
+def test_request_default_timeout_without_config(requests_mock):
+    timeout = True
+    toml_config = config.Toml({})
+    expected_timeout = http.DEFAULT_TIMEOUT
+
+    _assert_request_timeout(
+        requests_mock,
+        timeout,
+        toml_config,
+        expected_timeout)
+
+
+@patch('requests.request')
+def test_request_default_timeout_with_config(requests_mock):
+    timeout = 5
+
+    toml_config = config.Toml({
+        'core': {'timeout': timeout}
+    })
+
+    expected_timeout = (http.DEFAULT_CONNECT_TIMEOUT, timeout)
+
+    _assert_request_timeout(
+        requests_mock,
+        timeout,
+        toml_config,
+        expected_timeout)
+
+
+@patch('requests.request')
+def test_request_timeout_with_numeric_argument(requests_mock):
+    timeout = 30
+    toml_config = config.Toml({})
+    expected_timeout = (http.DEFAULT_CONNECT_TIMEOUT, timeout)
+
+    _assert_request_timeout(
+        requests_mock,
+        timeout,
+        toml_config,
+        expected_timeout)
+
+
+@patch('requests.request')
+def test_request_timeout_with_tuple_argument(requests_mock):
+    timeout = (5, 30)
+    toml_config = config.Toml({})
+
+    _assert_request_timeout(requests_mock, timeout, toml_config, timeout)
+
+
+def _assert_request_timeout(
+        requests_mock, timeout, toml_config, expected_timeout):
+    resp = Response()
+    resp.status_code = 200
+    requests_mock.return_value = resp
+
+    method = 'GET'
+    url = 'https://www.example.com'
+
+    http.request(
+        method,
+        url,
+        timeout=timeout,
+        headers={},
+        toml_config=toml_config)
+
+    requests_mock.assert_called_once_with(
+        method=method,
+        url=url,
+        auth=None,
+        timeout=expected_timeout,
+        headers={},
+        verify=None)


### PR DESCRIPTION
This leverages the tuple timeout of the requests package in order to distinguish between the connection timeout and the response read timeout.

When a timeout is passed as a numeric value, it refers to the read_timeout.

When no explicit timeout is passed, the `core.timeout` value in the config file is now used, or if not present, defaults to 180. This also refers to the read_timeout.

The connection timeout defaults to 5. In order to overwrite it, one must pass a tuple of the form `(connection_timeout, read_timeout)`.

https://jira.mesosphere.com/browse/DCOS_OSS-1956
https://jira.mesosphere.com/browse/DCOS_OSS-1957