### PR TITLE
fix dcos-cli CI

### DIFF
--- a/ci/Jenkinsfile-linux-integration
+++ b/ci/Jenkinsfile-linux-integration
@@ -43,6 +43,7 @@ dcos_config:
         - 10.10.0.2
     dns_search: us-west-2.compute.internal
     master_discovery: static
+    exhibitor_storage_backend: static
 """
 }
 

--- a/ci/Jenkinsfile-mac-integration
+++ b/ci/Jenkinsfile-mac-integration
@@ -43,6 +43,7 @@ dcos_config:
         - 10.10.0.2
     dns_search: us-west-2.compute.internal
     master_discovery: static
+    exhibitor_storage_backend: static
 """
 }
 

--- a/ci/Jenkinsfile-windows-integration
+++ b/ci/Jenkinsfile-windows-integration
@@ -43,6 +43,7 @@ dcos_config:
         - 10.10.0.2
     dns_search: us-west-2.compute.internal
     master_discovery: static
+    exhibitor_storage_backend: static
 """
 }
 


### PR DESCRIPTION
installer would not pass exhibitor_storage_backend implicitly anymore, we
need to include it in dcos-launch config.