### PR TITLE
Improve output from metrics summary

### DIFF
--- a/cli/dcoscli/metrics.py
+++ b/cli/dcoscli/metrics.py
@@ -98,6 +98,8 @@ def _node_summary_json(datapoints):
     summary_datapoints = [
         _get_datapoint(datapoints, 'cpu.total'),
         _get_datapoint(datapoints, 'memory.total'),
+        _get_datapoint(datapoints, 'memory.free'),
+        _get_datapoint(datapoints, 'filesystem.capacity.total', {'path': '/'}),
         _get_datapoint(datapoints, 'filesystem.capacity.used', {'path': '/'})
     ]
     return json.dumps(summary_datapoints)

--- a/cli/dcoscli/metrics.py
+++ b/cli/dcoscli/metrics.py
@@ -124,10 +124,9 @@ def _node_summary_data(datapoints):
 
     disk_total = _get_datapoint_value(
         datapoints, 'filesystem.capacity.total', {'path': '/'})
-    disk_free = _get_datapoint_value(
+    disk_used = _get_datapoint_value(
         datapoints, 'filesystem.capacity.used', {'path': '/'})
-    disk_used = disk_total - disk_free
-    disk_used_pc = _percentage(disk_free, disk_total)
+    disk_used_pc = _percentage(disk_used, disk_total)
 
     return {
         'cpu': '{:0.2f} ({:0.2f}%)'.format(cpu_used, cpu_used_pc),

--- a/cli/dcoscli/metrics.py
+++ b/cli/dcoscli/metrics.py
@@ -125,7 +125,7 @@ def _node_summary_data(datapoints):
     disk_free = _get_datapoint_value(
         datapoints, 'filesystem.capacity.used', {'path': '/'})
     disk_used = disk_total - disk_free
-    disk_used_pc = _percentage(disk_used, disk_total)
+    disk_used_pc = _percentage(disk_free, disk_total)
 
     return {
         'cpu': '{:0.2f} ({:0.2f}%)'.format(cpu_used, cpu_used_pc),

--- a/cli/tests/integrations/test_node.py
+++ b/cli/tests/integrations/test_node.py
@@ -129,7 +129,8 @@ def test_node_metrics_agent_summary_json():
     )
 
     names = [d['name'] for d in node_json]
-    assert names == ['cpu.total', 'memory.total', 'filesystem.capacity.used']
+    assert names == ['cpu.total', 'memory.total', 'memory.free',
+                     'filesystem.capacity.total', 'filesystem.capacity.used']
 
 
 def test_node_metrics_agent_details():


### PR DESCRIPTION
Previously, as an outcome of `dcos node metrics summary`, the CLI reported the percentage of the disk that was available, eg 1GB (99%) for a 100GB disk.

This PR updates that calculation so we now see the used percentage, so in the above case the user would now see a disk entry of 1GB (1%). 

Additionally, I expanded the output from the --json endpoint after noticing that it only reported the total system memory and disk usage. 