### PR TITLE
Catch exceptions when matching configured clusters hosts

### DIFF
--- a/cli/dcoscli/cluster/main.py
+++ b/cli/dcoscli/cluster/main.py
@@ -257,7 +257,12 @@ def _link(dcos_url, provider_id):
     for configured_cluster in cluster.get_clusters():
         configured_cluster_host = \
             urlparse(configured_cluster.get_url()).netloc
-        configured_cluster_ip = socket.gethostbyname(configured_cluster_host)
+
+        try:
+            configured_cluster_ip = \
+                socket.gethostbyname(configured_cluster_host)
+        except OSError as error:
+            continue
 
         if linked_cluster_ip == configured_cluster_ip:
             linked_cluster_id = configured_cluster.get_cluster_id()


### PR DESCRIPTION
During cluster linking, the host to be linked gets its IP address
resolved in order to get matched against the currently configured ones.

Resolving configured clusters IP address might throw an exception (when
they are not reachable anymore), this continues silently in such cases.