### PR TITLE
Adding Metronome job queue functionality

### DIFF
--- a/cli/tests/data/metronome/jobs/gyarados.json
+++ b/cli/tests/data/metronome/jobs/gyarados.json
@@ -1,0 +1,10 @@
+{
+  "id": "gyarados",
+  "description": "so large I do not fit",
+  "run": {
+    "cmd": "sleep 20000",
+    "cpus": 10,
+    "mem": 32,
+    "disk": 0
+  }
+}

--- a/cli/tests/unit/data/job_queue.txt
+++ b/cli/tests/unit/data/job_queue.txt
@@ -1,0 +1,3 @@
+ID              JOB RUN ID      
+queue-job  20180123185638P0Dxf  
+queue-job  20180123185640uv3PZ  

--- a/python/lib/dcos/dcos/metronome.py
+++ b/python/lib/dcos/dcos/metronome.py
@@ -339,7 +339,8 @@ class Client(object):
         :rtype: None
         """
         if job_id is None or run_id is None:
-            raise DCOSException("job_id and run_id are required to kill a jobrun.")
+            raise DCOSException(
+                "job_id and run_id are required to kill a jobrun.")
         job_id = util.normalize_marathon_id_path(job_id)
         run_id = util.normalize_marathon_id_path(run_id)
         path = '/v1/jobs{}/runs{}/actions/stop'.format(job_id, run_id)

--- a/python/lib/dcos/dcos/metronome.py
+++ b/python/lib/dcos/dcos/metronome.py
@@ -345,7 +345,7 @@ class Client(object):
         path = '/v1/jobs{}/runs{}/actions/stop'.format(job_id, run_id)
         self._rpc.http_req(http.post, path)
 
-    def get_queued_jobruns(self, job_id):
+    def get_queued_job_runs(self, job_id):
         """Returns the content of the launch queue,
         including the jobruns for each job_id which should be scheduled.
 
@@ -356,7 +356,7 @@ class Client(object):
         if job_id is not None:
             deployments = [
                 deployment for deployment in response.json()
-                if job_id in deployment['jobId']
+                if job_id == deployment['jobId']
             ]
         else:
             deployments = response.json()

--- a/python/lib/dcos/dcos/metronome.py
+++ b/python/lib/dcos/dcos/metronome.py
@@ -338,11 +338,30 @@ class Client(object):
         :type run_id: str
         :rtype: None
         """
-
+        if job_id is None or run_id is None:
+            raise DCOSException("job_id and run_id are required to kill a jobrun.")
         job_id = util.normalize_marathon_id_path(job_id)
         run_id = util.normalize_marathon_id_path(run_id)
         path = '/v1/jobs{}/runs{}/actions/stop'.format(job_id, run_id)
         self._rpc.http_req(http.post, path)
+
+    def get_queued_jobruns(self, job_id):
+        """Returns the content of the launch queue,
+        including the jobruns for each job_id which should be scheduled.
+
+        :returns: a list of jobruns to launch
+        :rtype: list of dict
+        """
+        response = self._rpc.http_req(http.get, 'v1/queue')
+        if job_id is not None:
+            deployments = [
+                deployment for deployment in response.json()
+                if job_id in deployment['jobId']
+            ]
+        else:
+            deployments = response.json()
+
+        return deployments
 
     @staticmethod
     def _job_id_path_format(url_path_template, id_path):

--- a/python/lib/dcoscli/dcoscli/data/help/job.txt
+++ b/python/lib/dcoscli/dcoscli/data/help/job.txt
@@ -18,6 +18,7 @@ Description:
         dcos job schedule remove <job-id> <schedule-id>
         dcos job schedule update <job-id> <schedule-file>
         dcos job show runs <job-id> [--run-id <run-id>][--json|--quiet]
+        dcos job queue [<job-id>][--json|--quiet]
         dcos job history <job-id> [--json|--quiet] [--failures --last]
 
 Commands:
@@ -45,6 +46,8 @@ Commands:
         Updates a schedule on a job.
     job show runs
         Shows the successful and failure runs of a job.
+    job queue
+        Print a list of currently jobruns that a queued to launch
     job history
         Provides a job run history.
 

--- a/python/lib/dcoscli/dcoscli/job/main.py
+++ b/python/lib/dcoscli/dcoscli/job/main.py
@@ -237,13 +237,14 @@ def _queue(job_id, json_flag=False, quiet=False):
     """
     :param job_id: Id of the job
     :type job_id: str
-    :param json_flag: output json if True
+    :param json_flag: Output json if True
     :type json_flag: bool
     :returns: process return code
     :rtype: int
     """
+
     client = metronome.create_client()
-    deployment_list = client.get_queued_jobruns(job_id)
+    deployment_list = client.get_queued_job_runs(job_id)
 
     if not deployment_list and not json_flag:
         msg = "There are no deployments in the queue"

--- a/python/lib/dcoscli/dcoscli/job/main.py
+++ b/python/lib/dcoscli/dcoscli/job/main.py
@@ -239,6 +239,8 @@ def _queue(job_id, json_flag=False, quiet=False):
     :type job_id: str
     :param json_flag: Output json if True
     :type json_flag: bool
+    :param quiet: Output only job run ids if true
+    :type quiet: bool
     :returns: process return code
     :rtype: int
     """
@@ -250,10 +252,8 @@ def _queue(job_id, json_flag=False, quiet=False):
         msg = "There are no deployments in the queue"
         if job_id:
             msg += " for '{}'".format(job_id)
-            raise DCOSException(msg)
-        else:
-            emitter.publish(msg)
-            return 0
+        emitter.publish(msg)
+        return 0
 
     if quiet:
         for deployment in deployment_list:

--- a/python/lib/dcoscli/dcoscli/job/main.py
+++ b/python/lib/dcoscli/dcoscli/job/main.py
@@ -124,6 +124,11 @@ def _cmds():
             function=_list),
 
         cmds.Command(
+            hierarchy=['job', 'queue'],
+            arg_keys=['<job-id>', '--json', '--quiet'],
+            function=_queue),
+
+        cmds.Command(
             hierarchy=['job', 'history'],
             arg_keys=['<job-id>', '--json', '--failures', '--last', '--quiet'],
             function=_history),
@@ -225,6 +230,39 @@ def _remove(job_id, stop_current_job_runs=False):
         raise DCOSException("Unable to remove '{}'. {}."
                             .format(job_id, e))
 
+    return 0
+
+
+def _queue(job_id, json_flag=False, quiet=False):
+    """
+    :param job_id: Id of the job
+    :type job_id: str
+    :param json_flag: output json if True
+    :type json_flag: bool
+    :returns: process return code
+    :rtype: int
+    """
+    client = metronome.create_client()
+    deployment_list = client.get_queued_jobruns(job_id)
+
+    if not deployment_list and not json_flag:
+        msg = "There are no deployments in the queue"
+        if job_id:
+            msg += " for '{}'".format(job_id)
+            raise DCOSException(msg)
+        else:
+            emitter.publish(msg)
+            return 0
+
+    if quiet:
+        for deployment in deployment_list:
+            for runs in deployment.get("runs"):
+                emitter.publish(runs.get("runId"))
+    else:
+        emitting.publish_table(emitter,
+                               deployment_list,
+                               tables.job_queue_table,
+                               json_flag)
     return 0
 
 

--- a/python/lib/dcoscli/dcoscli/tables.py
+++ b/python/lib/dcoscli/dcoscli/tables.py
@@ -309,7 +309,8 @@ def job_queue_table(job_queue):
     for job in job_queue:
         job_id = job["jobId"]
         for jobruns in job.get("runs"):
-            flatten_job_list.append({'jobId': job_id, 'jobrun_id': jobruns.get("runId")})
+            flatten_job_list.append(
+                {'jobId': job_id, 'jobrun_id': jobruns.get("runId")})
 
     fields = OrderedDict([
         ('id', lambda s: s['jobId']),

--- a/python/lib/dcoscli/dcoscli/tables.py
+++ b/python/lib/dcoscli/dcoscli/tables.py
@@ -307,9 +307,9 @@ def job_queue_table(job_queue):
     flatten_job_list = []
 
     for job in job_queue:
-        job_id = job.get("jobId")
+        job_id = job["jobId"]
         for jobruns in job.get("runs"):
-            flatten_job_list.append({ 'jobId': job_id, 'jobrun_id': jobruns.get("runId")})
+            flatten_job_list.append({'jobId': job_id, 'jobrun_id': jobruns.get("runId")})
 
     fields = OrderedDict([
         ('id', lambda s: s['jobId']),

--- a/python/lib/dcoscli/dcoscli/tables.py
+++ b/python/lib/dcoscli/dcoscli/tables.py
@@ -296,6 +296,32 @@ def job_table(job_list):
     return tb
 
 
+def job_queue_table(job_queue):
+    """Returns a PrettyTable representation of the job queue from Metronome.
+
+    :param job_queue: jobs with jobruns in the queue to render
+    :type job_queue: [job]
+    :rtype: PrettyTable
+    """
+
+    flatten_job_list = []
+
+    for job in job_queue:
+        job_id = job.get("jobId")
+        for jobruns in job.get("runs"):
+            flatten_job_list.append({ 'jobId': job_id, 'jobrun_id': jobruns.get("runId")})
+
+    fields = OrderedDict([
+        ('id', lambda s: s['jobId']),
+        ('job run id', lambda s: s['jobrun_id']),
+    ])
+
+    tb = truncate_table(fields, flatten_job_list, None, sortby="ID")
+    tb.align["ID"] = 'l'
+
+    return tb
+
+
 def plugins_table(plugin_list):
     """Returns a PrettyTable representation of the plugins list from Marathon.
 

--- a/python/lib/dcoscli/tests/fixtures/metronome.py
+++ b/python/lib/dcoscli/tests/fixtures/metronome.py
@@ -117,6 +117,19 @@ def job_history_fixture():
         "id": "20170331210530QHpRU"
       }]
 
+def job_queue_fixture():
+    """Job queue fixture
+
+    :rtype: dict
+    """
+
+    return [
+    {
+      "jobId": "queue-job",
+      "runs": [
+      {"runId": "20180123185638P0Dxf"},
+      {"runId": "20180123185640uv3PZ"}]
+    }]
 
 def job_schedule_fixture():
     """Job schedule fixture

--- a/python/lib/dcoscli/tests/integrations/test_job.py
+++ b/python/lib/dcoscli/tests/integrations/test_job.py
@@ -105,6 +105,21 @@ def test_show_job_runs_blank_jobname():
         returncode=1)
 
 
+def test_show_job_queue_blank():
+    assert_command(
+        ['dcos', 'job', 'queue'],
+        stdout=b"There are no deployments in the queue\n",
+        stderr=b"",
+        returncode=0)
+
+
+def test_show_job_queue_blank_for_job():
+    assert_command(
+        ['dcos', 'job', 'queue', 'magikarp'],
+        stdout=b"There are no deployments in the queue for 'magikarp'\n",
+        stderr=b"",
+        returncode=0)
+
 def test_show_schedule_blank_jobname():
     returncode, stdout, stderr = exec_command(
         ['dcos', 'job', 'schedule', 'show'])
@@ -188,6 +203,19 @@ def _run_job(job_id):
     assert 'Run ID:' in stdout.decode('utf-8')
 
 
+def test_show_queue():
+    with _no_schedule_instance_large_job():
+
+        _run_job('gyarados')
+
+        returncode, stdout, stderr = exec_command(
+            ['dcos', 'job', 'queue'])
+
+        assert returncode == 0
+        assert 'JOB RUN ID' in stdout.decode('utf-8')
+        assert 'gyarados' in stdout.decode('utf-8')
+
+
 @contextlib.contextmanager
 def _no_schedule_instance_job():
     with job('tests/data/metronome/jobs/pikachu.json',
@@ -199,6 +227,13 @@ def _no_schedule_instance_job():
 def _schedule_instance_job():
     with job('tests/data/metronome/jobs/snorlax.json',
              'snorlax'):
+        yield
+
+
+@contextlib.contextmanager
+def _no_schedule_instance_large_job():
+    with job('tests/data/metronome/jobs/gyarados.json',
+             'gyarados'):
         yield
 
 

--- a/python/lib/dcoscli/tests/unit/test_tables.py
+++ b/python/lib/dcoscli/tests/unit/test_tables.py
@@ -19,7 +19,8 @@ from ..fixtures.metrics import (agent_metrics_node_details_fixture,
                                 agent_metrics_node_summary_fixture,
                                 agent_metrics_task_details_fixture)
 from ..fixtures.metronome import (job_history_fixture, job_list_fixture,
-                                  job_run_fixture, job_schedule_fixture)
+                                  job_run_fixture, job_schedule_fixture,
+                                  job_queue_fixture)
 from ..fixtures.node import slave_fixture
 from ..fixtures.package import package_fixture, search_result_fixture
 from ..fixtures.service import framework_fixture
@@ -103,6 +104,10 @@ def test_job_history_table():
                 job_history_fixture(),
                 'tests/unit/data/job_history.txt')
 
+def test_job_history_table():
+    _test_table(tables.job_queue_table,
+                job_queue_fixture(),
+                'tests/unit/data/job_queue.txt')
 
 def test_job_schedule_table():
     _test_table(tables.schedule_table,


### PR DESCRIPTION
command:   `job queue`, `job queue startdeadline`, `job queue --json`, `job queue -q`

```
dcos job queue 
ID                         JOB RUN ID              
startdeadline  /startdeadline/201801172321181BlLt  
```

```
 dcos job queue --json
[
  {
    "jobId": "startdeadline",
    "runs": [
      {
        "runId": "/startdeadline/201801172321181BlLt"
      }
    ]
  }
]
```