### PR TITLE
Add the CI license on integration tests

### DIFF
--- a/ci/Jenkinsfile-linux-integration
+++ b/ci/Jenkinsfile-linux-integration
@@ -21,7 +21,7 @@ def platforms = ["linux"]
 /**
  * This generates the `dcos_launch` config for a particular build.
  */
-def generateConfig(deploymentName, installerUrl, sshKeyPath) {
+def generateConfig(deploymentName, installerUrl, license, sshKeyPath) {
     return """
 ---
 launch_config_version: 1
@@ -44,6 +44,7 @@ dcos_config:
     dns_search: us-west-2.compute.internal
     master_discovery: static
     exhibitor_storage_backend: static
+    license_key_contents: ${license}
 """
 }
 
@@ -80,6 +81,7 @@ class TestCluster implements Serializable {
                         "text" : script.generateConfig(
                                 "dcos-cli-${platform}-${script.env.ghprbPullId}-${script.env.BUILD_ID}-${createAttempts}",
                                 "${script.env.DCOS_INSTALLER_URL}",
+                                "${script.env.DCOS_LICENSE}",
                                 "${script.env.CLI_TEST_SSH_KEY_PATH}")])
 
                 script.sh "./dcos-launch create -c ${platform}_config.yaml -i ${platform}_cluster_info.json"
@@ -276,6 +278,9 @@ throttle(['dcos-cli']) {
             [$class: 'StringBinding',
              credentialsId: '0b513aad-e0e0-4a82-95f4-309a80a02ff9',
              variable: 'DCOS_INSTALLER_URL'],
+            [$class: 'StringBinding',
+             credentialsId: 'ca159ad3-7323-4564-818c-46a8f03e1389',
+             variable: 'DCOS_LICENSE'],
             [$class: 'UsernamePasswordMultiBinding',
              credentialsId: '323df884-742b-4099-b8b7-d764e5eb9674',
              usernameVariable: 'DCOS_ADMIN_USERNAME',

--- a/ci/Jenkinsfile-mac-integration
+++ b/ci/Jenkinsfile-mac-integration
@@ -21,7 +21,7 @@ def platforms = ["mac"]
 /**
  * This generates the `dcos_launch` config for a particular build.
  */
-def generateConfig(deploymentName, installerUrl, sshKeyPath) {
+def generateConfig(deploymentName, installerUrl, license, sshKeyPath) {
     return """
 ---
 launch_config_version: 1
@@ -44,6 +44,7 @@ dcos_config:
     dns_search: us-west-2.compute.internal
     master_discovery: static
     exhibitor_storage_backend: static
+    license_key_contents: ${license}
 """
 }
 
@@ -80,6 +81,7 @@ class TestCluster implements Serializable {
                         "text" : script.generateConfig(
                                 "dcos-cli-${platform}-${script.env.ghprbPullId}-${script.env.BUILD_ID}-${createAttempts}",
                                 "${script.env.DCOS_INSTALLER_URL}",
+                                "${script.env.DCOS_LICENSE}",
                                 "${script.env.CLI_TEST_SSH_KEY_PATH}")])
 
                 script.sh "./dcos-launch create -c ${platform}_config.yaml -i ${platform}_cluster_info.json"
@@ -281,6 +283,9 @@ throttle(['dcos-cli']) {
             [$class: 'StringBinding',
              credentialsId: '0b513aad-e0e0-4a82-95f4-309a80a02ff9',
              variable: 'DCOS_INSTALLER_URL'],
+            [$class: 'StringBinding',
+             credentialsId: 'ca159ad3-7323-4564-818c-46a8f03e1389',
+             variable: 'DCOS_LICENSE'],
             [$class: 'UsernamePasswordMultiBinding',
              credentialsId: '323df884-742b-4099-b8b7-d764e5eb9674',
              usernameVariable: 'DCOS_ADMIN_USERNAME',

--- a/ci/Jenkinsfile-windows-integration
+++ b/ci/Jenkinsfile-windows-integration
@@ -21,7 +21,7 @@ def platforms = ["windows"]
 /**
  * This generates the `dcos_launch` config for a particular build.
  */
-def generateConfig(deploymentName, installerUrl, sshKeyPath) {
+def generateConfig(deploymentName, installerUrl, license, sshKeyPath) {
     return """
 ---
 launch_config_version: 1
@@ -44,6 +44,7 @@ dcos_config:
     dns_search: us-west-2.compute.internal
     master_discovery: static
     exhibitor_storage_backend: static
+    license_key_contents: ${license}
 """
 }
 
@@ -80,6 +81,7 @@ class TestCluster implements Serializable {
                         "text" : script.generateConfig(
                                 "dcos-cli-${platform}-${script.env.ghprbPullId}-${script.env.BUILD_ID}-${createAttempts}",
                                 "${script.env.DCOS_INSTALLER_URL}",
+                                "${script.env.DCOS_LICENSE}",
                                 "${script.env.CLI_TEST_SSH_KEY_PATH}")])
 
                 script.sh "./dcos-launch create -c ${platform}_config.yaml -i ${platform}_cluster_info.json"
@@ -276,6 +278,9 @@ throttle(['dcos-cli']) {
             [$class: 'StringBinding',
              credentialsId: '0b513aad-e0e0-4a82-95f4-309a80a02ff9',
              variable: 'DCOS_INSTALLER_URL'],
+            [$class: 'StringBinding',
+             credentialsId: 'ca159ad3-7323-4564-818c-46a8f03e1389',
+             variable: 'DCOS_LICENSE'],
             [$class: 'UsernamePasswordMultiBinding',
              credentialsId: '323df884-742b-4099-b8b7-d764e5eb9674',
              usernameVariable: 'DCOS_ADMIN_USERNAME',

--- a/cli/tox.ini
+++ b/cli/tox.ini
@@ -45,7 +45,7 @@ commands =
 
 [testenv:py35-integration]
 commands =
-  py.test --durations=0 -p no:cacheprovider -vv -x {env:CI_FLAGS:} tests/integrations{posargs}
+  py.test --durations=10 -p no:cacheprovider -vv -x {env:CI_FLAGS:} tests/integrations{posargs}
 
 [testenv:py35-unit]
 commands =


### PR DESCRIPTION
DC/OS 1.11 now requires a valid license in order to get installed. This adapts the CLI Jenkinsfiles accordingly.