### PR TITLE
Consider that dcos version metadata might be invalid

### DIFF
--- a/dcos/cluster.py
+++ b/dcos/cluster.py
@@ -391,10 +391,10 @@ class Cluster():
                 url=endpoint,
                 timeout=5,
                 verify=False)
+
+            return resp.json().get("version", VERSION_UNKNOWN)
         except Exception as e:
             return VERSION_UNKNOWN
-
-        return resp.json().get("version", VERSION_UNKNOWN)
 
     def is_attached(self):
         cluster_envvar = os.environ.get(constants.DCOS_CLUSTER)


### PR DESCRIPTION
I had an issue I cannot reproduce where the JSON returned by this endpoint was invalid, probably because of a wrongly installed / unhealthy cluster.

In such case it becomes impossible to run `dcos cluster list` for example as an exception is thrown, this change makes the code more resilient to this kind of problem.