### PR TITLE
Cluster link error messages improvements

### DIFF
--- a/cli/dcoscli/cluster/main.py
+++ b/cli/dcoscli/cluster/main.py
@@ -327,7 +327,12 @@ def _unlink(name):
     endpoint = urllib.parse.urljoin(
             dcos_url, '/cluster/v1/links/' + name)
 
-    http.delete(endpoint)
+    try:
+        http.delete(endpoint)
+    except DCOSHTTPException as e:
+        if e.status() == 404:
+            raise DCOSException('Unknown cluster link {}.'.format(name))
+        raise
 
     return 0
 

--- a/cli/dcoscli/cluster/main.py
+++ b/cli/dcoscli/cluster/main.py
@@ -315,12 +315,12 @@ def _unlink(name):
     """
 
     c = cluster.get_cluster(name)
-    if not c:
-        raise DCOSException('Unknown cluster {}.'.format(name))
+    if c:
+        name = c.get_cluster_id()
 
     dcos_url = config.get_config_val('core.dcos_url')
     endpoint = urllib.parse.urljoin(
-            dcos_url, '/cluster/v1/links/' + c.get_cluster_id())
+            dcos_url, '/cluster/v1/links/' + name)
 
     http.delete(endpoint)
 

--- a/cli/dcoscli/cluster/main.py
+++ b/cli/dcoscli/cluster/main.py
@@ -308,7 +308,7 @@ def _unlink(name):
     """
     Unlink a DC/OS cluster.
 
-    :param name:  name of the cluster
+    :param name: ID or name of the cluster
     :type name: str
     :returns: process status
     :rtype: int

--- a/cli/tests/integrations/test_cluster.py
+++ b/cli/tests/integrations/test_cluster.py
@@ -188,6 +188,15 @@ def test_link_self(dcos_dir_tmp_copy):
 
     assert_command(['dcos', 'cluster', 'unlink', link['cluster_id']])
 
+    # Unlinking an unexisting cluster should return an error.
+    ret, stdout, stderr = exec_command(
+        ['dcos', 'cluster', 'unlink', link['cluster_id']])
+
+    assert ret != 0
+    assert stdout == b''
+    expected_err_msg = "Unknown cluster link {}.\n".format(link['cluster_id'])
+    assert stderr.decode() == expected_err_msg
+
 
 def test_link_invalid_cluster(dcos_dir_tmp_copy):
     name = 'https://will.never.exist.hopefully.BOFGY7tfb7doftd'
@@ -201,7 +210,7 @@ def test_unlink_invalid_cluster(dcos_dir_tmp_copy):
     name = 'not-me'
     ret, _, err = exec_command(['dcos', 'cluster', 'unlink', name])
     assert ret != 0
-    assert err.decode('utf-8') == "Unknown cluster {}.\n".format(name)
+    assert err.decode('utf-8') == "Unknown cluster link {}.\n".format(name)
 
 
 def _num_of_clusters():

--- a/cli/tests/integrations/test_cluster.py
+++ b/cli/tests/integrations/test_cluster.py
@@ -156,6 +156,18 @@ def test_link_self(dcos_dir_tmp_copy):
 
     assert returncode == 0
 
+    # Recreating the exact same link should return an error.
+    returncode, stdout, stderr = exec_command(
+        ['dcos',
+         'cluster',
+         'link',
+         '--provider=' + provider,
+         os.environ.get(DCOS_TEST_URL_ENV)])
+
+    assert returncode != 0
+    assert stdout == b''
+    assert stderr == b"This cluster link already exists.\n"
+
     # Get linked clusters through the list command
     returncode, stdout, stderr = exec_command(
         ['dcos', 'cluster', 'list', '--json', '--linked'])


### PR DESCRIPTION
- Update a parameter pydoc description
- Don't require the cluster to be configured when unlinking
- Show an explicit error message when recreating an existing link
- Display a custom error message when unlinking an invalid cluster