### PR TITLE
 dcos-log v2: add a custom handler for 500 error

### DIFF
--- a/cli/tests/unit/test_task.py
+++ b/cli/tests/unit/test_task.py
@@ -321,3 +321,16 @@ def test_task_fault_domain():
 
     slave = mesos.Slave({}, None, None)
     assert not slave.fault_domain()
+
+
+@patch('dcos.http.get')
+def test_dcos_log_v2_500(mocked_http_get):
+    mock_http_response = MagicMock()
+    mock_http_response.status_code = 500
+    mock_http_response.text = "foo bar error"
+    mocked_http_get.return_value = mock_http_response
+
+    task = {'id': 'test-task'}
+    with pytest.raises(DCOSException) as excinfo:
+        _dcos_log_v2(False, [task], 10, 'stdout')
+    assert 'foo bar error' in str(excinfo.value)

--- a/dcos/errors.py
+++ b/dcos/errors.py
@@ -17,6 +17,9 @@ class DCOSHTTPException(DCOSException):
     def status(self):
         return self.response.status_code
 
+    def text(self):
+        return self.response.text
+
     def __str__(self):
         return 'Error while fetching [{0}]: HTTP {1}: "{2}".'.format(
             self.response.request.url,


### PR DESCRIPTION
- add 500 response code to is_success function to handle the 500 error
   in caller instead of `http` module.
- if the user encounters 500 when trying to fetch the logs, use
  `DCOSUnprocessableException` to include the text with the actual error
   message.