### PR TITLE
Use `hello-world` instead of `cassandra` in a test

### DIFF
--- a/cli/dcoscli/test/marathon.py
+++ b/cli/dcoscli/test/marathon.py
@@ -378,6 +378,19 @@ def watch_all_deployments(count=300):
         watch_deployment(dep['id'], count)
 
 
+def count_apps():
+    """Count the number of marathon apps.
+
+    :returns: number of marathon apps
+    :rtype: int
+    """
+
+    returncode, stdout, _ = exec_command(
+            ['dcos', 'marathon', 'app', 'list', '--json'])
+    assert returncode == 0
+    return len(json.loads(stdout.decode()))
+
+
 def watch_for_overdue(max_count=300):
     """Wait for overdue to be set to true.  Useful to test apps stuck in
     deployment.

--- a/cli/dcoscli/test/package.py
+++ b/cli/dcoscli/test/package.py
@@ -112,7 +112,7 @@ def package_install(package, deploy=False, args=[]):
     :rtype: None
     """
 
-    returncode, stdout, stderr = exec_command(
+    returncode, _, stderr = exec_command(
         ['dcos', 'package', 'install', '--yes', package] + args)
 
     assert returncode == 0

--- a/cli/tests/integrations/test_service.py
+++ b/cli/tests/integrations/test_service.py
@@ -99,27 +99,20 @@ def test_service_inactive_and_completed():
 
 
 def test_log():
-    with package(
-        'cassandra',
-        deploy=True,
-        args=['--package-version=1.0.25-3.0.10']
-    ):
+    with package('hello-world', deploy=True):
         returncode, stdout, stderr = exec_command(
-            ['dcos', 'service', 'log', 'cassandra'])
+            ['dcos', 'service', 'log', 'hello-world'])
 
         assert returncode == 0
         assert len(stdout.decode('utf-8').split('\n')) > 1
         assert stderr == b''
 
         returncode, stdout, stderr = exec_command(
-            ['dcos', 'service', 'log', 'cassandra', 'stderr'])
+            ['dcos', 'service', 'log', 'hello-world', 'stderr'])
 
         assert returncode == 0
         assert len(stdout.decode('utf-8').split('\n')) > 1
         assert stderr == b''
-
-    # Package was uninstalled but its group needs to be removed separately
-    exec_command(['dcos', 'marathon', 'group', 'remove', 'cassandra'])
 
 
 def test_log_marathon_file():


### PR DESCRIPTION
Using `cassandra` here started to fail as the test cluster doesn't seem to have enough resources to run it anymore.

In any case, using it for such tests is overkill. There were already an effort to move away from installing latest versions of heavy frameworks in our tests (https://github.com/dcos/dcos-cli/pull/1094).

This would also help us to move towards https://github.com/dcos/dcos-cli/pull/1097.

https://jira.mesosphere.com/browse/DCOS_OSS-2131