### PR TITLE
Properly query for DC/OS version on Windows 

### DIFF
--- a/cli/tests/integrations/test_cluster.py
+++ b/cli/tests/integrations/test_cluster.py
@@ -46,6 +46,7 @@ def test_list():
     assert info.get("attached")
     keys = ["attached", "cluster_id", "name", "status", "url", "version"]
     assert sorted(info.keys()) == keys
+    assert info.get('version') != cluster.VERSION_UNKNOWN
 
 
 def test_remove_all(dcos_dir_tmp_copy):

--- a/dcos/cluster.py
+++ b/dcos/cluster.py
@@ -380,8 +380,7 @@ class Cluster():
         if not dcos_url:
             return VERSION_UNKNOWN
 
-        endpoint = os.path.join(
-            self.get_url(), "dcos-metadata/dcos-version.json")
+        endpoint = dcos_url.rstrip('/') + '/dcos-metadata/dcos-version.json'
 
         try:
             # This is an informational request,


### PR DESCRIPTION
Currently it is using `os.path`, which would use a backslash on Windows, this makes the HTTP request to fail.

Discovered while looking at https://jira.mesosphere.com/browse/COPS-2400