### PR TITLE
Re-enable Marathon test

### DIFF
--- a/cli/tests/integrations/test_marathon.py
+++ b/cli/tests/integrations/test_marathon.py
@@ -158,7 +158,6 @@ def test_show_missing_absolute_app_version():
             "Error: App '/zero-instance-app' does not exist")
 
 
-@pytest.mark.skipif(True, reason=('MARATHON-7954'))
 def test_show_bad_app_version():
     with _zero_instance_app():
         _update_app(
@@ -171,9 +170,10 @@ def test_show_bad_app_version():
         assert returncode == 1
         assert stdout == b''
         assert stderr.startswith(b'Error while fetching')
-        pattern = (b"""{"message":"Invalid format: """
-                   b"""\\"20:39:32.972Z\\" is malformed"""
-                   b""" at \\":39:32.972Z\\""}".\n""")
+        pattern = (b"""{"message":"Invalid timestamp provided """
+                   b"""\'20:39:32.972Z\'. Expecting ISO-8601 """
+                   b"""datetime string."}".\n""")
+
         assert stderr.endswith(pattern)
 
 


### PR DESCRIPTION
It had been disabled in #1122, now that the Marathon version in DC/OS contains the patch, the test can be re-enabled.