### PR TITLE
Disable self-linking

### DIFF
--- a/cli/dcoscli/cluster/main.py
+++ b/cli/dcoscli/cluster/main.py
@@ -253,7 +253,7 @@ def _link(dcos_url, provider_id):
         raise DCOSException("Unable to retrieve IP for '{dcos_url}': {error}"
                             .format(dcos_url=dcos_url, error=error))
 
-    # Check if the linked cluster is already configured (based on its IP)
+    # Make sure the linked cluster is already configured (based on its IP)
     for configured_cluster in cluster.get_clusters():
         configured_cluster_host = \
             urlparse(configured_cluster.get_url()).netloc

--- a/cli/dcoscli/cluster/main.py
+++ b/cli/dcoscli/cluster/main.py
@@ -274,6 +274,9 @@ def _link(dcos_url, provider_id):
                "    $ dcos cluster setup {}".format(dcos_url))
         raise DCOSException(msg)
 
+    if linked_cluster_id == current_cluster.get_cluster_id():
+        raise DCOSException('Cannot link a cluster to itself.')
+
     providers = auth.get_providers(dcos_url)
 
     if provider_id:

--- a/cli/tests/integrations/test_cluster.py
+++ b/cli/tests/integrations/test_cluster.py
@@ -139,64 +139,16 @@ def test_setup_unreachable_url():
 def test_link_self(dcos_dir_tmp_copy):
     skip_if_env_missing([DCOS_TEST_URL_ENV])
 
-    attached_cluster = cluster.get_attached_cluster()
-
-    # There should be no linked clusters yet
-    linked_clusters = cluster.get_cluster_links(attached_cluster.get_url())
-    assert not linked_clusters.get('links')
-
-    # Link a cluster with a given provider
-    provider = 'dcos-users'
-
-    returncode, _, stderr = exec_command(
-        ['dcos',
-         'cluster',
-         'link',
-         '--provider=' + provider,
-         os.environ.get(DCOS_TEST_URL_ENV)])
-
-    assert returncode == 0
-
-    # Recreating the exact same link should return an error.
     returncode, stdout, stderr = exec_command(
         ['dcos',
          'cluster',
          'link',
-         '--provider=' + provider,
+         '--provider=dcos-users',
          os.environ.get(DCOS_TEST_URL_ENV)])
 
     assert returncode != 0
     assert stdout == b''
-    assert stderr == b"This cluster link already exists.\n"
-
-    # Get linked clusters through the list command
-    returncode, stdout, stderr = exec_command(
-        ['dcos', 'cluster', 'list', '--json', '--linked'])
-    assert returncode == 0
-    assert stderr == b''
-    linked_clusters = json.loads(stdout.decode('utf-8'))
-    assert len(linked_clusters) == 1
-
-    link = linked_clusters[0]
-    assert link['cluster_id'] == attached_cluster.get_cluster_id()
-    assert link['name'] == attached_cluster.get_name()
-    assert link['url'] == attached_cluster.get_url()
-
-    # Get linked clusters from the API (to check the login_provider)
-    links = cluster.get_cluster_links(attached_cluster.get_url()).get('links')
-    assert len(links) == 1
-    assert links[0]['login_provider']['id'] == provider
-
-    assert_command(['dcos', 'cluster', 'unlink', link['cluster_id']])
-
-    # Unlinking an unexisting cluster should return an error.
-    ret, stdout, stderr = exec_command(
-        ['dcos', 'cluster', 'unlink', link['cluster_id']])
-
-    assert ret != 0
-    assert stdout == b''
-    expected_err_msg = "Unknown cluster link {}.\n".format(link['cluster_id'])
-    assert stderr.decode() == expected_err_msg
+    assert stderr == b"Cannot link a cluster to itself.\n"
 
 
 def test_link_invalid_cluster(dcos_dir_tmp_copy):


### PR DESCRIPTION
User test reports have shown this to be confusing, as once they configure a second cluster, they forget to attach back to the original one.

https://jira.mesosphere.com/browse/DCOS-21047