### PR TITLE
Fix nightly slack notification

### DIFF
--- a/ci/Jenkinsfile-linux-integration
+++ b/ci/Jenkinsfile-linux-integration
@@ -16,11 +16,6 @@
 @Library('sec_ci_libs@v2-latest') _
 
 /**
- * These are the platforms we are building against.
- */
-def platforms = ["linux"]
-
-/**
  * These branches will trigger a Slack notification in case of failure.
  */
 def master_branches = ["master", "0.4.x", "0.5.x", ] as String[]

--- a/ci/Jenkinsfile-linux-integration
+++ b/ci/Jenkinsfile-linux-integration
@@ -139,7 +139,7 @@ class TestCluster implements Serializable {
  * This function returns a closure that prepares a test environment for a
  * specific platform on a specific node in a specific workspace.
  */
-def testBuilder(String platform, String nodeId, String[] master_branches, String workspace = null) {
+def testBuilder(String platform, String nodeId, String workspace = null) {
     return { Closure _body ->
         def body = _body
 
@@ -154,7 +154,7 @@ def testBuilder(String platform, String nodeId, String[] master_branches, String
             try {
                 def dcosIp = cluster.getDcosIp()
 
-                task_wrapper(nodeId, master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89', '#dcos-cli-ci') {
+                node(nodeId) {
                     if (!workspace) {
                         workspace = "${env.WORKSPACE}"
                     }
@@ -214,7 +214,7 @@ def testBuilder(String platform, String nodeId, String[] master_branches, String
 def builders = [:]
 
 
-builders['linux-tests'] = testBuilder('linux', 'py35', master_branches, '/workspace')({
+builders['linux-tests'] = testBuilder('linux', 'py35', '/workspace')({
     stage ("Run dcos-cli tests") {
         sh "rm -rf ~/.dcos"
 
@@ -245,7 +245,7 @@ builders['linux-tests'] = testBuilder('linux', 'py35', master_branches, '/worksp
  * are done.
  */
 throttle(['dcos-cli']) {
-    node('py35') {
+    task_wrapper('py35', master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89', '#dcos-cli-ci') {
         stage('Cleanup workspace') {
             deleteDir()
         }

--- a/ci/Jenkinsfile-mac-integration
+++ b/ci/Jenkinsfile-mac-integration
@@ -138,7 +138,7 @@ class TestCluster implements Serializable {
  * This function returns a closure that prepares a test environment for a
  * specific platform on a specific node in a specific workspace.
  */
-def testBuilder(String platform, String nodeId, String[] master_branches, String workspace = null) {
+def testBuilder(String platform, String nodeId, String workspace = null) {
     return { Closure _body ->
         def body = _body
 
@@ -153,7 +153,7 @@ def testBuilder(String platform, String nodeId, String[] master_branches, String
             try {
                 def dcosIp = cluster.getDcosIp()
 
-                task_wrapper(nodeId, master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89', '#dcos-cli-ci') {
+                node(nodeId) {
                     if (!workspace) {
                         workspace = "${env.WORKSPACE}"
                     }
@@ -213,7 +213,7 @@ def testBuilder(String platform, String nodeId, String[] master_branches, String
 def builders = [:]
 
 
-builders['mac-tests'] = testBuilder('mac', 'mac', master_branches)({
+builders['mac-tests'] = testBuilder('mac', 'mac')({
     try {
         stage ("Run dcos-cli tests") {
             sh "rm -rf ~/.dcos"
@@ -250,7 +250,7 @@ builders['mac-tests'] = testBuilder('mac', 'mac', master_branches)({
  * are done.
  */
 throttle(['dcos-cli']) {
-    node('py35') {
+    task_wrapper('py35', master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89', '#dcos-cli-ci') {
         stage('Cleanup workspace') {
             deleteDir()
         }

--- a/ci/Jenkinsfile-mac-integration
+++ b/ci/Jenkinsfile-mac-integration
@@ -16,11 +16,6 @@
 @Library('sec_ci_libs@v2-latest') _
 
 /**
- * These are the platforms we are building against.
- */
-def platforms = ["mac"]
-
-/**
  * These branches will trigger a Slack notification in case of failure.
  */
 def master_branches = ["master", "0.4.x", "0.5.x", ] as String[]

--- a/ci/Jenkinsfile-windows-integration
+++ b/ci/Jenkinsfile-windows-integration
@@ -20,7 +20,6 @@
  */
 def master_branches = ["master", "0.4.x", "0.5.x", ] as String[]
 
-
 /**
  * This generates the `dcos_launch` config for a particular build.
  */
@@ -139,7 +138,7 @@ class TestCluster implements Serializable {
  * This function returns a closure that prepares a test environment for a
  * specific platform on a specific node in a specific workspace.
  */
-def testBuilder(String platform, String nodeId, String[] master_branches, String workspace = null) {
+def testBuilder(String platform, String nodeId, String workspace = null) {
     return { Closure _body ->
         def body = _body
 
@@ -154,7 +153,7 @@ def testBuilder(String platform, String nodeId, String[] master_branches, String
             try {
                 def dcosIp = cluster.getDcosIp()
 
-                task_wrapper(nodeId, master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89', '#dcos-cli-ci') {
+                node(nodeId) {
                     if (!workspace) {
                         workspace = "${env.WORKSPACE}"
                     }
@@ -214,7 +213,7 @@ def testBuilder(String platform, String nodeId, String[] master_branches, String
 def builders = [:]
 
 
-builders['windows-tests'] = testBuilder('windows', 'windows', master_branches, 'C:\\windows\\workspace')({
+builders['windows-tests'] = testBuilder('windows', 'windows', 'C:\\windows\\workspace')({
     stage ("Run dcos-cli tests") {
         bat 'bash -c "rm -rf ${HOME}/.dcos"'
 
@@ -246,7 +245,7 @@ builders['windows-tests'] = testBuilder('windows', 'windows', master_branches, '
  * are done.
  */
 throttle(['dcos-cli']) {
-    node('py35') {
+    task_wrapper('py35', master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89', '#dcos-cli-ci') {
         stage('Cleanup workspace') {
             deleteDir()
         }

--- a/ci/Jenkinsfile-windows-integration
+++ b/ci/Jenkinsfile-windows-integration
@@ -16,11 +16,6 @@
 @Library('sec_ci_libs@v2-latest') _
 
 /**
- * These are the platforms we are building against.
- */
-def platforms = ["windows"]
-
-/**
  * These branches will trigger a Slack notification in case of failure.
  */
 def master_branches = ["master", "0.4.x", "0.5.x", ] as String[]


### PR DESCRIPTION
I've added a `BRANCH_NAME=master` environment variable in the nightly build config, so we should now receive slack notifications on failures.

This patch is just about using `task_wrapper()` on the main node instead of the inner one. This would send notifications for failures during `dcos_launch` too.