### PR TITLE
Ignore DCOS_CLUSTER_NAME env var

### DIFF
--- a/dcos/config.py
+++ b/dcos/config.py
@@ -170,12 +170,16 @@ def get_config_val_envvar(name, config=None):
 
     section, subkey = split_key(name.upper())
 
-    env_var = None
+    env_var = ''
     if section == "CORE":
         if subkey.startswith("DCOS") and os.environ.get(subkey):
             env_var = subkey
         else:
             env_var = "DCOS_{}".format(subkey)
+    elif section == "CLUSTER" and subkey == "NAME":
+        # Ignore DCOS_CLUSTER_NAME, this environment variable is confusing.
+        # cf. https://jira.mesosphere.com/browse/DCOS-21098
+        pass
     else:
         env_var = "DCOS_{}_{}".format(section, subkey)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -189,6 +189,19 @@ def test_get_config(load_path_mock):
         load_path_mock.assert_called_with(cluster_toml, True)
 
 
+def test_get_cluster_name_ignore_env():
+    with env():
+        os.environ['DCOS_CLUSTER_NAME'] = 'fake-name'
+
+        cluster_conf = config.Toml({
+            'cluster': {'name': 'real-name'},
+        })
+
+        cluster_name = config.get_config_val('cluster.name', cluster_conf)
+
+        assert cluster_name == 'real-name'
+
+
 def _create_clusters_dir(dcos_dir):
     clusters_dir = os.path.join(dcos_dir, constants.DCOS_CLUSTERS_SUBDIR)
     util.ensure_dir_exists(clusters_dir)


### PR DESCRIPTION
This env variable causes inconsistent behaviours, eg. `dcos cluster list` would display all clusters with the same name when DCOS_CLUSTER_NAME is set.

One should instead run `dcos cluster rename <cluster> <new_name>` in order to change a cluster name.

https://jira.mesosphere.com/browse/DCOS-21098