### PR TITLE
Simplify setup_cluster_config()

### DIFF
--- a/cli/dcoscli/cluster/main.py
+++ b/cli/dcoscli/cluster/main.py
@@ -420,8 +420,8 @@ def setup(dcos_url,
             raise DCOSException(msg)
 
         # configure cluster directory
-        cluster_path = cluster.setup_cluster_config(dcos_url, real_config_dir,
-                                                    stored_cert)
+        cluster_path = cluster.setup_cluster_config(
+            dcos_url, real_config_dir, temp_cluster_path, stored_cert)
 
         attached_file = os.path.join(
             cluster_path, constants.DCOS_CLUSTER_ATTACHED_FILE)


### PR DESCRIPTION
This simplifies the setup_cluster_config() function and updates tests to make sure that the core.ssl_verify config with a CA downloaded from the cluster points to the correct cluster path.

https://jira.mesosphere.com/browse/DCOS_OSS-2201