### PR TITLE
Prepare 0.6.x

### DIFF
--- a/ci/Jenkinsfile-linux-integration
+++ b/ci/Jenkinsfile-linux-integration
@@ -278,7 +278,7 @@ throttle(['dcos-cli']) {
              credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
              variable: 'CLI_TEST_SSH_KEY_PATH'],
             [$class: 'StringBinding',
-             credentialsId: '0b513aad-e0e0-4a82-95f4-309a80a02ff9',
+             credentialsId: '2e66a3b5-d710-43d0-9f75-d9a8a534f53f',
              variable: 'DCOS_INSTALLER_URL'],
             [$class: 'StringBinding',
              credentialsId: 'ca159ad3-7323-4564-818c-46a8f03e1389',

--- a/ci/Jenkinsfile-mac-integration
+++ b/ci/Jenkinsfile-mac-integration
@@ -283,7 +283,7 @@ throttle(['dcos-cli']) {
              credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
              variable: 'CLI_TEST_SSH_KEY_PATH'],
             [$class: 'StringBinding',
-             credentialsId: '0b513aad-e0e0-4a82-95f4-309a80a02ff9',
+             credentialsId: '2e66a3b5-d710-43d0-9f75-d9a8a534f53f',
              variable: 'DCOS_INSTALLER_URL'],
             [$class: 'StringBinding',
              credentialsId: 'ca159ad3-7323-4564-818c-46a8f03e1389',

--- a/ci/Jenkinsfile-windows-integration
+++ b/ci/Jenkinsfile-windows-integration
@@ -278,7 +278,7 @@ throttle(['dcos-cli']) {
              credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
              variable: 'CLI_TEST_SSH_KEY_PATH'],
             [$class: 'StringBinding',
-             credentialsId: '0b513aad-e0e0-4a82-95f4-309a80a02ff9',
+             credentialsId: '2e66a3b5-d710-43d0-9f75-d9a8a534f53f',
              variable: 'DCOS_INSTALLER_URL'],
             [$class: 'StringBinding',
              credentialsId: 'ca159ad3-7323-4564-818c-46a8f03e1389',

--- a/dcos/config.py
+++ b/dcos/config.py
@@ -170,12 +170,16 @@ def get_config_val_envvar(name, config=None):
 
     section, subkey = split_key(name.upper())
 
-    env_var = None
+    env_var = ''
     if section == "CORE":
         if subkey.startswith("DCOS") and os.environ.get(subkey):
             env_var = subkey
         else:
             env_var = "DCOS_{}".format(subkey)
+    elif section == "CLUSTER" and subkey == "NAME":
+        # Ignore DCOS_CLUSTER_NAME, this environment variable is confusing.
+        # cf. https://jira.mesosphere.com/browse/DCOS-21098
+        pass
     else:
         env_var = "DCOS_{}_{}".format(section, subkey)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -189,6 +189,19 @@ def test_get_config(load_path_mock):
         load_path_mock.assert_called_with(cluster_toml, True)
 
 
+def test_get_cluster_name_ignore_env():
+    with env():
+        os.environ['DCOS_CLUSTER_NAME'] = 'fake-name'
+
+        cluster_conf = config.Toml({
+            'cluster': {'name': 'real-name'},
+        })
+
+        cluster_name = config.get_config_val('cluster.name', cluster_conf)
+
+        assert cluster_name == 'real-name'
+
+
 def _create_clusters_dir(dcos_dir):
     clusters_dir = os.path.join(dcos_dir, constants.DCOS_CLUSTERS_SUBDIR)
     util.ensure_dir_exists(clusters_dir)


### PR DESCRIPTION
 - Revert "Moved cluster attachment to not lose track of attached cluster."
- Ignore DCOS_CLUSTER_NAME env var
- Update DC/OS installer credentials to use 1.11