### PR TITLE
[WIP] Increase timeout for integration tests

### DIFF
--- a/ci/Jenkinsfile-linux-integration
+++ b/ci/Jenkinsfile-linux-integration
@@ -232,7 +232,7 @@ builders['linux-tests'] = testBuilder('linux', 'py35', '/workspace')({
                    --insecure --username=${DCOS_ADMIN_USERNAME} \
                    --password-env=DCOS_ADMIN_PASSWORD; \
                dist/dcos config set core.reporting false; \
-               dist/dcos config set core.timeout 5; \
+               dist/dcos config set core.timeout 30; \
                make test-binary'''
         }
     }

--- a/ci/Jenkinsfile-mac-integration
+++ b/ci/Jenkinsfile-mac-integration
@@ -232,7 +232,7 @@ builders['mac-tests'] = testBuilder('mac', 'mac')({
                      --insecure --username=${DCOS_ADMIN_USERNAME} \
                      --password-env=DCOS_ADMIN_PASSWORD; \
                    dist/dcos config set core.reporting false; \
-                   dist/dcos config set core.timeout 5; \
+                   dist/dcos config set core.timeout 30; \
                    make test-binary'''
             }
         }

--- a/ci/Jenkinsfile-windows-integration
+++ b/ci/Jenkinsfile-windows-integration
@@ -232,7 +232,7 @@ builders['windows-tests'] = testBuilder('windows', 'windows', 'C:\\windows\\work
                     --insecure --username=${DCOS_ADMIN_USERNAME} \
                     --password-env=DCOS_ADMIN_PASSWORD; \
                 dist/dcos config set core.reporting false; \
-                dist/dcos config set core.timeout 5; \
+                dist/dcos config set core.timeout 30; \
                 make test-binary"'''
         }
     }


### PR DESCRIPTION
We experienced some tests failures due to timeout issues. This will become even more visible if we start some Jenkins builders in Europe, as they'd be making requests to AWS servers in the US thus have a higher network latency.

For reference, the default value is 180 seconds.