### PR TITLE
Config tweaks

### DIFF
--- a/pkg/cmd/dcos_config_show.go
+++ b/pkg/cmd/dcos_config_show.go
@@ -35,6 +35,7 @@ func configShowAll(store *config.Store) {
 			for _, maskedKey := range maskedKeys {
 				if maskedKey == key {
 					val = "********"
+					break
 				}
 			}
 			fmt.Printf("%s %v\n", key, val)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,7 +10,7 @@ type Config struct {
 	url            string
 	acsToken       string
 	tls            TLS
-	timeout        int
+	timeout        time.Duration
 	sshUser        string
 	sshProxyHost   string
 	pagination     bool
@@ -58,13 +58,13 @@ func (conf *Config) SetTLS(tls TLS) {
 	conf.setDirty(&conf.tls)
 }
 
-// Timeout returns the HTTP request timeout in seconds once the connection is established.
+// Timeout returns the HTTP request timeout once the connection is established.
 func (conf *Config) Timeout() time.Duration {
-	return time.Duration(conf.timeout) * time.Second
+	return conf.timeout
 }
 
-// SetTimeout sets the HTTP request timeout in seconds once the connection is established.
-func (conf *Config) SetTimeout(timeout int) {
+// SetTimeout sets the HTTP request timeout once the connection is established.
+func (conf *Config) SetTimeout(timeout time.Duration) {
 	conf.timeout = timeout
 	conf.setDirty(&conf.timeout)
 }
@@ -192,9 +192,9 @@ func New() Config {
 }
 
 // Default returns the default configuration for the DC/OS CLI.
-// All config defaults are their zero value except for the timeout which is 180 seconds.
+// All config defaults are their zero value except for the timeout which is 3 minutes.
 func Default() Config {
 	conf := New()
-	conf.timeout = 180
+	conf.timeout = 3 * time.Minute
 	return conf
 }

--- a/pkg/config/marshal.go
+++ b/pkg/config/marshal.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"time"
 
 	toml "github.com/pelletier/go-toml"
 	"github.com/spf13/afero"
@@ -53,7 +54,7 @@ func Unmarshal(store *Store, conf *Config) {
 		case keyTLS:
 			conf.tls = unmarshalTLS(val)
 		case keyTimeout:
-			conf.timeout = cast.ToInt(val)
+			conf.timeout = time.Duration(cast.ToInt64(val)) * time.Second
 		case keySSHUser:
 			conf.sshUser = cast.ToString(val)
 		case keySSHProxyHost:
@@ -132,7 +133,7 @@ func Marshal(conf *Config, store *Store) {
 		store.Set(keyTLS, marshalTLS(conf.tls))
 	}
 	if conf.dirtyFields[&conf.timeout] {
-		store.Set(keyTimeout, conf.timeout)
+		store.Set(keyTimeout, conf.timeout.Seconds())
 	}
 	if conf.dirtyFields[&conf.sshUser] {
 		store.Set(keySSHUser, conf.sshUser)

--- a/pkg/config/marshal.go
+++ b/pkg/config/marshal.go
@@ -155,6 +155,9 @@ func Marshal(conf *Config, store *Store) {
 	if conf.dirtyFields[&conf.clusterName] {
 		store.Set(keyClusterName, conf.clusterName)
 	}
+
+	// Clear config dirty fields.
+	conf.dirtyFields = make(map[interface{}]bool)
 }
 
 // marshalTLS creates a string from a TLS struct.

--- a/pkg/config/marshal_test.go
+++ b/pkg/config/marshal_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"crypto/x509"
 	"testing"
+	"time"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
@@ -13,7 +14,7 @@ func TestMarshal(t *testing.T) {
 	conf.SetURL("https://dcos.example.com")
 	conf.SetACSToken("token_XYZ")
 	conf.SetTLS(TLS{})
-	conf.SetTimeout(15)
+	conf.SetTimeout(15 * time.Second)
 	conf.SetSSHUser("dcos-user")
 	conf.SetSSHProxyHost("dcos-bastion")
 	conf.SetPagination(true)

--- a/pkg/config/marshal_test.go
+++ b/pkg/config/marshal_test.go
@@ -35,6 +35,9 @@ func TestMarshal(t *testing.T) {
 	require.Equal(t, "https://mesos.example.com", store.Get(keyMesosMasterURL))
 	require.Equal(t, true, store.Get(keyPrompLogin))
 	require.Equal(t, "custom-cluster-name", store.Get(keyClusterName))
+
+	// Make sure dirty fields map is cleared after marshalling.
+	require.Equal(t, 0, len(conf.dirtyFields))
 }
 
 func TestMarshalTLS(t *testing.T) {

--- a/pkg/config/store_test.go
+++ b/pkg/config/store_test.go
@@ -100,7 +100,6 @@ func TestStoreKeys(t *testing.T) {
 		},
 	})
 
-	keys := store.Keys()
 	expectedKeys := []string{
 		"cluster.name",
 		"core.dcos_url",
@@ -108,7 +107,7 @@ func TestStoreKeys(t *testing.T) {
 		"core.timeout",
 		"marathon.url",
 	}
-	require.Equal(t, expectedKeys, keys)
+	require.Equal(t, expectedKeys, store.Keys())
 }
 
 func TestPersistWithoutPath(t *testing.T) {

--- a/pkg/config/store_test.go
+++ b/pkg/config/store_test.go
@@ -113,7 +113,7 @@ func TestStoreKeys(t *testing.T) {
 
 func TestPersistWithoutPath(t *testing.T) {
 	store := NewStore(StoreOpts{})
-	require.Error(t, store.Persist())
+	require.Equal(t, ErrNoStorePath, store.Persist())
 }
 
 func TestPersist(t *testing.T) {


### PR DESCRIPTION
- Break once a masked key is found in `config show`
- Clear dirty config fields after Marshalling
- Switch Config.timeout from int to time.Duration 