### PR TITLE
Add a lint target to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ darwin linux windows:
 
 .PHONY: test
 test: vet
-	$(call inDocker,go test -cover ./...)
+	$(call inDocker,go test -race -cover ./...)
 
 .PHONY: vet
 vet:

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,13 @@ test: vet
 	$(call inDocker,go test -race -cover ./...)
 
 .PHONY: vet
-vet:
+vet: lint
 	$(call inDocker,go vet ./...)
+
+.PHONY: lint
+lint:
+	# Can be simplified once https://github.com/golang/lint/issues/320 is fixed.
+	$(call inDocker,go get -u golang.org/x/lint/golint && golint -set_exit_status ./cmd/... ./pkg/...)
 
 .PHONY: vendor
 vendor:

--- a/pkg/cmd/dcos.go
+++ b/pkg/cmd/dcos.go
@@ -25,6 +25,7 @@ func Execute() {
 	}
 }
 
+// Cluster is a temporary struct representing a cluster until we have the proper abstraction for this.
 type Cluster struct {
 	Config config.Config
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -161,6 +161,7 @@ func (conf *Config) SetPath(path string) {
 	conf.store.path = path
 }
 
+// Save unmarshals the Config into its associated Store and persists it to the disk.
 func (conf *Config) Save() error {
 	Marshal(conf, conf.store)
 	return conf.store.Persist()


### PR DESCRIPTION
It is automatically triggered on `make vet` or `make test`.

It also runs tests with the race detector enabled.