### PR TITLE
CI: Run syntax and unit tests on the linux-binary check

### DIFF
--- a/ci/Jenkinsfile-linux-binary
+++ b/ci/Jenkinsfile-linux-binary
@@ -43,10 +43,31 @@ def binaryBuilder = builder('py35', '/workspace')({
         }
     }
 
-    stage ("Build dcos-cli binary") {
-        dir('dcos-cli/python/lib/dcoscli') {
+    dir('dcos-cli/python/lib/dcoscli') {
+        stage ("Build dcos-cli binary") {
             sh "make binary"
             sh "dist/dcos"
+        }
+
+        stage ("Run syntax checks on dcoscli") {
+            sh "make env"
+            sh '''
+                bash -c " \
+                  source env/bin/activate && \
+                  tox -e py35-syntax"
+                '''
+        }
+    }
+
+    stage ("Run syntax checks and unit tests on dcos") {
+        dir('dcos-cli/python/lib/dcos') {
+            sh "make env"
+            sh '''
+                bash -c " \
+                    source env/bin/activate && \
+                    tox -e py35-syntax && \
+                    tox -e py35-unit"
+                '''
         }
     }
 })


### PR DESCRIPTION
It allows to get quicker feedback if something is obviously broken without the need to wait for linux-integration tests to be triggered and the costly AWS cluster to be created.