### PR TITLE
 Use mac-hh-yosemite Jenkins node for MacOS builds

### DIFF
--- a/ci/Jenkinsfile-mac-binary
+++ b/ci/Jenkinsfile-mac-binary
@@ -36,7 +36,7 @@ def builder(String nodeId, String workspace = null) {
 /**
  * Run a builder to create the dcos-cli binary and execute it.
  */
-def binaryBuilder = builder('mac')({
+def binaryBuilder = builder('mac-hh-yosemite')({
     stage ('Pull dcos-cli repository') {
         dir('dcos-cli') {
             checkout scm

--- a/ci/Jenkinsfile-mac-integration
+++ b/ci/Jenkinsfile-mac-integration
@@ -213,7 +213,7 @@ def testBuilder(String platform, String nodeId, String workspace = null) {
 def builders = [:]
 
 
-builders['mac-tests'] = testBuilder('mac', 'mac')({
+builders['mac-tests'] = testBuilder('mac', 'mac-hh-yosemite')({
     try {
         stage ("Run dcos-cli tests") {
             sh "rm -rf ~/.dcos"


### PR DESCRIPTION
According to PyInstaller requirements :

> PyInstaller builds apps that are compatible with the Mac OS X release in which you run it, and following releases.

Building from an old enough Mac makes sure we support all versions onwards. The latest Yosemite version was released 3 years ago, so it already brings a wide range of supported MacOS versions for the CLI.

The Jenkins node has Python 3.5.5 compiled with OpenSSL 1.0.2n.

https://jira.mesosphere.com/browse/DCOS_OSS-2290