### PR TITLE
pin latest sseclient package

### DIFF
--- a/python/lib/dcos/setup.py
+++ b/python/lib/dcos/setup.py
@@ -68,7 +68,7 @@ setup(
         'requests>=2.6, <3.0',
         'six>=1.9, <2.0',
         'toml>=0.9, <1.0',
-        'sseclient==0.0.14',
+        'sseclient==0.0.19',
         'retrying==1.3.3',
     ],
 

--- a/python/lib/dcoscli/setup.py
+++ b/python/lib/dcoscli/setup.py
@@ -70,7 +70,7 @@ setup(
         'toml>=0.9, <1.0',
         'virtualenv>=13.0, <16.0',
         'cryptography==2.0.2',
-        'sseclient==0.0.14',
+        'sseclient==0.0.19',
         'retrying==1.3.3',
     ],
 


### PR DESCRIPTION
latest version has a fix to successfully reconnect to the backend after timeout

[DCOS_OSS-2292](https://jira.mesosphere.com/browse/DCOS_OSS-2292)