### PR TITLE
Fixed pattern matching for task IDs in 'task exec'.

### DIFF
--- a/python/lib/dcos/dcos/mesos.py
+++ b/python/lib/dcos/dcos/mesos.py
@@ -493,33 +493,17 @@ class Master(object):
 
         return tasks
 
-    def get_container_id(self, task_id):
-        """Returns the container ID for a task ID matching `task_id`
+    def get_container_id(self, task_obj):
+        """Returns the container ID for a task.
 
-        :param task_id: The task ID which will be mapped to container ID
-        :type task_id: str
-        :returns: The container ID associated with 'task_id'
+        :param task__obj: The task which will be mapped to container ID
+        :type task_obj: Task()
+        :returns: The container ID associated with 'task_obj'
         :rtype: str
         """
 
-        def _get_task(task_id):
-            candidates = []
-            if 'frameworks' in self.state():
-                for framework in self.state()['frameworks']:
-                    if 'tasks' in framework:
-                        for task in framework['tasks']:
-                            if 'id' in task:
-                                if task['id'].startswith(task_id):
-                                    candidates.append(task)
-
-            if len(candidates) == 1:
-                return candidates[0]
-
-            raise DCOSException(
-                "More than one task matching '{}' found: {}"
-                .format(task_id, candidates))
-
-        def _get_container_status(task):
+        def _get_container_status(task_obj):
+            task = task_obj.dict()
             if 'statuses' in task:
                 if len(task['statuses']) > 0:
                     if 'container_status' in task['statuses'][0]:
@@ -539,11 +523,7 @@ class Master(object):
                 " It might still be spinning up."
                 " Please try again.")
 
-        if not task_id:
-            raise DCOSException("Invalid task ID")
-
-        task = _get_task(task_id)
-        container_status = _get_container_status(task)
+        container_status = _get_container_status(task_obj)
         return _get_container_id(container_status)
 
     def frameworks(self, inactive=False, completed=False):
@@ -1136,7 +1116,7 @@ class TaskIO(object):
                 path="api/v1")
 
         # Grab a reference to the container ID for the task.
-        self.parent_id = master.get_container_id(task_id)
+        self.parent_id = master.get_container_id(task_obj)
 
         # Generate a new UUID for the nested container
         # used to run commands passed to `task exec`.

--- a/python/lib/dcoscli/dcoscli/task/main.py
+++ b/python/lib/dcoscli/dcoscli/task/main.py
@@ -628,7 +628,7 @@ def _metrics(summary, task_id, json_):
             'Error finding agent associated with task: {}'.format(task_id))
 
     slave_id = task['slave_id']
-    container_id = master.get_container_id(task_id)["value"]
+    container_id = master.get_container_id(task)["value"]
 
     endpoint = '/system/v1/agent/{}/metrics/v0/containers/{}'.format(
         slave_id, container_id

--- a/python/lib/dcoscli/tests/integrations/test_task.py
+++ b/python/lib/dcoscli/tests/integrations/test_task.py
@@ -312,6 +312,13 @@ def test_exec_interactive():
             stdout=content, stdin=text)
 
 
+def test_exec_match_id_pattern():
+    assert_command(['dcos', 'task', 'exec', 'app1', 'true'])
+    assert_command(['dcos', 'task', 'exec', 'app2', 'true'])
+    returncode, _, _ = exec_command(['dcos', 'task', 'exec', 'app', 'true'])
+    assert returncode != 0
+
+
 def _mark_non_blocking(file_):
     import fcntl
     fcntl.fcntl(file_.fileno(), fcntl.F_SETFL, os.O_NONBLOCK)


### PR DESCRIPTION
Previously, there were problems with the way patterns were matched for
the task ID when calling `task exec`. Specifically, it didn't follow the
semantics indicated in the help string for (1) matching regular
expressions and (2) matching any substring within the ID, not just the
prefix of the ID.

The reason we did not adhere to these semantics is because we were
trying to match the exact semantics of `docker exec`, which only allows
prefix matching, not arbitrary regex or 'contains()' like semantics for
pattern matching the ID.

With this change, we have decided to break from the docker semantics and
use the default pattern matching semantics provided by the dcos-cli
library command for pattern matching task ids.

Unfortunately, there is a bug in this library, and regular expressions
are not supported! However, arbitrary substring pattern mathing is.

This commit, therefore, updates the semantics of `task exec` to adhere
to 'contains()' like smeantics within the task ID for the 'task_id'
parameter passed to it, but does not yet support proper regular
expression pattern matching.

A subsequent commit will be added to fix regex matching in library call
implementing task ID pattern matching.