### PR TITLE
Update `dcos task exec` help message about regexes

### DIFF
--- a/python/lib/dcoscli/dcoscli/data/help/task.txt
+++ b/python/lib/dcoscli/dcoscli/data/help/task.txt
@@ -61,4 +61,4 @@ Positional Arguments:
     <path>
         The Mesos sandbox directory path. The default is '.'.
     <task>
-        A full task ID, a partial task ID, or a regular expression.
+        A full task ID, a partial task ID, or a Unix shell wildcard pattern (eg. 'my-task*').


### PR DESCRIPTION
This makes it more precise as it accepts Unix file pattern wildcards instead of regexes.