### PR TITLE
Httpclient updates

### DIFF
--- a/pkg/httpclient/client_test.go
+++ b/pkg/httpclient/client_test.go
@@ -60,12 +60,26 @@ func TestPost(t *testing.T) {
 func TestNewRequest(t *testing.T) {
 	client := New("https://dcos.io", func(client *Client) {
 		client.acsToken = "acsToken"
+		client.timeout = 60 * time.Second
 	})
 
 	req, err := client.NewRequest("GET", "/path", nil)
 	require.NoError(t, err)
 	require.Equal(t, req.URL.String(), "https://dcos.io/path")
 	require.Equal(t, "token=acsToken", req.Header.Get("Authorization"))
+	_, ok := req.Context().Deadline()
+	require.True(t, ok)
+}
+
+func TestNewRequestWithoutTimeout(t *testing.T) {
+	client := New("https://dcos.io", func(client *Client) {
+		client.timeout = 60 * time.Second
+	})
+
+	req, err := client.NewRequest("GET", "/path", nil, NoTimeout())
+	require.NoError(t, err)
+	_, ok := req.Context().Deadline()
+	require.False(t, ok)
 }
 
 func TestCancelRequest(t *testing.T) {

--- a/pkg/httpclient/client_test.go
+++ b/pkg/httpclient/client_test.go
@@ -76,7 +76,7 @@ func TestTimeout(t *testing.T) {
 	defer ts.Close()
 
 	client := New(ts.URL, func(client *Client) {
-		client.baseClient.Timeout = 50 * time.Millisecond
+		client.timeout = 50 * time.Millisecond
 	})
 
 	// The handler will sleep for 100ms with a client timeout of 50ms, the call should fail.


### PR DESCRIPTION
- add a default transport
- set a default timeout of 3 minutes
- fix a flaky test
- add a functional option type for Requests 