### PR TITLE
Skip `pip install --upgrade pip` on Windows

### DIFF
--- a/python/bin/env.sh
+++ b/python/bin/env.sh
@@ -40,7 +40,11 @@ if [ ! -d "${BUILDDIR}/${VENV}" ]; then
 
     # Install all requirements into the virtualenv.
     echo "Installing virtualenv requirements..."
-    ${BUILDDIR}/${VENV}/${BIN}/pip${EXE} install --upgrade pip
+
+    # https://jira.mesosphere.com/browse/DCOS_OSS-2332
+    if [ "$(uname)" != "Windows_NT" ]; then
+        ${BUILDDIR}/${VENV}/${BIN}/pip${EXE} install --upgrade pip
+    fi
     ${BUILDDIR}/${VENV}/${BIN}/pip${EXE} install -r ${BASEDIR}/requirements.txt
     ${BUILDDIR}/${VENV}/${BIN}/pip${EXE} install -e ${BASEDIR}
     if [ "$(uname)" = "Windows_NT" ]; then


### PR DESCRIPTION
It is currently failing in our Jenkins builder.

https://jira.mesosphere.com/browse/DCOS_OSS-2332