### PR TITLE
Use `python -m pip install -U pip` on Windows 

### DIFF
--- a/python/bin/env.sh
+++ b/python/bin/env.sh
@@ -40,7 +40,11 @@ if [ ! -d "${BUILDDIR}/${VENV}" ]; then
 
     # Install all requirements into the virtualenv.
     echo "Installing virtualenv requirements..."
-    ${BUILDDIR}/${VENV}/${BIN}/pip${EXE} install --upgrade pip
+    if [ "$(uname)" = "Windows_NT" ]; then
+      ${PYTHON} -m pip install -U pip
+    else
+      ${BUILDDIR}/${VENV}/${BIN}/pip${EXE} install --upgrade pip
+    fi
     ${BUILDDIR}/${VENV}/${BIN}/pip${EXE} install -r ${BASEDIR}/requirements.txt
     ${BUILDDIR}/${VENV}/${BIN}/pip${EXE} install -e ${BASEDIR}
     if [ "$(uname)" = "Windows_NT" ]; then


### PR DESCRIPTION
Don't run `pip install --upgrade pip` on Windows, it started to fail in
our Jenkins node and this is not the right command.

https://jira.mesosphere.com/browse/DCOS_OSS-2332
https://pip.pypa.io/en/stable/installing/#upgrading-pip
pypa/pip#1299