### PR TITLE
Rewrite Cosmos binary resource URLs when needed

### DIFF
--- a/python/lib/dcos/tests/test_subcommand.py
+++ b/python/lib/dcos/tests/test_subcommand.py
@@ -7,3 +7,37 @@ def test_noun():
 
 def test_hyphen_noun():
     assert subcommand.noun("some/path/to/dcos-sub-command") == "sub-command"
+
+
+def test_rewrite_binary_url_with_incorrect_scheme():
+    binary_url = ("http://dcos.example.com/package/resource"
+                  "?url=https://binary.example.com")
+
+    dcos_url = "https://dcos.example.com"
+
+    rewritten_url = subcommand._rewrite_binary_url(binary_url, dcos_url)
+
+    assert rewritten_url == ("https://dcos.example.com/package/resource"
+                             "?url=https://binary.example.com")
+
+
+def test_rewrite_binary_url_with_correct_scheme():
+    binary_url = ("https://dcos.example.com/package/resource"
+                  "?url=https://binary.example.com")
+
+    dcos_url = "https://dcos.example.com"
+
+    rewritten_url = subcommand._rewrite_binary_url(binary_url, dcos_url)
+
+    assert rewritten_url == binary_url
+
+
+def test_rewrite_binary_url_with_external_url():
+    binary_url = ("https://not-dcos.example.com/package/resource"
+                  "?url=https://binary.example.com")
+
+    dcos_url = "https://dcos.example.com"
+
+    rewritten_url = subcommand._rewrite_binary_url(binary_url, dcos_url)
+
+    assert rewritten_url == binary_url


### PR DESCRIPTION
Depending on the user setup, they might contain an incorrect scheme.
This is because Cosmos relies in the scheme used to query admin router.
If a CLI is configured to use HTTPS but a load balancer sits in front
of admin router and does TLS termination, these URLs will use the HTTP
scheme.

Not only that it is a security concern, it would simply fail on setups
which don't support HTTPS. This is hopefully a temporary fix until we
come-up with a long-term fix in DC/OS.

Fixes #1190
https://jira.mesosphere.com/browse/COPS-3052
https://jira.mesosphere.com/browse/DCOS_OSS-2325