### PR TITLE
Add `dcos cluster list` subcommand.

### DIFF
--- a/pkg/cli/cluster.go
+++ b/pkg/cli/cluster.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"crypto/x509"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -99,6 +100,12 @@ func (c *Cluster) Timeout() time.Duration {
 // SetTimeout sets the HTTP request timeout once the connection is established.
 func (c *Cluster) SetTimeout(timeout time.Duration) {
 	c.config.Set("core.timeout", timeout.Seconds())
+}
+
+// ID returns the ID of the cluster.
+func (c *Cluster) ID() string {
+	path := c.Config().Path()
+	return filepath.Base(filepath.Dir(path))
 }
 
 // Name returns the custom name for the cluster.

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -71,6 +71,17 @@ func (ctx *Context) Cluster() (*Cluster, error) {
 	return NewCluster(conf), nil
 }
 
+// Clusters returns the clusters.
+func (ctx *Context) Clusters() []*Cluster {
+	confs := ctx.ConfigManager().All()
+	var clusters []*Cluster
+	for _, conf := range confs {
+		clusters = append(clusters, NewCluster(conf))
+	}
+
+	return clusters
+}
+
 // HTTPClient creates an httpclient.Client for a given cluster.
 func (ctx *Context) HTTPClient(c *Cluster, opts ...httpclient.Option) *httpclient.Client {
 	if c.Timeout() > 0 {

--- a/pkg/cli/table.go
+++ b/pkg/cli/table.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"io"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+// NewTable returns a simple table to output information.
+func NewTable(writer io.Writer, header []string) *tablewriter.Table {
+	table := tablewriter.NewWriter(writer)
+	table.SetHeader(header)
+
+	// Disable line between header and content.
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetRowSeparator(" ")
+	table.SetColumnSeparator("")
+	table.SetCenterSeparator(" ")
+	// Turn off wrapping because it seems to wrap even if the column is set to be wide enough.
+	table.SetAutoWrapText(false)
+
+	return table
+}

--- a/pkg/cmd/dcos_auth_listproviders.go
+++ b/pkg/cmd/dcos_auth_listproviders.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/dcos/dcos-cli/pkg/cli"
 	"github.com/dcos/dcos-cli/pkg/httpclient"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 )
 
@@ -52,14 +51,7 @@ func newCmdAuthListProviders(ctx *cli.Context) *cobra.Command {
 				}
 				fmt.Fprintln(ctx.Out, string(out))
 			} else {
-				table := tablewriter.NewWriter(ctx.Out)
-				table.SetHeader([]string{"PROVIDER ID", "AUTHENTICATION TYPE"})
-				// Turn off wrapping because it seems to wrap even if the column is set to be wide enough.
-				table.SetAutoWrapText(false)
-				table.SetBorder(false)
-				table.SetRowSeparator(" ")
-				table.SetColumnSeparator(" ")
-				table.SetCenterSeparator(" ")
+				table := cli.NewTable(ctx.Out, []string{"PROVIDER ID", "AUTHENTICATION TYPE"})
 
 				for name, provider := range *providers {
 					desc, err := loginTypeDescription(provider.AuthenticationType, provider)

--- a/pkg/cmd/dcos_cluster.go
+++ b/pkg/cmd/dcos_cluster.go
@@ -12,6 +12,7 @@ func newCmdCluster(ctx *cli.Context) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newCmdClusterAttach(ctx),
+		newCmdClusterList(ctx),
 		newCmdClusterRemove(ctx),
 		newCmdClusterRename(ctx),
 	)

--- a/pkg/cmd/dcos_cluster_list.go
+++ b/pkg/cmd/dcos_cluster_list.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/dcos/dcos-cli/pkg/cli"
+	"github.com/dcos/dcos-cli/pkg/httpclient"
+	"github.com/spf13/cobra"
+)
+
+// newCmdClusterList lists the clusters.
+func newCmdClusterList(ctx *cli.Context) *cobra.Command {
+	var onlyAttached bool
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:  "list",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clusters := ctx.Clusters()
+
+			currentCluster, err := ctx.Cluster()
+			var currentClusterID string
+			if err == nil {
+				currentClusterID = currentCluster.ID()
+			}
+
+			// infos is composed of clusters information: attachment, name, id, status, version, and url.
+			infos := []clusterInfo{}
+			var mu sync.Mutex
+
+			var wg sync.WaitGroup
+			for _, cluster := range clusters {
+				// Add should execute before the statement creating the goroutine.
+				wg.Add(1)
+				go func(cluster *cli.Cluster) {
+					defer wg.Done()
+
+					var info clusterInfo
+					info.Name = cluster.Name()
+					info.ID = cluster.ID()
+					if info.ID == currentClusterID {
+						info.Attached = true
+					} else if onlyAttached {
+						return
+					}
+					info.URL = cluster.URL()
+					info.Status = "AVAILABLE"
+					info.Version, err = getVersion(ctx, cluster)
+					if err != nil {
+						info.Status = "UNAVAILABLE"
+					}
+
+					mu.Lock()
+					infos = append(infos, info)
+					mu.Unlock()
+				}(cluster)
+			}
+			wg.Wait()
+
+			if jsonOutput {
+				// Re-marshal it into json with indents added in for pretty printing.
+				out, err := json.MarshalIndent(infos, "", "\t")
+				if err != nil {
+					return err
+				}
+				fmt.Fprintln(ctx.Out, string(out))
+			} else {
+				table := cli.NewTable(ctx.Out, []string{"", "NAME", "ID", "STATUS", "VERSION", "URL"})
+				for i := range infos {
+					var attached string
+					if infos[i].Attached {
+						attached = "*"
+					}
+					table.Append([]string{attached, infos[i].Name, infos[i].ID, infos[i].Status, infos[i].Version, infos[i].URL})
+				}
+				table.Render()
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&onlyAttached, "attached", false, "returns attached cluster only")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "returns clusters in json format")
+	return cmd
+}
+
+// getVersion returns the version of the cluster as a string.
+func getVersion(ctx *cli.Context, cluster *cli.Cluster) (string, error) {
+	client := ctx.HTTPClient(cluster, httpclient.Timeout(5*time.Second))
+	resp, err := client.Get("/dcos-metadata/dcos-version.json")
+	if err != nil {
+		return "UNKNOWN", err
+	}
+	defer resp.Body.Close()
+
+	var version version
+
+	json.NewDecoder(resp.Body).Decode(&version)
+	return version.Version, nil
+}
+
+type version struct {
+	Version         string `json:"version"`
+	DCOSImageCommit string `json:"dcos-image-commit"`
+	BootstrapID     string `json:"bootstrap-id"`
+}
+
+type clusterInfo struct {
+	Attached bool   `json:"attached"`
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Status   string `json:"status"`
+	URL      string `json:"url"`
+	Version  string `json:"version"`
+}


### PR DESCRIPTION
Same features as in the current DC/OS CLI, I have just renamed `CLUSTER ID` by `ID` in the output as the command already states that we list clusters.

Also abstracts the table creation so that we use the same for all our commands.