### PR TITLE
Fix number of expected args for cluster attach/rename

### DIFF
--- a/pkg/cmd/dcos_cluster_attach.go
+++ b/pkg/cmd/dcos_cluster_attach.go
@@ -9,7 +9,7 @@ import (
 func newCmdClusterAttach(ctx *cli.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:  "attach",
-		Args: cobra.MaximumNArgs(1),
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			manager := ctx.ConfigManager()
 			conf, err := manager.Find(args[0], false)

--- a/pkg/cmd/dcos_cluster_rename.go
+++ b/pkg/cmd/dcos_cluster_rename.go
@@ -9,7 +9,7 @@ import (
 func newCmdClusterRename(ctx *cli.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:  "rename",
-		Args: cobra.MaximumNArgs(2),
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			conf, err := ctx.ConfigManager().Find(args[0], false)
 			if err != nil {


### PR DESCRIPTION
There is a single required arg for `cluster attach` and 2 for `cluster rename`.