### PR TITLE
Add an HTTPClient method in the cli.Context

### DIFF
--- a/pkg/cmd/dcos_auth_listproviders.go
+++ b/pkg/cmd/dcos_auth_listproviders.go
@@ -28,18 +28,18 @@ func newCmdAuthListProviders(ctx *cli.Context) *cobra.Command {
 		Use:  "list-providers",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var url string
+			var client *httpclient.Client
 			if len(args) == 0 {
 				cluster, err := ctx.Cluster()
 				if err != nil {
 					return err
 				}
-				url = cluster.URL()
+				client = ctx.HTTPClient(cluster)
 			} else {
-				url = args[0]
+				client = httpclient.New(args[0])
 			}
 
-			providers, err := getProviders(url)
+			providers, err := getProviders(client)
 			if err != nil {
 				return err
 			}
@@ -78,8 +78,7 @@ func newCmdAuthListProviders(ctx *cli.Context) *cobra.Command {
 	return cmd
 }
 
-func getProviders(baseURL string) (*map[string]loginProvider, error) {
-	client := httpclient.New(baseURL)
+func getProviders(client *httpclient.Client) (*map[string]loginProvider, error) {
 	response, err := client.Get("/acs/api/v1/auth/providers")
 	if err != nil {
 		return nil, err

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -2,6 +2,7 @@ package httpclient
 
 import (
 	"context"
+	"crypto/tls"
 	"io"
 	"net"
 	"net/http"
@@ -18,6 +19,20 @@ type Client struct {
 
 // Option is a functional option for an HTTP client.
 type Option func(*Client)
+
+// TLS sets the TLS configuration for the HTTP client transport.
+func TLS(tlsConfig *tls.Config) Option {
+	return func(c *Client) {
+		c.baseClient.Transport.(*http.Transport).TLSClientConfig = tlsConfig
+	}
+}
+
+// Timeout sets the timeout for HTTP requests.
+func Timeout(timeout time.Duration) Option {
+	return func(c *Client) {
+		c.timeout = timeout
+	}
+}
 
 // RequestOption is a functional option for an HTTP request.
 type RequestOption func(*http.Request)


### PR DESCRIPTION
It allows to create an HTTP client from a given Cluster. The client will use the cluster's TLS configuration and timeout.