### PR TITLE
Print a clear error when no cluster is attached

### DIFF
--- a/python/lib/dcos/dcos/config.py
+++ b/python/lib/dcos/dcos/config.py
@@ -109,6 +109,8 @@ def get_config_path():
         return get_global_config_path()
     else:
         cluster_path = get_attached_cluster_path()
+        if not cluster_path:
+            raise DCOSException("No cluster is currently attached.")
         return os.path.join(cluster_path, "dcos.toml")
 
 


### PR DESCRIPTION
This came-up multiple times, when running `dcos config set` commands and
no cluster is currently attached, a stack trace is shown :

  TypeError: join() argument must be str or bytes, not 'NoneType'

This change prevents that stack trace to be shown.

https://jira.mesosphere.com/browse/COPS-2857
https://jira.mesosphere.com/browse/DCOS_OSS-2319