### PR TITLE
Add logs for HTTP requests and responses

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -91,15 +91,17 @@ func (ctx *Context) Clusters() []*Cluster {
 
 // HTTPClient creates an httpclient.Client for a given cluster.
 func (ctx *Context) HTTPClient(c *Cluster, opts ...httpclient.Option) *httpclient.Client {
+	var baseOpts []httpclient.Option
 	if c.Timeout() > 0 {
-		timeoutOpt := httpclient.Timeout(c.Timeout())
-		opts = append([]httpclient.Option{timeoutOpt}, opts...)
+		baseOpts = append(baseOpts, httpclient.Timeout(c.Timeout()))
 	}
 	tlsOpt := httpclient.TLS(&tls.Config{
 		InsecureSkipVerify: c.TLS().Insecure,
 		RootCAs:            c.TLS().RootCAs,
 	})
 
-	opts = append([]httpclient.Option{tlsOpt}, opts...)
+	baseOpts = append(baseOpts, tlsOpt, httpclient.Logger(ctx.Logger))
+	opts = append(baseOpts, opts...)
+
 	return httpclient.New(c.URL(), opts...)
 }

--- a/pkg/cmd/dcos_auth_listproviders.go
+++ b/pkg/cmd/dcos_auth_listproviders.go
@@ -35,7 +35,7 @@ func newCmdAuthListProviders(ctx *cli.Context) *cobra.Command {
 				}
 				client = ctx.HTTPClient(cluster)
 			} else {
-				client = httpclient.New(args[0])
+				client = httpclient.New(args[0], httpclient.Logger(ctx.Logger))
 			}
 
 			providers, err := getProviders(client)


### PR DESCRIPTION
This relies on the httputil package to dump requests and reponses, the INFO logging level displays requests/responses without the body while the DEBUG level displays them.

Eg. :
```
$ dcos -v auth list-providers https://dcos.example.com
INFO[0000] Outgoing request:
GET /acs/api/v1/auth/providers HTTP/1.1
Host: dcos.example.com
User-Agent: Go-http-client/1.1
Accept-Encoding: gzip

INFO[0000] Incoming response:
HTTP/1.1 200 OK
Content-Length: 531
Connection: keep-alive
Content-Type: application/json; charset=utf-8
Date: Fri, 20 Apr 2018 13:28:19 GMT
Server: openresty

   PROVIDER ID                           AUTHENTICATION TYPE
  dcos-users     Log in using a standard DC/OS user account (username and password)
  dcos-services  Log in using a DC/OS service user account (username and private key)
```