### PR TITLE
[WIP] Add logs for HTTP requests and responses

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -91,15 +91,17 @@ func (ctx *Context) Clusters() []*Cluster {
 
 // HTTPClient creates an httpclient.Client for a given cluster.
 func (ctx *Context) HTTPClient(c *Cluster, opts ...httpclient.Option) *httpclient.Client {
+	var baseOpts []httpclient.Option
 	if c.Timeout() > 0 {
-		timeoutOpt := httpclient.Timeout(c.Timeout())
-		opts = append([]httpclient.Option{timeoutOpt}, opts...)
+		baseOpts = append(baseOpts, httpclient.Timeout(c.Timeout()))
 	}
 	tlsOpt := httpclient.TLS(&tls.Config{
 		InsecureSkipVerify: c.TLS().Insecure,
 		RootCAs:            c.TLS().RootCAs,
 	})
 
-	opts = append([]httpclient.Option{tlsOpt}, opts...)
+	baseOpts = append(baseOpts, tlsOpt, httpclient.Logger(ctx.Logger))
+	opts = append(baseOpts, opts...)
+
 	return httpclient.New(c.URL(), opts...)
 }

--- a/pkg/cmd/dcos_auth_listproviders.go
+++ b/pkg/cmd/dcos_auth_listproviders.go
@@ -35,7 +35,7 @@ func newCmdAuthListProviders(ctx *cli.Context) *cobra.Command {
 				}
 				client = ctx.HTTPClient(cluster)
 			} else {
-				client = httpclient.New(args[0])
+				client = httpclient.New(args[0], httpclient.Logger(ctx.Logger))
 			}
 
 			providers, err := getProviders(client)

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -6,7 +6,11 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httputil"
 	"time"
+
+	"github.com/dcos/dcos-cli/pkg/printer"
+	"github.com/sirupsen/logrus"
 )
 
 // A Client is an HTTP client.
@@ -15,6 +19,7 @@ type Client struct {
 	baseURL    string
 	timeout    time.Duration
 	baseClient *http.Client
+	logger     *logrus.Logger
 }
 
 // Option is a functional option for an HTTP client.
@@ -31,6 +36,13 @@ func TLS(tlsConfig *tls.Config) Option {
 func Timeout(timeout time.Duration) Option {
 	return func(c *Client) {
 		c.timeout = timeout
+	}
+}
+
+// Logger sets the logger for the HTTP client.
+func Logger(logger *logrus.Logger) Option {
+	return func(c *Client) {
+		c.logger = logger
 	}
 }
 
@@ -145,5 +157,28 @@ func (c *Client) NewRequest(method, path string, body io.Reader, opts ...Request
 // policy (such as redirects, cookies, auth) as configured on the
 // client.
 func (c *Client) Do(req *http.Request) (*http.Response, error) {
-	return c.baseClient.Do(req)
+	var dumpBody bool
+
+	if c.logger != nil && c.logger.Level >= logrus.DebugLevel {
+		dumpBody = true
+	}
+
+	reqDump, err := httputil.DumpRequestOut(req, dumpBody)
+	if err != nil {
+		printer.Log(c.logger, logrus.WarnLevel, false, "Couldn't dump request: %s", err)
+	} else {
+		printer.Log(c.logger, logrus.InfoLevel, false, "Outgoing request:\n%s", reqDump)
+	}
+
+	resp, err := c.baseClient.Do(req)
+
+	if err == nil {
+		respDump, err := httputil.DumpResponse(resp, dumpBody)
+		if err != nil {
+			printer.Log(c.logger, logrus.WarnLevel, false, "Couldn't dump response: %s", err)
+		} else {
+			printer.Log(c.logger, logrus.InfoLevel, false, "Incoming response:\n%s", respDump)
+		}
+	}
+	return resp, err
 }

--- a/pkg/printer/logger.go
+++ b/pkg/printer/logger.go
@@ -1,0 +1,26 @@
+package printer
+
+import "github.com/sirupsen/logrus"
+
+// Log prints logs if necessary.
+func Log(logger *logrus.Logger, level logrus.Level, strict bool, format string, args ...interface{}) {
+	if logger != nil && logger.Level >= level {
+		if strict && logger.Level != level {
+			return
+		}
+		switch level {
+		case logrus.DebugLevel:
+			logger.Debugf(format, args)
+		case logrus.InfoLevel:
+			logger.Infof(format, args)
+		case logrus.WarnLevel:
+			logger.Warnf(format, args)
+		case logrus.ErrorLevel:
+			logger.Errorf(format, args)
+		case logrus.FatalLevel:
+			logger.Fatalf(format, args)
+		default:
+			logger.Panicf(format, args)
+		}
+	}
+}


### PR DESCRIPTION
This relies on the httputil package to dump requests and reponses, the
INFO logging level displays requests/responses without the body while
the DEBUG level displays them.

Eg. :

$ dcos -v auth list-providers https://dcos.example.com
INFO[0000] Outgoing request:
GET /acs/api/v1/auth/providers HTTP/1.1
Host: dcos.example.com
User-Agent: Go-http-client/1.1
Accept-Encoding: gzip

INFO[0000] Incoming response:
HTTP/1.1 200 OK
Content-Length: 531
Connection: keep-alive
Content-Type: application/json; charset=utf-8
Date: Fri, 20 Apr 2018 13:28:19 GMT
Server: openresty

   PROVIDER ID                           AUTHENTICATION TYPE
  dcos-users     Log in using a standard DC/OS user account (username
and password)
  dcos-services  Log in using a DC/OS service user account (username and
private key)