### PR TITLE
Fix bad rebase

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -116,7 +116,7 @@ func (ctx *Context) HTTPClient(c *Cluster, opts ...httpclient.Option) *httpclien
 		RootCAs:            c.TLS().RootCAs,
 	})
 
-	baseOpts = append(baseOpts, tlsOpt, httpclient.Logger(ctx.Logger))
+	baseOpts = append(baseOpts, tlsOpt, httpclient.Logger(ctx.Logger()))
 	opts = append(baseOpts, opts...)
 
 	return httpclient.New(c.URL(), opts...)

--- a/pkg/cmd/dcos_auth_listproviders.go
+++ b/pkg/cmd/dcos_auth_listproviders.go
@@ -35,7 +35,7 @@ func newCmdAuthListProviders(ctx *cli.Context) *cobra.Command {
 				}
 				client = ctx.HTTPClient(cluster)
 			} else {
-				client = httpclient.New(args[0], httpclient.Logger(ctx.Logger))
+				client = httpclient.New(args[0], httpclient.Logger(ctx.Logger()))
 			}
 
 			providers, err := getProviders(client)

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -162,7 +162,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		if err != nil {
 			c.logger.Warnf("Couldn't dump request: %s", err)
 		} else {
-			c.logger.Infof("Incoming response:\n%s", reqDump)
+			c.logger.Infof("Outgoing request:\n%s", reqDump)
 		}
 	}
 


### PR DESCRIPTION
- Use ctx.Logger() instead of ctx.Logger
- Update an incorrect log message