### PR TITLE
Move subcommands to their own packages

### DIFF
--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -1,12 +1,12 @@
-package cmd
+package auth
 
 import (
 	"github.com/dcos/dcos-cli/pkg/cli"
 	"github.com/spf13/cobra"
 )
 
-// newCmdAuth creates the `dcos auth` subcommand.
-func newCmdAuth(ctx *cli.Context) *cobra.Command {
+// NewCommand creates the `dcos auth` subcommand.
+func NewCommand(ctx *cli.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "auth",
 	}

--- a/pkg/cmd/auth/auth_listproviders.go
+++ b/pkg/cmd/auth/auth_listproviders.go
@@ -1,4 +1,4 @@
-package cmd
+package auth
 
 import (
 	"encoding/json"

--- a/pkg/cmd/cluster/cluster.go
+++ b/pkg/cmd/cluster/cluster.go
@@ -1,12 +1,12 @@
-package cmd
+package cluster
 
 import (
 	"github.com/dcos/dcos-cli/pkg/cli"
 	"github.com/spf13/cobra"
 )
 
-// newCmdCluster creates the `dcos cluster` subcommand.
-func newCmdCluster(ctx *cli.Context) *cobra.Command {
+// NewCommand creates the `dcos cluster` subcommand.
+func NewCommand(ctx *cli.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "cluster",
 	}

--- a/pkg/cmd/cluster/cluster_attach.go
+++ b/pkg/cmd/cluster/cluster_attach.go
@@ -1,4 +1,4 @@
-package cmd
+package cluster
 
 import (
 	"github.com/dcos/dcos-cli/pkg/cli"

--- a/pkg/cmd/cluster/cluster_list.go
+++ b/pkg/cmd/cluster/cluster_list.go
@@ -1,4 +1,4 @@
-package cmd
+package cluster
 
 import (
 	"encoding/json"

--- a/pkg/cmd/cluster/cluster_remove.go
+++ b/pkg/cmd/cluster/cluster_remove.go
@@ -1,4 +1,4 @@
-package cmd
+package cluster
 
 import (
 	"errors"

--- a/pkg/cmd/cluster/cluster_rename.go
+++ b/pkg/cmd/cluster/cluster_rename.go
@@ -1,4 +1,4 @@
-package cmd
+package cluster
 
 import (
 	"github.com/dcos/dcos-cli/pkg/cli"

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -1,12 +1,12 @@
-package cmd
+package config
 
 import (
 	"github.com/dcos/dcos-cli/pkg/cli"
 	"github.com/spf13/cobra"
 )
 
-// newCmdConfig creates the `dcos config` subcommand.
-func newCmdConfig(ctx *cli.Context) *cobra.Command {
+// NewCommand creates the `dcos config` subcommand.
+func NewCommand(ctx *cli.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "config",
 	}

--- a/pkg/cmd/config/config_set.go
+++ b/pkg/cmd/config/config_set.go
@@ -1,4 +1,4 @@
-package cmd
+package config
 
 import (
 	"github.com/dcos/dcos-cli/pkg/cli"

--- a/pkg/cmd/config/config_show.go
+++ b/pkg/cmd/config/config_show.go
@@ -1,4 +1,4 @@
-package cmd
+package config
 
 import (
 	"fmt"

--- a/pkg/cmd/config/config_show_test.go
+++ b/pkg/cmd/config/config_show_test.go
@@ -1,4 +1,4 @@
-package cmd
+package config
 
 import (
 	"bytes"

--- a/pkg/cmd/config/config_unset.go
+++ b/pkg/cmd/config/config_unset.go
@@ -1,4 +1,4 @@
-package cmd
+package config
 
 import (
 	"github.com/dcos/dcos-cli/pkg/cli"

--- a/pkg/cmd/dcos.go
+++ b/pkg/cmd/dcos.go
@@ -3,6 +3,9 @@ package cmd
 
 import (
 	"github.com/dcos/dcos-cli/pkg/cli"
+	"github.com/dcos/dcos-cli/pkg/cmd/auth"
+	"github.com/dcos/dcos-cli/pkg/cmd/cluster"
+	"github.com/dcos/dcos-cli/pkg/cmd/config"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -27,9 +30,9 @@ func NewDCOSCommand(ctx *cli.Context) *cobra.Command {
 	cmd.PersistentFlags().CountVarP(&verbose, "", "v", "verbosity (-v or -vv)")
 
 	cmd.AddCommand(
-		newCmdAuth(ctx),
-		newCmdConfig(ctx),
-		newCmdCluster(ctx),
+		auth.NewCommand(ctx),
+		config.NewCommand(ctx),
+		cluster.NewCommand(ctx),
 	)
 	return cmd
 }


### PR DESCRIPTION
Otherwise the directory will contain many files in the future,
especially once tests are added.

Having a single command per file still allows to quickly jump to a
command code, but they are now in sub-packages.

```
/cmd                               
├── auth                              
│   ├── auth.go                       
│   └── auth_listproviders.go         
├── cluster                           
│   ├── cluster.go                    
│   ├── cluster_attach.go             
│   ├── cluster_list.go               
│   ├── cluster_remove.go             
│   └── cluster_rename.go             
├── config                            
│   ├── config.go                     
│   ├── config_set.go                 
│   ├── config_show.go                
│   ├── config_show_test.go           
│   └── config_unset.go               
└── dcos.go
```