### PR TITLE
Support the auth header challenge to detect login providers

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -108,6 +108,10 @@ func (ctx *Context) Clusters() []*Cluster {
 // HTTPClient creates an httpclient.Client for a given cluster.
 func (ctx *Context) HTTPClient(c *Cluster, opts ...httpclient.Option) *httpclient.Client {
 	var baseOpts []httpclient.Option
+
+	if c.ACSToken() != "" {
+		baseOpts = append(baseOpts, httpclient.ACSToken(c.ACSToken()))
+	}
 	if c.Timeout() > 0 {
 		baseOpts = append(baseOpts, httpclient.Timeout(c.Timeout()))
 	}

--- a/pkg/cmd/auth/auth_listproviders.go
+++ b/pkg/cmd/auth/auth_listproviders.go
@@ -42,7 +42,7 @@ func newCmdAuthListProviders(ctx *cli.Context) *cobra.Command {
 				}
 				fmt.Fprintln(ctx.Out(), string(out))
 			} else {
-				table := cli.NewTable(ctx.Out(), []string{"PROVIDER ID", "AUTHENTICATION TYPE"})
+				table := cli.NewTable(ctx.Out(), []string{"PROVIDER ID", "LOGIN METHOD"})
 				for name, provider := range providers {
 					table.Append([]string{name, provider.String()})
 				}

--- a/pkg/cmd/auth/auth_listproviders.go
+++ b/pkg/cmd/auth/auth_listproviders.go
@@ -6,18 +6,8 @@ import (
 
 	"github.com/dcos/dcos-cli/pkg/cli"
 	"github.com/dcos/dcos-cli/pkg/httpclient"
+	"github.com/dcos/dcos-cli/pkg/login"
 	"github.com/spf13/cobra"
-)
-
-// These are the different auth types that DC/OS supports with the names that they'll be given from the providers
-// endpoint.
-const (
-	LoginTypeDCOSUidPassword     = "dcos-uid-password"
-	LoginTypeDCOSUidServiceKey   = "dcos-uid-servicekey"
-	LoginTypeDCOSUidPasswordLDAP = "dcos-uid-password-ldap"
-	LoginTypeSAMLSpInitiated     = "saml-sp-initiated"
-	LoginTypeOIDCAuthCodeFlow    = "oidc-authorization-code-flow"
-	LoginTypeOIDCImplicitFlow    = "oidc-implicit-flow"
 )
 
 // newCmdAuthListProviders creates the `dcos auth list-providers` subcommand.
@@ -27,18 +17,19 @@ func newCmdAuthListProviders(ctx *cli.Context) *cobra.Command {
 		Use:  "list-providers",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			var client *httpclient.Client
+			var client *login.Client
 			if len(args) == 0 {
 				cluster, err := ctx.Cluster()
 				if err != nil {
 					return err
 				}
-				client = ctx.HTTPClient(cluster)
+				client = login.NewClient(ctx.HTTPClient(cluster), ctx.Logger())
 			} else {
-				client = httpclient.New(args[0], httpclient.Logger(ctx.Logger()))
+				httpClient := httpclient.New(args[0], httpclient.Logger(ctx.Logger()))
+				client = login.NewClient(httpClient, ctx.Logger())
 			}
 
-			providers, err := getProviders(client)
+			providers, err := client.Providers()
 			if err != nil {
 				return err
 			}
@@ -52,13 +43,8 @@ func newCmdAuthListProviders(ctx *cli.Context) *cobra.Command {
 				fmt.Fprintln(ctx.Out(), string(out))
 			} else {
 				table := cli.NewTable(ctx.Out(), []string{"PROVIDER ID", "AUTHENTICATION TYPE"})
-
-				for name, provider := range *providers {
-					desc, err := loginTypeDescription(provider.AuthenticationType, provider)
-					if err != nil {
-						return err
-					}
-					table.Append([]string{name, desc})
+				for name, provider := range providers {
+					table.Append([]string{name, provider.String()})
 				}
 				table.Render()
 			}
@@ -68,46 +54,4 @@ func newCmdAuthListProviders(ctx *cli.Context) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "returns providers in json format")
 	return cmd
-}
-
-func getProviders(client *httpclient.Client) (*map[string]loginProvider, error) {
-	response, err := client.Get("/acs/api/v1/auth/providers")
-	if err != nil {
-		return nil, err
-	}
-	defer response.Body.Close()
-
-	var resp map[string]loginProvider
-	err = json.NewDecoder(response.Body).Decode(&resp)
-	return &resp, err
-}
-
-func loginTypeDescription(loginType string, provider loginProvider) (string, error) {
-	switch loginType {
-	case LoginTypeDCOSUidPassword:
-		return "Log in using a standard DC/OS user account (username and password)", nil
-	case LoginTypeDCOSUidServiceKey:
-		return "Log in using a DC/OS service user account (username and private key)", nil
-	case LoginTypeDCOSUidPasswordLDAP:
-		return "Log in in using an LDAP user account (username and password)", nil
-	case LoginTypeSAMLSpInitiated:
-		return fmt.Sprintf("Log in using SAML 2.0 (%s)", provider.Description), nil
-	case LoginTypeOIDCImplicitFlow:
-		return fmt.Sprintf("Log in using OpenID Connect(%s)", provider.Description), nil
-	case LoginTypeOIDCAuthCodeFlow:
-		return fmt.Sprintf("Log in using OpenID Connect(%s)", provider.Description), nil
-	default:
-		return "", fmt.Errorf("unknown login provider %s", loginType)
-	}
-}
-
-type loginProvider struct {
-	AuthenticationType string                  `json:"authentication-type"`
-	ClientMethod       string                  `json:"client-method"`
-	Config             loginListProviderConfig `json:"config"`
-	Description        string                  `json:"description"`
-}
-
-type loginListProviderConfig struct {
-	StartFlowURL string `json:"start_flow_url"`
 }

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -31,6 +31,13 @@ func TLS(tlsConfig *tls.Config) Option {
 	}
 }
 
+// ACSToken sets the authorization token for HTTP requests.
+func ACSToken(token string) Option {
+	return func(c *Client) {
+		c.acsToken = token
+	}
+}
+
 // Timeout sets the timeout for HTTP requests.
 func Timeout(timeout time.Duration) Option {
 	return func(c *Client) {

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -31,7 +31,7 @@ func TLS(tlsConfig *tls.Config) Option {
 	}
 }
 
-// ACSToken sets the authorization token for HTTP requests.
+// ACSToken sets the authentication token for HTTP requests.
 func ACSToken(token string) Option {
 	return func(c *Client) {
 		c.acsToken = token

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -2,6 +2,7 @@ package login
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/dcos/dcos-cli/pkg/httpclient"
 	"github.com/sirupsen/logrus"
@@ -29,7 +30,51 @@ func (c *Client) Providers() (map[string]*Provider, error) {
 	}
 	defer resp.Body.Close()
 
-	var providers map[string]*Provider
-	err = json.NewDecoder(resp.Body).Decode(&providers)
-	return providers, err
+	providers := make(map[string]*Provider)
+	if resp.StatusCode == 200 {
+		err := json.NewDecoder(resp.Body).Decode(&providers)
+		if err == nil {
+			return providers, nil
+		}
+	}
+
+	c.logger.Info("Falling back to the WWW-Authenticate challenge.")
+	authHeader, err := c.challengeAuth()
+	if err != nil {
+		return nil, err
+	}
+
+	switch authHeader {
+	case "oauthjwt":
+		providers["dcos-oidc"] = defaultOIDCImplicitFlowProvider()
+	case "acsjwt":
+		providers["dcos-users"] = defaultDCOSUIDPasswordProvider()
+	default:
+		return nil, fmt.Errorf("unsupported WWW-Authenticate challenge '%s'", authHeader)
+	}
+	return providers, nil
 }
+
+// challengeAuth sends an unauthenticated HTTP request to a DC/OS well-known resource.
+// It then expects a 401 response with a WWW-Authenticate header containing the login method to use.
+// This method is used to determine which login provider is available when the /acs/api/v1/auth/providers
+// endpoint is not present. In practice this is mainly useful for DC/OS EE 1.7/1.8 and DC/OS Open Source.
+func (c *Client) challengeAuth() (string, error) {
+	req, err := c.http.NewRequest("HEAD", "/pkgpanda/active.buildinfo.full.json", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Del("Authorization")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return "", err
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode != 401 {
+		return "", fmt.Errorf("expected status code 401, got %d", resp.StatusCode)
+	}
+	return resp.Header.Get("WWW-Authenticate"), nil
+}
+

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -50,7 +50,7 @@ func (c *Client) Providers() (map[string]*Provider, error) {
 	switch authHeader {
 	case "oauthjwt":
 		// DC/OS Open Source
-		providers["dcos-oidc"] = defaultOIDCImplicitFlowProvider()
+		providers["dcos-oidc-auth0"] = defaultOIDCImplicitFlowProvider()
 	case "acsjwt":
 		// DC/OS EE 1.7/1.8
 		providers["dcos-users"] = defaultDCOSUIDPasswordProvider()

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -33,9 +33,10 @@ func (c *Client) Providers() (map[string]*Provider, error) {
 	providers := make(map[string]*Provider)
 	if resp.StatusCode == 200 {
 		err := json.NewDecoder(resp.Body).Decode(&providers)
-		if err == nil {
-			return providers, nil
+		if err != nil {
+			return nil, err
 		}
+		return providers, nil
 	}
 
 	c.logger.Info("Falling back to the WWW-Authenticate challenge.")

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -39,6 +39,8 @@ func (c *Client) Providers() (map[string]*Provider, error) {
 	}
 
 	c.logger.Info("Falling back to the WWW-Authenticate challenge.")
+
+	// This is for DC/OS EE 1.7/1.8 and DC/OS Open Source.
 	authHeader, err := c.challengeAuth()
 	if err != nil {
 		return nil, err
@@ -46,8 +48,10 @@ func (c *Client) Providers() (map[string]*Provider, error) {
 
 	switch authHeader {
 	case "oauthjwt":
+		// DC/OS Open Source
 		providers["dcos-oidc"] = defaultOIDCImplicitFlowProvider()
 	case "acsjwt":
+		// DC/OS EE 1.7/1.8
 		providers["dcos-users"] = defaultDCOSUIDPasswordProvider()
 	default:
 		return nil, fmt.Errorf("unsupported WWW-Authenticate challenge '%s'", authHeader)
@@ -58,7 +62,7 @@ func (c *Client) Providers() (map[string]*Provider, error) {
 // challengeAuth sends an unauthenticated HTTP request to a DC/OS well-known resource.
 // It then expects a 401 response with a WWW-Authenticate header containing the login method to use.
 // This method is used to determine which login provider is available when the /acs/api/v1/auth/providers
-// endpoint is not present. In practice this is mainly useful for DC/OS EE 1.7/1.8 and DC/OS Open Source.
+// endpoint is not present.
 func (c *Client) challengeAuth() (string, error) {
 	req, err := c.http.NewRequest("HEAD", "/pkgpanda/active.buildinfo.full.json", nil)
 	if err != nil {

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -1,0 +1,35 @@
+package login
+
+import (
+	"encoding/json"
+
+	"github.com/dcos/dcos-cli/pkg/httpclient"
+	"github.com/sirupsen/logrus"
+)
+
+// Client is able to detect available login providers and login to DC/OS.
+type Client struct {
+	http   *httpclient.Client
+	logger *logrus.Logger
+}
+
+// NewClient creates a new login client.
+func NewClient(baseClient *httpclient.Client, logger *logrus.Logger) *Client {
+	return &Client{
+		http:   baseClient,
+		logger: logger,
+	}
+}
+
+// Providers returns the supported login providers for a given DC/OS cluster.
+func (c *Client) Providers() (map[string]*Provider, error) {
+	resp, err := c.http.Get("/acs/api/v1/auth/providers")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var providers map[string]*Provider
+	err = json.NewDecoder(resp.Body).Decode(&providers)
+	return providers, err
+}

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -77,4 +77,3 @@ func (c *Client) challengeAuth() (string, error) {
 	}
 	return resp.Header.Get("WWW-Authenticate"), nil
 }
-

--- a/pkg/login/login_test.go
+++ b/pkg/login/login_test.go
@@ -52,6 +52,8 @@ func TestProviders(t *testing.T) {
 		if fixture.authChallenge != "" {
 			mux.HandleFunc("/pkgpanda/active.buildinfo.full.json", func(w http.ResponseWriter, req *http.Request) {
 				assert.Equal(t, "HEAD", req.Method)
+				assert.Equal(t, "", req.Header.Get("Authorization"))
+
 				w.Header().Add("WWW-Authenticate", fixture.authChallenge)
 				w.WriteHeader(401)
 			})

--- a/pkg/login/login_test.go
+++ b/pkg/login/login_test.go
@@ -34,7 +34,7 @@ func TestProviders(t *testing.T) {
 		{
 			nil,
 			"oauthjwt",
-			map[string]*Provider{"dcos-oidc": defaultOIDCImplicitFlowProvider()},
+			map[string]*Provider{"dcos-oidc-auth0": defaultOIDCImplicitFlowProvider()},
 		},
 	}
 

--- a/pkg/login/login_test.go
+++ b/pkg/login/login_test.go
@@ -1,0 +1,73 @@
+package login
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dcos/dcos-cli/pkg/httpclient"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProviders(t *testing.T) {
+	fixtures := []struct {
+		providersEndpoint map[string]*Provider
+		authChallenge     string
+		expectedProviders map[string]*Provider
+	}{
+		{nil, "", nil},
+		{nil, "unexisting-login-method", nil},
+		{
+			map[string]*Provider{"dcos-users": defaultDCOSUIDPasswordProvider()},
+			"",
+			map[string]*Provider{"dcos-users": defaultDCOSUIDPasswordProvider()},
+		},
+		{
+			nil,
+			"acsjwt",
+			map[string]*Provider{"dcos-users": defaultDCOSUIDPasswordProvider()},
+		},
+		{
+			nil,
+			"oauthjwt",
+			map[string]*Provider{"dcos-oidc": defaultOIDCImplicitFlowProvider()},
+		},
+	}
+
+	for _, fixture := range fixtures {
+		mux := http.NewServeMux()
+
+		if fixture.providersEndpoint != nil {
+			mux.HandleFunc("/acs/api/v1/auth/providers", func(w http.ResponseWriter, req *http.Request) {
+				assert.Equal(t, "GET", req.Method)
+				err := json.NewEncoder(w).Encode(&fixture.providersEndpoint)
+				assert.NoError(t, err)
+			})
+		}
+
+		if fixture.authChallenge != "" {
+			mux.HandleFunc("/pkgpanda/active.buildinfo.full.json", func(w http.ResponseWriter, req *http.Request) {
+				assert.Equal(t, "HEAD", req.Method)
+				w.Header().Add("WWW-Authenticate", fixture.authChallenge)
+				w.WriteHeader(401)
+			})
+		}
+
+		ts := httptest.NewServer(mux)
+		defer ts.Close()
+
+		client := NewClient(httpclient.New(ts.URL), &logrus.Logger{Out: ioutil.Discard})
+
+		providers, err := client.Providers()
+		if fixture.expectedProviders != nil {
+			require.NoError(t, err)
+			require.Equal(t, fixture.expectedProviders, providers)
+		} else {
+			require.Error(t, err)
+		}
+	}
+}

--- a/pkg/login/provider.go
+++ b/pkg/login/provider.go
@@ -44,3 +44,25 @@ func (provider *Provider) String() string {
 type ProviderConfig struct {
 	StartFlowURL string `json:"start_flow_url"`
 }
+
+func defaultDCOSUIDPasswordProvider() (provider *Provider) {
+	return &Provider{
+		Type:         DCOSUIDPassword,
+		Description:  "Default DC/OS login provider",
+		ClientMethod: "dcos-usercredential-post-receive-authtoken",
+		Config: ProviderConfig{
+			StartFlowURL: "/acs/api/v1/auth/login",
+		},
+	}
+}
+
+func defaultOIDCImplicitFlowProvider() (provider *Provider) {
+	return &Provider{
+		Type:         OIDCImplicitFlow,
+		Description:  "Google, GitHub, or Microsoft",
+		ClientMethod: "browser-prompt-authtoken",
+		Config: ProviderConfig{
+			StartFlowURL: "/login?redirect_uri=urn:ietf:wg:oauth:2.0:oob",
+		},
+	}
+}

--- a/pkg/login/provider.go
+++ b/pkg/login/provider.go
@@ -28,7 +28,7 @@ func (provider *Provider) String() string {
 	case DCOSUIDServiceKey:
 		return "Log in using a DC/OS service user account (username and private key)"
 	case DCOSUIDPasswordLDAP:
-		return "Log in in using an LDAP user account (username and password)"
+		return "Log in using an LDAP user account (username and password)"
 	case SAMLSpInitiated:
 		return fmt.Sprintf("Log in using SAML 2.0 (%s)", provider.Description)
 	case OIDCImplicitFlow:

--- a/pkg/login/provider.go
+++ b/pkg/login/provider.go
@@ -1,0 +1,46 @@
+package login
+
+import "fmt"
+
+// These are the different login provider types that DC/OS supports.
+const (
+	DCOSUIDPassword     = "dcos-uid-password"
+	DCOSUIDServiceKey   = "dcos-uid-servicekey"
+	DCOSUIDPasswordLDAP = "dcos-uid-password-ldap"
+	SAMLSpInitiated     = "saml-sp-initiated"
+	OIDCAuthCodeFlow    = "oidc-authorization-code-flow"
+	OIDCImplicitFlow    = "oidc-implicit-flow"
+)
+
+// Provider is a DC/OS login provider.
+type Provider struct {
+	Type         string         `json:"authentication-type"`
+	ClientMethod string         `json:"client-method"`
+	Config       ProviderConfig `json:"config"`
+	Description  string         `json:"description"`
+}
+
+// String converts a login provider to a string.
+func (provider *Provider) String() string {
+	switch provider.Type {
+	case DCOSUIDPassword:
+		return "Log in using a standard DC/OS user account (username and password)"
+	case DCOSUIDServiceKey:
+		return "Log in using a DC/OS service user account (username and private key)"
+	case DCOSUIDPasswordLDAP:
+		return "Log in in using an LDAP user account (username and password)"
+	case SAMLSpInitiated:
+		return fmt.Sprintf("Log in using SAML 2.0 (%s)", provider.Description)
+	case OIDCImplicitFlow:
+		return fmt.Sprintf("Log in using OpenID Connect (%s)", provider.Description)
+	case OIDCAuthCodeFlow:
+		return fmt.Sprintf("Log in using OpenID Connect (%s)", provider.Description)
+	default:
+		return ""
+	}
+}
+
+// ProviderConfig holds login provider specific configuration.
+type ProviderConfig struct {
+	StartFlowURL string `json:"start_flow_url"`
+}


### PR DESCRIPTION
This introduces a login package and implements the auth header challenge as a fallback solution when the `/acs/api/v1/auth/providers` endpoint is not available.

This allows eg. to list providers with DC/OS OSS :
```
$ dcos auth list-providers http://54.202.72.66
  PROVIDER ID                     LOGIN METHOD                      
  dcos-oidc    Log in using OpenID Connect (Google, GitHub, or Microsoft)
```

With DC/OS EE 1.7/1.8 : 
```
$ dcos auth list-providers http://54.244.69.190
  PROVIDER ID                             LOGIN METHOD                             
  dcos-users   Log in using a standard DC/OS user account (username and password)
```