### PR TITLE
Add a prompt package

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -110,6 +110,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f30166619713aa3b843faaa6b2420e25eb224750eeb695fd3d9c54b832bd31b4"
+  inputs-digest = "6bceb95452a262dfd0e52d4398d825673f701dbb0bc639357492163bb27e9c59"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,3 +25,7 @@
 [[constraint]]
   name = "github.com/sirupsen/logrus"
   version = "1.0.5"
+
+[[constraint]]
+  branch = "master"
+  name = "golang.org/x/crypto"

--- a/cmd/dcos/main.go
+++ b/cmd/dcos/main.go
@@ -11,6 +11,7 @@ import (
 
 func main() {
 	ctx := cli.NewContext(&cli.Environment{
+		Input:      os.Stdin,
 		Out:        os.Stdout,
 		ErrOut:     os.Stderr,
 		EnvLookup:  os.LookupEnv,

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -24,6 +24,11 @@ func NewContext(env *Environment) *Context {
 	return &Context{env: env}
 }
 
+// Input returns the reader for CLI input.
+func (ctx *Context) Input() io.Reader {
+	return ctx.env.Input
+}
+
 // Out returns the writer for CLI output.
 func (ctx *Context) Out() io.Writer {
 	return ctx.env.Out

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dcos/dcos-cli/pkg/config"
 	"github.com/dcos/dcos-cli/pkg/httpclient"
+	"github.com/dcos/dcos-cli/pkg/prompt"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 )
@@ -129,4 +130,9 @@ func (ctx *Context) HTTPClient(c *Cluster, opts ...httpclient.Option) *httpclien
 	opts = append(baseOpts, opts...)
 
 	return httpclient.New(c.URL(), opts...)
+}
+
+// Prompt is able to prompt for input, password or choices.
+func (ctx *Context) Prompt() *prompt.Prompt {
+	return prompt.New(ctx.Input(), ctx.Out())
 }

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -11,6 +11,9 @@ import (
 // functions for environment variables or user lookup, as well as a filesystem abstraction.
 type Environment struct {
 
+	// Input is the reader for CLI input.
+	Input io.Reader
+
 	// Out is the writer for CLI output.
 	Out io.Writer
 

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -1,0 +1,80 @@
+package prompt
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"strconv"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+// Prompt prompts for interactive questions.
+type Prompt struct {
+	in  io.Reader
+	out io.Writer
+}
+
+// New returns a new prompt.
+func New(input io.Reader, output io.Writer) *Prompt {
+	return &Prompt{
+		in:  input,
+		out: output,
+	}
+}
+
+// Input prompts for a string input.
+func (prompt *Prompt) Input(msg string) string {
+	fmt.Fprint(prompt.out, msg)
+	scanner := bufio.NewScanner(prompt.in)
+	scanner.Scan()
+
+	return scanner.Text()
+}
+
+// Password prompts for a password. It is similar to input, except that it doesn't echo back to the terminal.
+func (prompt *Prompt) Password(msg string) string {
+	f, ok := prompt.in.(*os.File)
+	if !ok || !terminal.IsTerminal(int(f.Fd())) {
+		return prompt.Input(msg)
+	}
+
+	fmt.Fprint(prompt.out, msg)
+	defer fmt.Fprint(prompt.out, "\n")
+
+	pass, _ := terminal.ReadPassword(int(f.Fd()))
+	return string(pass)
+}
+
+// Select allows to pick an item from a list of choices. For example :
+//
+//  Please choose a login provider for your linked cluster:
+//  (1) dcos-uid-password
+//  (2) saml-sp-initiated
+//  (1-2): [...]
+func (prompt *Prompt) Select(msg string, choices interface{}) (int, error) {
+	rType := reflect.TypeOf(choices)
+	if rType.Kind() != reflect.Slice {
+		return 0, fmt.Errorf("expected a slice, got %s", rType.Kind())
+	}
+	rVal := reflect.ValueOf(choices)
+
+	fmt.Fprintln(prompt.out, msg)
+
+	choicesLen := rVal.Len()
+	for i := 0; i < choicesLen; i++ {
+		fmt.Fprintf(prompt.out, "(%d) %v\n", i+1, rVal.Index(i).Interface())
+	}
+
+	choice := prompt.Input(fmt.Sprintf("(%d-%d): ", 1, choicesLen))
+	i, err := strconv.Atoi(choice)
+	if err != nil {
+		return 0, err
+	}
+	if i < 1 || i > choicesLen {
+		return 0, fmt.Errorf("choice %d doesn't exist", i)
+	}
+	return i - 1, nil
+}

--- a/pkg/prompt/prompt_test.go
+++ b/pkg/prompt/prompt_test.go
@@ -1,0 +1,54 @@
+package prompt
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInput(t *testing.T) {
+	var buf bytes.Buffer
+	prompt := New(strings.NewReader("this\n"), &buf)
+	val := prompt.Input("What do you write? ")
+	require.Equal(t, "What do you write? ", buf.String())
+	require.Equal(t, "this", val)
+}
+
+func TestPassword(t *testing.T) {
+	var buf bytes.Buffer
+	prompt := New(strings.NewReader("pass\n"), &buf)
+	val := prompt.Input("Password:")
+	require.Equal(t, "Password:", buf.String())
+	require.Equal(t, "pass", val)
+}
+
+func TestSelect(t *testing.T) {
+	fixtures := []struct {
+		input         string
+		expectError   bool
+		expectedValue int
+	}{
+		{"-1\n", true, 0},
+		{"0\n", true, 0},
+		{"1\n", false, 0},
+		{"2\n", false, 1},
+		{"3\n", false, 2},
+		{"4\n", true, 0},
+	}
+
+	for _, fixture := range fixtures {
+		var buf bytes.Buffer
+		prompt := New(strings.NewReader(fixture.input), &buf)
+
+		i, err := prompt.Select("Please choose:", []string{"a", "b", "c"})
+		if fixture.expectError {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			require.Equal(t, fixture.expectedValue, i)
+		}
+
+	}
+}


### PR DESCRIPTION
This package provides helpers to ask for interactive input. It currently supports text input, password and choosing from a list.

Usage : 
``` go
prompt := prompt.New(os.Stdin, os.Stdout)

username := prompt.Input("Username: ")

pass := prompt.Password("Password:")

choices := []string{"a", "b", "c"}
i, err := prompt.Select("Please choose:", choices)
if err != nil {
	return err
}
choice = choices[i]
```