### PR TITLE
Create a custom map type for login providers

### DIFF
--- a/pkg/cmd/auth/auth_listproviders.go
+++ b/pkg/cmd/auth/auth_listproviders.go
@@ -43,8 +43,8 @@ func newCmdAuthListProviders(ctx *cli.Context) *cobra.Command {
 				fmt.Fprintln(ctx.Out(), string(out))
 			} else {
 				table := cli.NewTable(ctx.Out(), []string{"PROVIDER ID", "LOGIN METHOD"})
-				for name, provider := range providers {
-					table.Append([]string{name, provider.String()})
+				for _, provider := range providers.Slice() {
+					table.Append([]string{provider.ID, provider.String()})
 				}
 				table.Render()
 			}

--- a/pkg/login/login_test.go
+++ b/pkg/login/login_test.go
@@ -17,24 +17,24 @@ func TestProviders(t *testing.T) {
 	fixtures := []struct {
 		providersEndpoint map[string]*Provider
 		authChallenge     string
-		expectedProviders map[string]*Provider
+		expectedProviders Providers
 	}{
 		{nil, "", nil},
 		{nil, "unexisting-login-method", nil},
 		{
 			map[string]*Provider{"dcos-users": defaultDCOSUIDPasswordProvider()},
 			"",
-			map[string]*Provider{"dcos-users": defaultDCOSUIDPasswordProvider()},
+			Providers{"dcos-users": defaultDCOSUIDPasswordProvider()},
 		},
 		{
 			nil,
 			"acsjwt",
-			map[string]*Provider{"dcos-users": defaultDCOSUIDPasswordProvider()},
+			Providers{"dcos-users": defaultDCOSUIDPasswordProvider()},
 		},
 		{
 			nil,
 			"oauthjwt",
-			map[string]*Provider{"dcos-oidc-auth0": defaultOIDCImplicitFlowProvider()},
+			Providers{"dcos-oidc-auth0": defaultOIDCImplicitFlowProvider()},
 		},
 	}
 


### PR DESCRIPTION
As Go randomizes iteration over maps, the `dcos auth list-providers` currently lists providers in an unstable order. This can be confusing and error-prone for users in some cases (eg. if we are printing a list to select from).

This introduces a custom type with a `Slice()` method returning the providers in a constant order (sorted by ID).