### PR TITLE
Add an open package

### DIFF
--- a/api/cli.go
+++ b/api/cli.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dcos/dcos-cli/pkg/cli"
 	"github.com/dcos/dcos-cli/pkg/config"
 	"github.com/dcos/dcos-cli/pkg/httpclient"
+	"github.com/dcos/dcos-cli/pkg/open"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 )
@@ -48,4 +49,7 @@ type Context interface {
 
 	// HTTPClient creates an httpclient.Client for a given cluster.
 	HTTPClient(c *cli.Cluster, opts ...httpclient.Option) *httpclient.Client
+
+	// Opener returns an open.Opener.
+	Opener() *open.Opener
 }

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dcos/dcos-cli/pkg/config"
 	"github.com/dcos/dcos-cli/pkg/httpclient"
+	"github.com/dcos/dcos-cli/pkg/open"
 	"github.com/dcos/dcos-cli/pkg/prompt"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -135,4 +136,9 @@ func (ctx *Context) HTTPClient(c *Cluster, opts ...httpclient.Option) *httpclien
 // Prompt is able to prompt for input, password or choices.
 func (ctx *Context) Prompt() *prompt.Prompt {
 	return prompt.New(ctx.Input(), ctx.Out())
+}
+
+// Opener returns a new OS Opener.
+func (ctx *Context) Opener() open.Opener {
+	return open.NewOsOpener(ctx.Logger())
 }

--- a/pkg/open/open.go
+++ b/pkg/open/open.go
@@ -1,0 +1,23 @@
+package open
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+// Opener opens a file or URL in the user's preferred application.
+type Opener interface {
+	Open(resource string) error
+}
+
+// OsOpener is an Opener using OS-specific commands.
+// It is only relevant in desktop environments.
+type OsOpener struct {
+	logger *logrus.Logger
+}
+
+// NewOsOpener creates a new OsOpener,
+func NewOsOpener(logger *logrus.Logger) *OsOpener {
+	return &OsOpener{
+		logger: logger,
+	}
+}

--- a/pkg/open/open_darwin.go
+++ b/pkg/open/open_darwin.go
@@ -1,0 +1,15 @@
+package open
+
+import (
+	"os/exec"
+)
+
+// Open opens a resource on macOS, using the "open" command.
+func (o *OsOpener) Open(resource string) error {
+	cmd := exec.Command("open", resource)
+	out, err := cmd.CombinedOutput()
+	if len(out) > 0 {
+		o.logger.Debug(string(out))
+	}
+	return err
+}

--- a/pkg/open/open_linux.go
+++ b/pkg/open/open_linux.go
@@ -1,0 +1,15 @@
+package open
+
+import (
+	"os/exec"
+)
+
+// Open opens a resource on Linux, it relies on "xdg-open".
+func (o *OsOpener) Open(resource string) error {
+	cmd := exec.Command("xdg-open", resource)
+	out, err := cmd.CombinedOutput()
+	if len(out) > 0 {
+		o.logger.Debug(string(out))
+	}
+	return err
+}

--- a/pkg/open/open_windows.go
+++ b/pkg/open/open_windows.go
@@ -1,0 +1,15 @@
+package open
+
+import (
+	"os/exec"
+)
+
+// Open opens a resource on Windows through the FileProtocolHandler entrypoint of the url DLL.
+func (o *OsOpener) Open(resource string) error {
+	cmd := exec.Command("rundll32", "url.dll,FileProtocolHandler", resource)
+	out, err := cmd.CombinedOutput()
+	if len(out) > 0 {
+		o.logger.Debug(string(out))
+	}
+	return err
+}


### PR DESCRIPTION
It allows to open files or URLs in user's preferred application. It is mainly useful to trigger auth flow in browsers.

This implementation is based on what https://github.com/skratchdot/open-golang does, except that it introduces an interface and has logging capabilities.