### PR TITLE
Job Kill Requires Argument

### DIFF
--- a/python/lib/dcoscli/dcoscli/data/help/job.txt
+++ b/python/lib/dcoscli/dcoscli/data/help/job.txt
@@ -10,7 +10,7 @@ Description:
         dcos job remove <job-id> [--stop-current-job-runs]
         dcos job show <job-id>
         dcos job update <job-file>
-        dcos job kill <job-id> [<run-id>][--all]
+        dcos job kill <job-id> (<run-id>|--all)
         dcos job run <job-id> [--json]
         dcos job list [--json|--quiet]
         dcos job schedule add <job-id> <schedule-file>


### PR DESCRIPTION
Either job_run_id OR --all flag is required for `dcos job <job_id>`

https://jira.mesosphere.com/browse/DCOS_OSS-3302