### PR TITLE
Fix the context interface and use it in commands

### DIFF
--- a/api/cli.go
+++ b/api/cli.go
@@ -51,5 +51,5 @@ type Context interface {
 	HTTPClient(c *cli.Cluster, opts ...httpclient.Option) *httpclient.Client
 
 	// Opener returns an open.Opener.
-	Opener() *open.Opener
+	Opener() open.Opener
 }

--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -1,12 +1,12 @@
 package auth
 
 import (
-	"github.com/dcos/dcos-cli/pkg/cli"
+	"github.com/dcos/dcos-cli/api"
 	"github.com/spf13/cobra"
 )
 
 // NewCommand creates the `dcos auth` subcommand.
-func NewCommand(ctx *cli.Context) *cobra.Command {
+func NewCommand(ctx api.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "auth",
 	}

--- a/pkg/cmd/auth/auth_listproviders.go
+++ b/pkg/cmd/auth/auth_listproviders.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/dcos/dcos-cli/api"
 	"github.com/dcos/dcos-cli/pkg/cli"
 	"github.com/dcos/dcos-cli/pkg/httpclient"
 	"github.com/dcos/dcos-cli/pkg/login"
@@ -11,7 +12,7 @@ import (
 )
 
 // newCmdAuthListProviders creates the `dcos auth list-providers` subcommand.
-func newCmdAuthListProviders(ctx *cli.Context) *cobra.Command {
+func newCmdAuthListProviders(ctx api.Context) *cobra.Command {
 	var jsonOutput bool
 	cmd := &cobra.Command{
 		Use:  "list-providers",

--- a/pkg/cmd/cluster/cluster.go
+++ b/pkg/cmd/cluster/cluster.go
@@ -1,12 +1,12 @@
 package cluster
 
 import (
-	"github.com/dcos/dcos-cli/pkg/cli"
+	"github.com/dcos/dcos-cli/api"
 	"github.com/spf13/cobra"
 )
 
 // NewCommand creates the `dcos cluster` subcommand.
-func NewCommand(ctx *cli.Context) *cobra.Command {
+func NewCommand(ctx api.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "cluster",
 	}

--- a/pkg/cmd/cluster/cluster_attach.go
+++ b/pkg/cmd/cluster/cluster_attach.go
@@ -1,12 +1,12 @@
 package cluster
 
 import (
-	"github.com/dcos/dcos-cli/pkg/cli"
+	"github.com/dcos/dcos-cli/api"
 	"github.com/spf13/cobra"
 )
 
 // newCmdClusterAttach ataches the CLI to a cluster.
-func newCmdClusterAttach(ctx *cli.Context) *cobra.Command {
+func newCmdClusterAttach(ctx api.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:  "attach",
 		Args: cobra.ExactArgs(1),

--- a/pkg/cmd/cluster/cluster_list.go
+++ b/pkg/cmd/cluster/cluster_list.go
@@ -6,13 +6,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dcos/dcos-cli/api"
 	"github.com/dcos/dcos-cli/pkg/cli"
 	"github.com/dcos/dcos-cli/pkg/httpclient"
 	"github.com/spf13/cobra"
 )
 
 // newCmdClusterList lists the clusters.
-func newCmdClusterList(ctx *cli.Context) *cobra.Command {
+func newCmdClusterList(ctx api.Context) *cobra.Command {
 	var onlyAttached bool
 	var jsonOutput bool
 	cmd := &cobra.Command{
@@ -87,7 +88,7 @@ func newCmdClusterList(ctx *cli.Context) *cobra.Command {
 }
 
 // getVersion returns the version of the cluster as a string.
-func getVersion(ctx *cli.Context, cluster *cli.Cluster) (string, error) {
+func getVersion(ctx api.Context, cluster *cli.Cluster) (string, error) {
 	client := ctx.HTTPClient(cluster, httpclient.Timeout(5*time.Second))
 	resp, err := client.Get("/dcos-metadata/dcos-version.json")
 	if err != nil {

--- a/pkg/cmd/cluster/cluster_remove.go
+++ b/pkg/cmd/cluster/cluster_remove.go
@@ -4,12 +4,12 @@ import (
 	"errors"
 	"path/filepath"
 
-	"github.com/dcos/dcos-cli/pkg/cli"
+	"github.com/dcos/dcos-cli/api"
 	"github.com/spf13/cobra"
 )
 
 // newCmdClusterRemove removes a cluster.
-func newCmdClusterRemove(ctx *cli.Context) *cobra.Command {
+func newCmdClusterRemove(ctx api.Context) *cobra.Command {
 	var removeAll bool
 	cmd := &cobra.Command{
 		Use:  "remove",

--- a/pkg/cmd/cluster/cluster_rename.go
+++ b/pkg/cmd/cluster/cluster_rename.go
@@ -1,12 +1,12 @@
 package cluster
 
 import (
-	"github.com/dcos/dcos-cli/pkg/cli"
+	"github.com/dcos/dcos-cli/api"
 	"github.com/spf13/cobra"
 )
 
 // newCmdClusterRename renames a cluster.
-func newCmdClusterRename(ctx *cli.Context) *cobra.Command {
+func newCmdClusterRename(ctx api.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:  "rename",
 		Args: cobra.ExactArgs(2),

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -1,12 +1,12 @@
 package config
 
 import (
-	"github.com/dcos/dcos-cli/pkg/cli"
+	"github.com/dcos/dcos-cli/api"
 	"github.com/spf13/cobra"
 )
 
 // NewCommand creates the `dcos config` subcommand.
-func NewCommand(ctx *cli.Context) *cobra.Command {
+func NewCommand(ctx api.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "config",
 	}

--- a/pkg/cmd/config/config_set.go
+++ b/pkg/cmd/config/config_set.go
@@ -1,12 +1,12 @@
 package config
 
 import (
-	"github.com/dcos/dcos-cli/pkg/cli"
+	"github.com/dcos/dcos-cli/api"
 	"github.com/spf13/cobra"
 )
 
 // newCmdConfigSet creates the `dcos config set` subcommand.
-func newCmdConfigSet(ctx *cli.Context) *cobra.Command {
+func newCmdConfigSet(ctx api.Context) *cobra.Command {
 	return &cobra.Command{
 		Use:  "set",
 		Args: cobra.ExactArgs(2),

--- a/pkg/cmd/config/config_show.go
+++ b/pkg/cmd/config/config_show.go
@@ -3,12 +3,12 @@ package config
 import (
 	"fmt"
 
-	"github.com/dcos/dcos-cli/pkg/cli"
+	"github.com/dcos/dcos-cli/api"
 	"github.com/spf13/cobra"
 )
 
 // newCmdConfigShow creates the `dcos config show` subcommand.
-func newCmdConfigShow(ctx *cli.Context) *cobra.Command {
+func newCmdConfigShow(ctx api.Context) *cobra.Command {
 	return &cobra.Command{
 		Use:  "show",
 		Args: cobra.MaximumNArgs(1),

--- a/pkg/cmd/config/config_unset.go
+++ b/pkg/cmd/config/config_unset.go
@@ -1,12 +1,12 @@
 package config
 
 import (
-	"github.com/dcos/dcos-cli/pkg/cli"
+	"github.com/dcos/dcos-cli/api"
 	"github.com/spf13/cobra"
 )
 
 // newCmdConfigUnset creates the `dcos config unset` subcommand.
-func newCmdConfigUnset(ctx *cli.Context) *cobra.Command {
+func newCmdConfigUnset(ctx api.Context) *cobra.Command {
 	return &cobra.Command{
 		Use:  "unset",
 		Args: cobra.ExactArgs(1),


### PR DESCRIPTION
open.Opener is an interface, this also updates commands to use the
interface so that other mistakes like this get detected, it would also
allow to pass mocks during tests.