### PR TITLE
WIP: Tab complete alternative

### DIFF
--- a/pkg/cmd/cluster/cluster_attach.go
+++ b/pkg/cmd/cluster/cluster_attach.go
@@ -8,8 +8,9 @@ import (
 // newCmdClusterAttach ataches the CLI to a cluster.
 func newCmdClusterAttach(ctx api.Context) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:  "attach",
-		Args: cobra.ExactArgs(1),
+		Use:         "attach",
+		Args:        cobra.ExactArgs(1),
+		Annotations: map[string]string{"custom_completion": "cluster_list"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			manager := ctx.ConfigManager()
 			conf, err := manager.Find(args[0], false)

--- a/pkg/cmd/cluster/cluster_remove.go
+++ b/pkg/cmd/cluster/cluster_remove.go
@@ -12,8 +12,9 @@ import (
 func newCmdClusterRemove(ctx api.Context) *cobra.Command {
 	var removeAll bool
 	cmd := &cobra.Command{
-		Use:  "remove",
-		Args: cobra.MaximumNArgs(1),
+		Use:         "remove",
+		Args:        cobra.MaximumNArgs(1),
+		Annotations: map[string]string{"custom_completion": "cluster_list"},
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if removeAll && len(args) == 1 {
 				return errors.New("cannot accept both a cluster name and the --all option")

--- a/pkg/cmd/completion/dcos_autocomplete.go
+++ b/pkg/cmd/completion/dcos_autocomplete.go
@@ -1,4 +1,4 @@
-package cmd
+package completion
 
 import (
 	"errors"
@@ -10,7 +10,8 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-func newAutocompleteCommand(ctx *cli.Context) *cobra.Command {
+// NewAutocompleteCommand creates and returns a command to get autocompletion options for the CLi
+func NewAutocompleteCommand(ctx *cli.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "__autocomplete__",
 

--- a/pkg/cmd/completion/dcos_autocomplete.go
+++ b/pkg/cmd/completion/dcos_autocomplete.go
@@ -108,10 +108,6 @@ func internalCompletion(cmd *cobra.Command, flagComplete bool) []string {
 				name := "--" + f.Name
 				out = append(out, name)
 			}
-			if f.Shorthand != "" {
-				shorthand := "-" + f.Shorthand
-				out = append(out, shorthand)
-			}
 		})
 	}
 	return out

--- a/pkg/cmd/dcos.go
+++ b/pkg/cmd/dcos.go
@@ -33,7 +33,7 @@ func NewDCOSCommand(ctx *cli.Context) *cobra.Command {
 		auth.NewCommand(ctx),
 		config.NewCommand(ctx),
 		cluster.NewCommand(ctx),
-		newAutocompleteCommand(ctx),
+		completion.newAutocompleteCommand(ctx),
 	)
 	return cmd
 }

--- a/pkg/cmd/dcos.go
+++ b/pkg/cmd/dcos.go
@@ -5,6 +5,7 @@ import (
 	"github.com/dcos/dcos-cli/pkg/cli"
 	"github.com/dcos/dcos-cli/pkg/cmd/auth"
 	"github.com/dcos/dcos-cli/pkg/cmd/cluster"
+	"github.com/dcos/dcos-cli/pkg/cmd/completion"
 	"github.com/dcos/dcos-cli/pkg/cmd/config"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -33,7 +34,7 @@ func NewDCOSCommand(ctx *cli.Context) *cobra.Command {
 		auth.NewCommand(ctx),
 		config.NewCommand(ctx),
 		cluster.NewCommand(ctx),
-		completion.newAutocompleteCommand(ctx),
+		completion.NewAutocompleteCommand(ctx),
 	)
 	return cmd
 }

--- a/pkg/cmd/dcos.go
+++ b/pkg/cmd/dcos.go
@@ -33,6 +33,7 @@ func NewDCOSCommand(ctx *cli.Context) *cobra.Command {
 		auth.NewCommand(ctx),
 		config.NewCommand(ctx),
 		cluster.NewCommand(ctx),
+		newAutocompleteCommand(ctx),
 	)
 	return cmd
 }

--- a/pkg/cmd/dcos_autocomplete.go
+++ b/pkg/cmd/dcos_autocomplete.go
@@ -11,13 +11,10 @@ import (
 )
 
 func newAutocompleteCommand(ctx *cli.Context) *cobra.Command {
-	// We can either implement shell specification with an optional flag or we can require it as an
-	// argument taken by __autocomplete__. Thinking about it, I think giving it as the first argument
-	// is best because we'll only ever support a few shell types and users won't be typing these commands
-	// in manually.
 	cmd := &cobra.Command{
-		Use:  "__autocomplete__",
-		Args: cobra.MinimumNArgs(1),
+		Use:       "__autocomplete__",
+		Args:      cobra.MinimumNArgs(1),
+		ValidArgs: []string{"bash", "zsh"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
 				return errors.New("no arguments given")
@@ -52,12 +49,14 @@ func newAutocompleteCommand(ctx *cli.Context) *cobra.Command {
 				// not a command is internal or external. In this case we're only interested in whether the
 				// external key exists because we assume the default is internal.
 				if _, exists := cmd.Annotations["external"]; exists {
-					completions = externalCompletion(cmd)
+					completions = externalCompletion(command)
 				} else {
 					completions = internalCompletion(command, flags, flagComplete)
 				}
+
+				completions = append(completions, customCompletion(command, ctx)...)
 			default:
-				return errors.New("")
+				return fmt.Errorf("no completion implemented for shell %s", shell)
 			}
 
 			for _, c := range completions {
@@ -132,5 +131,5 @@ func customCompletion(cmd *cobra.Command, ctx *cli.Context) []string {
 	default:
 	}
 
-	return []string{}
+	return out
 }

--- a/pkg/cmd/dcos_autocomplete.go
+++ b/pkg/cmd/dcos_autocomplete.go
@@ -13,6 +13,7 @@ import (
 func newAutocompleteCommand(ctx *cli.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:       "__autocomplete__",
+		Hidden:    true,
 		Args:      cobra.MinimumNArgs(1),
 		ValidArgs: []string{"bash", "zsh"},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/dcos_autocomplete.go
+++ b/pkg/cmd/dcos_autocomplete.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/dcos/dcos-cli/pkg/cli"
+	"github.com/spf13/cobra"
+)
+
+func newAutocompleteCommand(ctx *cli.Context) *cobra.Command {
+	// We can either implement shell specification with an optional flag or we can require it as an
+	// argument taken by __autocomplete__. Thinking about it, I think giving it as the first argument
+	// is best because we'll only ever support a few shell types and users won't be typing these commands
+	// in manually.
+	cmd := &cobra.Command{
+		Use:  "__autocomplete__",
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return errors.New("no arguments given")
+			}
+			shell := args[0]
+			commands, flags := stripFlags(args[1:])
+			flagComplete := isFlag(args[len(args)-1])
+			root := cmd.Parent()
+
+			switch shell {
+			case "bash":
+				// root.Find will return the stuff remaining from after the words that matched the commands
+				// (e.g. `cluster att` will give ["att"]).
+				// However, if there are incorrect or, unfortunately, incomplete flags, this will error out
+				// so if they're completing on a flag with something like `auth list-providers --j`,
+				// it'll error
+				command, remaining, err := root.Find(commands)
+				if err != nil {
+					return err
+				}
+
+				internalCompletion(command, flags, flagComplete)
+			case "zsh":
+			default:
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func isFlag(arg string) bool {
+	return strings.HasPrefix(arg, "-")
+}
+
+func stripFlags(args []string) ([]string, []string) {
+	var commands []string
+	var flags []string
+	for _, a := range args {
+		if isFlag(a) {
+			flags = append(flags, a)
+		} else {
+			commands = append(commands, a)
+		}
+	}
+	return commands, flags
+}
+
+func internalCompletion(cmd *cobra.Command, flags []string, flagComplete bool) []string {
+	var out []string
+	if !flagComplete {
+		// subcommand or argument completion
+		for _, c := range cmd.Commands() {
+			out = append(out, c.Name())
+		}
+		out = append(out, cmd.ValidArgs...)
+	} else {
+		flagSet := cmd.Flags()
+	}
+	return out
+}
+
+func externalCompletion(cmd *cobra.Command, flag bool) []string {
+	return []string{}
+}

--- a/pkg/cmd/dcos_autocomplete.go
+++ b/pkg/cmd/dcos_autocomplete.go
@@ -12,8 +12,14 @@ import (
 
 func newAutocompleteCommand(ctx *cli.Context) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                "__autocomplete__",
-		Hidden:             true,
+		Use: "__autocomplete__",
+
+		// Hide it from the Usage output
+		Hidden: true,
+
+		// This needs to be true to prevent __autocomplete__ from trying to parse flags that are meant for
+		// the commands it's trying to complete and causing completion to fail because it takes no flags
+		// itself so any flags will break it.
 		DisableFlagParsing: true,
 		Args:               cobra.MinimumNArgs(1),
 		ValidArgs:          []string{"bash", "zsh"},

--- a/pkg/cmd/dcos_autocomplete.go
+++ b/pkg/cmd/dcos_autocomplete.go
@@ -18,8 +18,7 @@ func newAutocompleteCommand(ctx *cli.Context) *cobra.Command {
 		Hidden: true,
 
 		// This needs to be true to prevent __autocomplete__ from trying to parse flags that are meant for
-		// the commands it's trying to complete and causing completion to fail because it takes no flags
-		// itself so any flags will break it.
+		// the commands it's trying to complete causing it to fail.
 		DisableFlagParsing: true,
 		Args:               cobra.MinimumNArgs(1),
 		ValidArgs:          []string{"bash", "zsh"},


### PR DESCRIPTION

This is a WIP PR proposal for a model of how to do tab completion on the CLI. So users don't need to update completion script whenever they install a new plugin we'll have a simple and mostly static completion script that calls `dcos __autocomplete__` and then implement that as a cobra command which outputs the completion results.

To try it out, run
`dcos __autocomplete__ bash cluster`
Note that there it isn't `bash dcos cluster`. That's because of how cobra deals with searching from the root command. I could modify autocomplete to expect that or leave it as is and have the shells deal with it in their completion functions.

## Different Shells ##
Currently only bash autocompletion is implemented but there are plans to add zsh at some point and possibly more shells later on. For now we're thinking that to allow us to take full advantage of the various shell completion features, we'll differentiate which type of completion we want. I'm thinking that we have the type of shell as the first argument of the command e.g. `dcos __autocomplete__ bash dcos cluster`. This simplifies how we pull the shell type since the caller specifies what type they want and we don't need to pull from ennvars or anything. Since users won't be typing this out manually, I don't think requiring it is a big deal and each shell will likely have different completion scripts so on our side hardcoding that in the bash completion or zsh completion scripts won't be a big deal.

We could also separate out the shells into different subcommands under autocomplete without changing the API if we decide the code is different enough or cluttered enough for that to make sense. 

## External Commands ##
Autocomplete will need to differentiate between internal and external (located in plugins) commands. We haven't planned out how plugins will work yet but it's likely that they be cobra commands that are built and added to the command tree at runtime so we can differentiate them by adding an `external` key to their `Annotations` field. Alternatively we could have a `type` field and make the value `internal` or `external` but having the `external` key with some value means we don't need to modify any of our already written internal commands.

## Custom Completion ##
An extra feature that we'd really like to have is custom autocomplete beyond command names and flags such as cluster names, tasks, etc. For this I think the easiest and most flexible way would be to look for an optional `custom_completion` key in `Annotations` and statically define a list of allowed functions such as `cluster_list`. This would also allow plugins that haven't been made to handle autocompletion access to these functions if we have some `custom_completion` field in whatever metadata we create for them. This is better than shelling out to the dcos command because we won't need to create custom commands to handle this or modify existing ones to shape their output in a useful way.

In theory, we could further extend this to take arguments like `task_list kafka` if we wanted to allow for a bit more flexibility though this is probably better left to the plugins to support after being made autocomplete-aware.

Flags also have an `Annotations` field which we could leverage for this as well.

 Assuming we want to strictly keep custom completion to functionality available in the wrapper, something like `task_list` above wouldn't be possible and, due to the limited scope of the wrapper CLI, there wouldn't be many functions we can add here that wouldn't be reliant on parts of the core CLI so it may not be worth the additional complexity.

## Other things ##
* Right now for commands that have multiple flags, the output doesn't filter out the flags that have already been given.
* I'm not sure how to handle commands like `cluster rename` because the first argument could benefit from autocompleting off the attached cluster names but the second argument wouldn't really. However as it is now, if we add `cluster_list` as a custom completion function, any argument completion will use it. This also shows up in `cluster attach` which only takes a single arg but will still call out to `cluster_list` even if there's already an argument.
