### PR TITLE
Add style guide links to readme 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,10 @@ If you are submitting a bug report, please include:
 Please describe the problem you are addressing and your proposed solution.
 
 ### Style
-We follow [pep8](https://www.python.org/dev/peps/pep-0008/) and [isort](
+Please refer to our [style guide](https://github.com/dcos/dcos-cli/blob/master/STYLEGUIDE.md). We follow [pep8](https://www.python.org/dev/peps/pep-0008/) and [isort](
 https://pypi.python.org/pypi/isort) conventions. You can make sure you follow these by running
 `tox -e py34-syntax` in the `dcos-cli` and `cli` directories.
+
 
 ### Tests
 Please include test(s) with your changes. Make sure to separate integration and unit tests. Please

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ run:
 
         env/bin/tox -e py35-integration /<test-file>.py
 
-### Releasing
+## Releasing
 
 Releasing a new version of the DC/OS CLI is only possible through an
 [automated TeamCity
@@ -230,3 +230,7 @@ executables (for Windows, macOS, and Linux).
 
 The executables are pushed to s3 and available at
 <https://downloads.dcos.io/binaries/cli/>\<platform\>/x86-64/\<tag\>/dcos.
+
+## Contributing
+
+Contributions are always welcome! Please refer to our [contributing guidelines](https://github.com/dcos/dcos-cli/blob/master/CONTRIBUTING.md) and [style guide](https://github.com/dcos/dcos-cli/blob/master/STYLEGUIDE.md) first.


### PR DESCRIPTION
This PR adds a link to the CLI style guide making it clear to reference the style guide before contributing.