### PR TITLE
Set the logging level outside of cobra

### DIFF
--- a/cmd/dcos/main.go
+++ b/cmd/dcos/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/user"
 	"time"
@@ -11,7 +12,9 @@ import (
 	"github.com/dcos/dcos-cli/pkg/cmd"
 	"github.com/dcos/dcos-cli/pkg/dcos"
 	"github.com/dcos/dcos-cli/pkg/httpclient"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
+	"github.com/spf13/pflag"
 )
 
 var version = "SNAPSHOT"
@@ -26,13 +29,47 @@ func main() {
 		Fs:         afero.NewOsFs(),
 	})
 
-	if len(os.Args) == 2 && os.Args[1] == "--version" {
-		printVersion(ctx)
-		return
-	}
-
-	if err := cmd.NewDCOSCommand(ctx).Execute(); err != nil {
+	if err := run(ctx, os.Args); err != nil {
 		os.Exit(1)
+	}
+}
+
+// run launches the DC/OS CLI with a given context and args.
+func run(ctx api.Context, args []string) error {
+	var verbosity int
+	var showVersion bool
+
+	// Register the version and verbose global flags.
+	// We ContinueOnError because we don't want to fail for subcommand specific flags.
+	// We discard any output because we don't want the `-h` flag to trigger usage on this flagset.
+	globalFlags := pflag.NewFlagSet(args[0], pflag.ContinueOnError)
+	globalFlags.SetOutput(ioutil.Discard)
+	globalFlags.BoolVar(&showVersion, "version", false, "")
+	globalFlags.CountVarP(&verbosity, "", "v", "")
+	globalFlags.Parse(args[1:])
+
+	ctx.Logger().SetLevel(logLevel(verbosity))
+
+	if showVersion {
+		printVersion(ctx)
+		return nil
+	}
+	return cmd.NewDCOSCommand(ctx).Execute()
+}
+
+// logLevel returns the log level for the CLI based on the verbosity. The default verbosity is 0.
+func logLevel(verbosity int) logrus.Level {
+	switch verbosity {
+	case 0:
+		// Without the verbose flag, default to error level.
+		return logrus.ErrorLevel
+	case 1:
+		// -v sets the logger level to info.
+		return logrus.InfoLevel
+	default:
+		// -vv sets the logger level to debug. This also happens for -vvv
+		// and above, in such cases we set the logging level to its maximum.
+		return logrus.DebugLevel
 	}
 }
 

--- a/cmd/dcos/main_test.go
+++ b/cmd/dcos/main_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/dcos/dcos-cli/pkg/mock"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunWithoutVerbosity(t *testing.T) {
+	ctx := mock.NewContext(nil)
+	require.NoError(t, run(ctx, []string{"dcos"}))
+
+	require.Equal(t, logrus.ErrorLevel, ctx.Logger().Level)
+}
+
+func TestRunWithInfoVerbosity(t *testing.T) {
+	ctx := mock.NewContext(nil)
+	require.NoError(t, run(ctx, []string{"dcos", "-v"}))
+
+	require.Equal(t, logrus.InfoLevel, ctx.Logger().Level)
+}
+
+func TestRunWithDebugVerbosity(t *testing.T) {
+	ctx := mock.NewContext(nil)
+	require.NoError(t, run(ctx, []string{"dcos", "-vv"}))
+
+	require.Equal(t, logrus.DebugLevel, ctx.Logger().Level)
+}

--- a/pkg/cmd/dcos.go
+++ b/pkg/cmd/dcos.go
@@ -9,7 +9,6 @@ import (
 	"github.com/dcos/dcos-cli/pkg/cmd/cluster"
 	"github.com/dcos/dcos-cli/pkg/cmd/config"
 	"github.com/dcos/dcos-cli/pkg/plugin"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -17,23 +16,15 @@ const annotationUsageOptions string = "usage_options"
 
 // NewDCOSCommand creates the `dcos` command with its `auth`, `config`, and `cluster` subcommands.
 func NewDCOSCommand(ctx api.Context) *cobra.Command {
-	var verbose int
 	cmd := &cobra.Command{
 		Use: "dcos",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			cmd.SilenceUsage = true
-			if verbose == 1 {
-				// -v sets the logger level to info.
-				ctx.Logger().SetLevel(logrus.InfoLevel)
-			} else if verbose > 1 {
-				// -vv sets the logger level to debug. This also happens for -vvv
-				// and above, in such cases we set the logging level to its maximum.
-				ctx.Logger().SetLevel(logrus.DebugLevel)
-			}
 		},
 	}
 
-	cmd.PersistentFlags().CountVarP(&verbose, "", "v", "verbosity (-v or -vv)")
+	// This global flag is handled outside of cobra. It is declared here to prevent the unknown flag error.
+	cmd.PersistentFlags().CountP("", "v", "")
 
 	cmd.AddCommand(
 		auth.NewCommand(ctx),

--- a/pkg/mock/mock.go
+++ b/pkg/mock/mock.go
@@ -13,6 +13,8 @@ import (
 	"github.com/dcos/dcos-cli/pkg/cluster/linker"
 	"github.com/dcos/dcos-cli/pkg/config"
 	"github.com/dcos/dcos-cli/pkg/login"
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/spf13/afero"
 )
 
@@ -75,8 +77,10 @@ func NewEnvironment() *cli.Environment {
 // Context is an api.Context which can be mocked.
 type Context struct {
 	*cli.Context
-	cluster  *config.Cluster
-	clusters []*config.Cluster
+	logger     *logrus.Logger
+	loggerHook *logrustest.Hook
+	cluster    *config.Cluster
+	clusters   []*config.Cluster
 }
 
 // NewContext returns a new mock context.
@@ -84,8 +88,11 @@ func NewContext(environment *cli.Environment) *Context {
 	if environment == nil {
 		environment = NewEnvironment()
 	}
+	logger, hook := logrustest.NewNullLogger()
 	return &Context{
-		Context: cli.NewContext(environment),
+		Context:    cli.NewContext(environment),
+		logger:     logger,
+		loggerHook: hook,
 	}
 }
 
@@ -113,4 +120,14 @@ func (ctx *Context) Clusters() []*config.Cluster {
 		return ctx.clusters
 	}
 	return ctx.Context.Clusters()
+}
+
+// Logger returns the logger.
+func (ctx *Context) Logger() *logrus.Logger {
+	return ctx.logger
+}
+
+// LoggerHook returns the logger hook.
+func (ctx *Context) LoggerHook() *logrustest.Hook {
+	return ctx.loggerHook
 }


### PR DESCRIPTION
Having it in the pre run hook discards all the logs from the plugin manager, this is because the plugin manager is invoked while creating the cobra command tree. The hook is only invoked later while actually calling a command.

Declaring the flag outside of cobra and setting the log level directly fixes this problem.

https://jira.mesosphere.com/browse/DCOS_OSS-3822