### PR TITLE
Add missing Input() method to api.Context

### DIFF
--- a/api/cli.go
+++ b/api/cli.go
@@ -19,6 +19,8 @@ import (
 // It also acts as a factory/helper for various objects across the project. It has quite wide scope so
 // in the future it might be refined or interfaces might be introduced for subsets of its functionalities.
 type Context interface {
+	// Input returns the reader for CLI input.
+	Input() io.Reader
 
 	// Out returns a writer for CLI output.
 	Out() io.Writer

--- a/cmd/dcos/main.go
+++ b/cmd/dcos/main.go
@@ -6,6 +6,7 @@ import (
 	"os/user"
 	"time"
 
+	"github.com/dcos/dcos-cli/api"
 	"github.com/dcos/dcos-cli/pkg/cli"
 	"github.com/dcos/dcos-cli/pkg/cmd"
 	"github.com/dcos/dcos-cli/pkg/dcos"
@@ -36,7 +37,7 @@ func main() {
 }
 
 // printVersion prints CLI version information.
-func printVersion(ctx *cli.Context) {
+func printVersion(ctx api.Context) {
 	fmt.Fprintln(ctx.Out(), "dcoscli.version="+version)
 
 	cluster, err := ctx.Cluster()


### PR DESCRIPTION
It also updates a method signature to use the interface instead of the implementation.