### PR TITLE
Auto-install dcos-enterprise-cli during cluster setup

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -185,6 +185,7 @@ func (ctx *Context) Setup(flags *setup.Flags, clusterURL string) (*config.Cluste
 		Logger:        ctx.Logger(),
 		LoginFlow:     ctx.loginFlow(),
 		ConfigManager: ctx.ConfigManager(),
+		PluginManager: ctx.PluginManager(nil),
 	}).Configure(flags, clusterURL)
 }
 

--- a/pkg/cmd/cluster/cluster_setup.go
+++ b/pkg/cmd/cluster/cluster_setup.go
@@ -21,7 +21,6 @@ func newCmdClusterSetup(ctx api.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-
 			return ctx.ConfigManager().Attach(cluster.Config())
 		},
 	}

--- a/pkg/cmd/plugin/plugin_add.go
+++ b/pkg/cmd/plugin/plugin_add.go
@@ -2,12 +2,13 @@ package plugin
 
 import (
 	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-cli/pkg/plugin"
 	"github.com/spf13/cobra"
 )
 
 // newCmdPluginAdd creates the `dcos plugin add` subcommand.
 func newCmdPluginAdd(ctx api.Context) *cobra.Command {
-	var update bool
+	installOpts := &plugin.InstallOpts{}
 	cmd := &cobra.Command{
 		Use:   "add",
 		Short: "Add a CLI plugin",
@@ -17,9 +18,9 @@ func newCmdPluginAdd(ctx api.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return ctx.PluginManager(cluster).Install(args[0], update)
+			return ctx.PluginManager(cluster).Install(args[0], installOpts)
 		},
 	}
-	cmd.Flags().BoolVarP(&update, "update", "u", false, "")
+	cmd.Flags().BoolVarP(&installOpts.Update, "update", "u", false, "")
 	return cmd
 }

--- a/pkg/cosmos/client.go
+++ b/pkg/cosmos/client.go
@@ -1,0 +1,104 @@
+package cosmos
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/url"
+
+	"github.com/dcos/dcos-cli/pkg/httpclient"
+)
+
+// Client is a client for Cosmos.
+type Client struct {
+	http *httpclient.Client
+}
+
+// NewClient creates a new Cosmos client.
+func NewClient(baseClient *httpclient.Client) *Client {
+	return &Client{
+		http: baseClient,
+	}
+}
+
+// PackageInfo contains information about a DC/OS package.
+// It is mirroring the JSON response of the `/package/describe`
+// endpoint for unmarshalling convenience.
+type PackageInfo struct {
+	Package struct {
+		PackagingVersion      string `json:"packagingVersion"`
+		Name                  string `json:"name"`
+		Description           string `json:"description"`
+		Version               string `json:"version"`
+		ReleaseVersion        int    `json:"releaseVersion"`
+		MinDCOSReleaseVersion string `json:"minDcosReleaseVersion"`
+		Framework             bool   `json:"framework"`
+		Maintainer            string `json:"maintainer"`
+		Resource              struct {
+			CLI struct {
+				Plugins map[string]map[string]*Plugin `json:"binaries"`
+			} `json:"cli"`
+		} `json:"resource"`
+	} `json:"package"`
+}
+
+// Plugin represents a CLI plugin resource.
+type Plugin struct {
+	Kind string `json:"kind"`
+	URL  string `json:"url"`
+}
+
+// DescribePackage returns information about the named package.
+func (c *Client) DescribePackage(name string) (*PackageInfo, error) {
+	reqBodyPayload := map[string]string{"packageName": name}
+
+	var reqBody bytes.Buffer
+	if err := json.NewEncoder(&reqBody).Encode(reqBodyPayload); err != nil {
+		return nil, err
+	}
+
+	req, err := c.http.NewRequest("POST", "/package/describe", &reqBody, httpclient.FailOnErrStatus(true))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set(
+		"Content-Type",
+		"application/vnd.dcos.package.describe-request+json;charset=utf-8;version=v1",
+	)
+	req.Header.Set(
+		"Accept",
+		"application/vnd.dcos.package.describe-response+json;charset=utf-8;version=v3",
+	)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	var pkg PackageInfo
+	err = json.NewDecoder(resp.Body).Decode(&pkg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Workaround for a Cosmos bug leading to wrong schemes in plugin resource URLs.
+	// This happens on setups with TLS termination proxies, where Cosmos might rewrite
+	// the scheme to HTTP while it is actually HTTPS. The other way around is also possible.
+	// See https://jira.mesosphere.com/browse/COPS-3052 for more context.
+	//
+	// To prevent this we're rewriting such URLs with the scheme set in `core.dcos_url`.
+	httpClientBaseURL := c.http.BaseURL()
+	for _, plugins := range pkg.Package.Resource.CLI.Plugins {
+		for _, plugin := range plugins {
+			pluginURL, err := url.Parse(plugin.URL)
+			if err != nil {
+				continue
+			}
+			if pluginURL.Hostname() == httpClientBaseURL.Hostname() {
+				pluginURL.Scheme = httpClientBaseURL.Scheme
+				plugin.URL = pluginURL.String()
+			}
+		}
+	}
+	return &pkg, err
+}

--- a/pkg/cosmos/client_test.go
+++ b/pkg/cosmos/client_test.go
@@ -1,0 +1,85 @@
+package cosmos
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dcos/dcos-cli/pkg/httpclient"
+)
+
+func TestPackageDescribe(t *testing.T) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/package/describe", func(w http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "POST", req.Method)
+		assert.Equal(
+			t,
+			"application/vnd.dcos.package.describe-response+json;charset=utf-8;version=v3",
+			req.Header.Get("Accept"),
+		)
+		assert.Equal(
+			t,
+			"application/vnd.dcos.package.describe-request+json;charset=utf-8;version=v1",
+			req.Header.Get("Content-Type"),
+		)
+		payload := map[string]string{}
+		err := json.NewDecoder(req.Body).Decode(&payload)
+		assert.NoError(t, err)
+		assert.Equal(t, "dcos-test-cli", payload["packageName"])
+
+		var pkgInfo PackageInfo
+
+		pkgInfo.Package.Resource.CLI.Plugins = map[string]map[string]*Plugin{
+			"linux": map[string]*Plugin{
+				"x86-64": &Plugin{
+					Kind: "zip",
+					URL:  "https://linux.example.com/dcos-test-cli.zip",
+				},
+			},
+			"darwin": map[string]*Plugin{
+				"x86-64": &Plugin{
+					Kind: "zip",
+					URL:  "http://darwin.example.com/dcos-test-cli.zip",
+				},
+			},
+			// Test case against scheme mismatch between `core.dcos_url` and Cosmos resources.
+			"windows": map[string]*Plugin{
+				"x86-64": &Plugin{
+					Kind: "zip",
+					URL:  "https://" + req.Host + "/dcos-test-cli.zip",
+				},
+			},
+		}
+
+		err = json.NewEncoder(w).Encode(&pkgInfo)
+		assert.NoError(t, err)
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := NewClient(httpclient.New(ts.URL))
+
+	pkgInfo, err := client.DescribePackage("dcos-test-cli")
+	require.NoError(t, err)
+
+	linuxPlugin, ok := pkgInfo.Package.Resource.CLI.Plugins["linux"]["x86-64"]
+	require.True(t, ok)
+	require.Equal(t, "zip", linuxPlugin.Kind)
+	require.Equal(t, "https://linux.example.com/dcos-test-cli.zip", linuxPlugin.URL)
+
+	darwinPlugin, ok := pkgInfo.Package.Resource.CLI.Plugins["darwin"]["x86-64"]
+	require.True(t, ok)
+	require.Equal(t, "zip", darwinPlugin.Kind)
+	require.Equal(t, "http://darwin.example.com/dcos-test-cli.zip", darwinPlugin.URL)
+
+	windowsPlugin, ok := pkgInfo.Package.Resource.CLI.Plugins["windows"]["x86-64"]
+	require.True(t, ok)
+	require.Equal(t, "zip", windowsPlugin.Kind)
+	require.Equal(t, ts.URL+"/dcos-test-cli.zip", windowsPlugin.URL)
+}

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -229,4 +230,16 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		}
 	}
 	return resp, err
+}
+
+// BaseURL returns the HTTP client's base URL.
+func (c *Client) BaseURL() *url.URL {
+	baseURL, err := url.Parse(c.baseURL)
+	if err != nil && c.opts.Logger != nil {
+		// We don't return error-out to keep the method signature clean.
+		// If an http client contains an invalid URL it is broken anyway and
+		// it is not this method responsibility to check this.
+		c.opts.Logger.Debug(err)
+	}
+	return baseURL
 }

--- a/pkg/setup/flags.go
+++ b/pkg/setup/flags.go
@@ -12,6 +12,7 @@ type Flags struct {
 	caBundlePath string
 	name         string
 	noCheck      bool
+	noPlugin     bool
 	insecure     bool
 	loginFlags   *login.Flags
 	fs           afero.Fs
@@ -38,6 +39,12 @@ func (f *Flags) Register(flags *pflag.FlagSet) {
 		"no-check",
 		false,
 		"Do not check CA certficate downloaded from cluster (insecure). Applies to Enterprise DC/OS only.",
+	)
+	flags.BoolVar(
+		&f.noPlugin,
+		"no-plugin",
+		false,
+		"Do not auto-install dcos-core-cli and dcos-enterprise-cli plugins.",
 	)
 	flags.StringVar(
 		&f.caBundlePath,


### PR DESCRIPTION
Unless the --no-plugin flag is passed, `dcos cluster setup` will attempt
to install the dcos-enterprise-cli plugin. The dcos-enterprise-cli
plugin is only installed when the metadata endpoint explicitly specifies
that it is an enterprise variant.

The plugin resources are retrieved through the Cosmos client.

The plugin manager currently only supports installing a ZIP plugin from
the filesystem. Support for remote and bin resources will be added with
the future `dcos plugin add` command.

https://jira.mesosphere.com/browse/DCOS-20502