### PR TITLE
Implement "dcos plugin list"

### DIFF
--- a/pkg/cmd/plugin/plugin.go
+++ b/pkg/cmd/plugin/plugin.go
@@ -13,6 +13,7 @@ func NewCommand(ctx api.Context) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newCmdPluginRemove(ctx),
+		newCmdPluginList(ctx),
 	)
 	return cmd
 }

--- a/pkg/cmd/plugin/plugin_list.go
+++ b/pkg/cmd/plugin/plugin_list.go
@@ -1,0 +1,47 @@
+package plugin
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-cli/pkg/cli"
+	"github.com/spf13/cobra"
+)
+
+// newCmdPluginList creates the `dcos plugin list` subcommand.
+func newCmdPluginList(ctx api.Context) *cobra.Command {
+	var jsonOutput bool
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List CLI plugins",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cluster, err := ctx.Cluster()
+			if err != nil {
+				return err
+			}
+
+			plugins := ctx.PluginManager(cluster.SubcommandsDir()).Plugins()
+
+			if jsonOutput {
+				enc := json.NewEncoder(ctx.Out())
+				enc.SetIndent("", "    ")
+				return enc.Encode(plugins)
+			}
+
+			table := cli.NewTable(ctx.Out(), []string{"NAME", "COMMANDS"})
+			for _, plugin := range plugins {
+				var commands []string
+				for _, command := range plugin.Commands {
+					commands = append(commands, command.Name)
+				}
+				table.Append([]string{plugin.Name, strings.Join(commands, " ")})
+			}
+			table.Render()
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Print plugins in JSON format.")
+	return cmd
+}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -1,14 +1,16 @@
 package plugin
 
-// Plugin defines an external plugin and its associated data.
+// Plugin is the structure representation of a `plugin.toml file.
+// It also contains JSON tags for the `dcos plugin list --json` command.
 type Plugin struct {
-	Name     string     `toml:"name"`
-	Commands []*Command `toml:"commands"`
+	Name     string     `toml:"name" json:"name"`
+	Commands []*Command `toml:"commands" json:"commands"`
 }
 
-// Command is a Command living within a plugin binary.
+// Command represents each item defined in the `commands` key of the `plugin.toml` file.
+// It also contains JSON tags for the `dcos plugin list --json` command.
 type Command struct {
-	Name        string `toml:"name"`
-	Path        string `toml:"path"`
-	Description string `toml:"description"`
+	Name        string `toml:"name" json:"name"`
+	Path        string `toml:"path" json:"path"`
+	Description string `toml:"description" json:"description"`
 }


### PR DESCRIPTION
It supports table and JSON outputs.

TABLE:

    $ dcos plugin list
             NAME                 COMMANDS
      dcos-enterprise-cli  backup license security

JSON:
```` json
  $ dcos plugin list --json
  [
      {
          "name": "dcos-enterprise-cli",
          "commands": [
              {
                  "name": "backup",
                  "path": "/home/bamarni/.dcos/clusters/a95bf067-2e6b-4468-ba86-0d177b226950/subcommands/dcos-enterprise-cli/env/bin/dcos-backup",
                  "description": "Access DC/OS backup functionality"
              },
              {
                  "name": "license",
                  "path": "/home/bamarni/.dcos/clusters/a95bf067-2e6b-4468-ba86-0d177b226950/subcommands/dcos-enterprise-cli/env/bin/dcos-license",
                  "description": "Manage your DC/OS licenses"
              },
              {
                  "name": "security",
                  "path": "/home/bamarni/.dcos/clusters/a95bf067-2e6b-4468-ba86-0d177b226950/subcommands/dcos-enterprise-cli/env/bin/dcos-security",
                  "description": "DC/OS security related commands"
              }
          ]
      }
  ]
````

https://jira.mesosphere.com/browse/DCOS_OSS-3853