### PR TITLE
`dcos auth login` changes after the sec team review

### DIFF
--- a/pkg/login/flags.go
+++ b/pkg/login/flags.go
@@ -84,6 +84,12 @@ func (f *Flags) Resolve() error {
 		f.password = string(rawPassword)
 	}
 
+	if f.username == "" {
+		if username, ok := f.envLookup("DCOS_USERNAME"); ok {
+			f.username = username
+		}
+	}
+
 	if f.passwordEnv != "" {
 		if password, ok := f.envLookup(f.passwordEnv); ok {
 			f.password = password

--- a/pkg/login/flags.go
+++ b/pkg/login/flags.go
@@ -3,7 +3,6 @@ package login
 import (
 	"bytes"
 	"crypto/rsa"
-	"fmt"
 	"unicode"
 
 	"github.com/dcos/dcos-cli/pkg/fsutil"
@@ -19,7 +18,6 @@ type Flags struct {
 	providerID     string
 	username       string
 	password       string
-	passwordEnv    string
 	passwordFile   string
 	privateKey     *rsa.PrivateKey
 	privateKeyFile string
@@ -54,12 +52,6 @@ func (f *Flags) Register(flags *pflag.FlagSet) {
 		"Specify the password on the command line (insecure).",
 	)
 	flags.StringVar(
-		&f.passwordEnv,
-		"password-env",
-		"",
-		"Specify an environment variable name that contains the password.",
-	)
-	flags.StringVar(
 		&f.passwordFile,
 		"password-file",
 		"",
@@ -90,11 +82,9 @@ func (f *Flags) Resolve() error {
 		}
 	}
 
-	if f.passwordEnv != "" {
-		if password, ok := f.envLookup(f.passwordEnv); ok {
+	if f.password == "" {
+		if password, ok := f.envLookup("DCOS_PASSWORD"); ok {
 			f.password = password
-		} else {
-			return fmt.Errorf("couldn't read password from '%s' env var", f.passwordEnv)
 		}
 	}
 

--- a/pkg/login/flags_test.go
+++ b/pkg/login/flags_test.go
@@ -1,0 +1,23 @@
+package login
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/spf13/afero"
+)
+
+func TestResolveUsernameFromEnvVar(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	envLookup := func(key string) (string, bool) {
+		if key == "DCOS_USERNAME" {
+			return "alice", true
+		}
+		return "", false
+	}
+	flags := NewFlags(fs, envLookup)
+	require.NoError(t, flags.Resolve())
+	require.Equal(t, "alice", flags.username)
+}

--- a/pkg/login/flags_test.go
+++ b/pkg/login/flags_test.go
@@ -21,3 +21,51 @@ func TestResolveUsernameFromEnvVar(t *testing.T) {
 	require.NoError(t, flags.Resolve())
 	require.Equal(t, "alice", flags.username)
 }
+
+func TestResolvePasswordFromFile(t *testing.T) {
+	fixtures := []struct {
+		passwordFileContents string
+		passwordFilePerm     os.FileMode
+		expectedPassword     string
+	}{
+		{"123456", 0400, "123456"},
+		{"123456\n", 0600, "123456"},
+		{"123456", 0644, ""},
+	}
+
+	for _, fixture := range fixtures {
+		fs := afero.NewMemMapFs()
+		err := afero.WriteFile(
+			fs,
+			"/password.txt",
+			[]byte(fixture.passwordFileContents),
+			fixture.passwordFilePerm,
+		)
+		require.NoError(t, err)
+
+		envLookup := func(key string) (string, bool) {
+			return "", false
+		}
+		flags := NewFlags(fs, envLookup)
+		flags.passwordFile = "/password.txt"
+		err = flags.Resolve()
+		if fixture.expectedPassword != "" {
+			require.Equal(t, fixture.expectedPassword, flags.password)
+		} else {
+			require.Error(t, err)
+		}
+	}
+}
+
+func TestResolvePasswordFromEnvVar(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	envLookup := func(key string) (string, bool) {
+		if key == "DCOS_PASSWORD" {
+			return "123456", true
+		}
+		return "", false
+	}
+	flags := NewFlags(fs, envLookup)
+	require.NoError(t, flags.Resolve())
+	require.Equal(t, "123456", flags.password)
+}


### PR DESCRIPTION
- Support reading username from DCOS_USERNAME env var
- Remove the --password-env login flag

https://jira.mesosphere.com/browse/DCOS_OSS-3578