### PR TITLE
Add argument names in help menus

### DIFF
--- a/pkg/cmd/auth/auth_listproviders.go
+++ b/pkg/cmd/auth/auth_listproviders.go
@@ -14,7 +14,7 @@ import (
 func newCmdAuthListProviders(ctx api.Context) *cobra.Command {
 	var jsonOutput bool
 	cmd := &cobra.Command{
-		Use:   "list-providers",
+		Use:   "list-providers <url>",
 		Short: "List available login providers for a cluster",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/cluster/cluster_attach.go
+++ b/pkg/cmd/cluster/cluster_attach.go
@@ -13,7 +13,7 @@ import (
 // newCmdClusterAttach ataches the CLI to a cluster.
 func newCmdClusterAttach(ctx api.Context) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "attach",
+		Use:   "attach <cluster>",
 		Short: "Attach the CLI to a cluster",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/cluster/cluster_link.go
+++ b/pkg/cmd/cluster/cluster_link.go
@@ -15,7 +15,7 @@ import (
 func newCmdClusterLink(ctx api.Context) *cobra.Command {
 	setupFlags := setup.NewFlags(ctx.Fs(), ctx.EnvLookup)
 	cmd := &cobra.Command{
-		Use:   "link",
+		Use:   "link <cluster>",
 		Short: "Link the current cluster to another one",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/cluster/cluster_remove.go
+++ b/pkg/cmd/cluster/cluster_remove.go
@@ -12,7 +12,7 @@ import (
 func newCmdClusterRemove(ctx api.Context) *cobra.Command {
 	var removeAll bool
 	cmd := &cobra.Command{
-		Use:   "remove",
+		Use:   "remove <cluster>",
 		Short: "Remove a configured cluster from the CLI",
 		Args:  cobra.MaximumNArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/cluster/cluster_rename.go
+++ b/pkg/cmd/cluster/cluster_rename.go
@@ -8,7 +8,7 @@ import (
 // newCmdClusterRename renames a cluster.
 func newCmdClusterRename(ctx api.Context) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "rename",
+		Use:   "rename <cluster> <name>",
 		Short: "Rename a configured cluster",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/cluster/cluster_setup.go
+++ b/pkg/cmd/cluster/cluster_setup.go
@@ -11,7 +11,7 @@ import (
 func newCmdClusterSetup(ctx api.Context) *cobra.Command {
 	setupFlags := setup.NewFlags(ctx.Fs(), ctx.EnvLookup)
 	cmd := &cobra.Command{
-		Use:   "setup",
+		Use:   "setup <url>",
 		Short: "Set up the CLI to communicate with a cluster",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/cluster/cluster_unlink.go
+++ b/pkg/cmd/cluster/cluster_unlink.go
@@ -10,7 +10,7 @@ import (
 // newCmdClusterUnlink ublinks the attached cluster to a linked cluster.
 func newCmdClusterUnlink(ctx api.Context) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "unlink",
+		Use:   "unlink <cluster>",
 		Short: "Unlink the current cluster with one of its linked clusters",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/config/config_set.go
+++ b/pkg/cmd/config/config_set.go
@@ -8,7 +8,7 @@ import (
 // newCmdConfigSet creates the `dcos config set` subcommand.
 func newCmdConfigSet(ctx api.Context) *cobra.Command {
 	return &cobra.Command{
-		Use:   "set",
+		Use:   "set <name> <value>",
 		Short: "Add or set a property in the configuration file used for the current cluster",
 		Long:  "The properties that can be set are: core.dcos_url, core.dcos_acs_token, core.ssl_verify, core.timeout, core.ssh_user, core_ssh_proxy_ip, core.pagination, core.reporting, core.mesos_master_url, core_prompt_login",
 		Args:  cobra.ExactArgs(2),

--- a/pkg/cmd/config/config_show.go
+++ b/pkg/cmd/config/config_show.go
@@ -10,7 +10,7 @@ import (
 // newCmdConfigShow creates the `dcos config show` subcommand.
 func newCmdConfigShow(ctx api.Context) *cobra.Command {
 	return &cobra.Command{
-		Use:   "show",
+		Use:   "show <name>",
 		Short: "Print the configuration file related to the current cluster",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/config/config_unset.go
+++ b/pkg/cmd/config/config_unset.go
@@ -8,7 +8,7 @@ import (
 // newCmdConfigUnset creates the `dcos config unset` subcommand.
 func newCmdConfigUnset(ctx api.Context) *cobra.Command {
 	return &cobra.Command{
-		Use:   "unset",
+		Use:   "unset <name>",
 		Short: "Remove a property from the configuration file used for the current cluster",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/plugin/plugin_add.go
+++ b/pkg/cmd/plugin/plugin_add.go
@@ -9,7 +9,7 @@ import (
 func newCmdPluginAdd(ctx api.Context) *cobra.Command {
 	var update bool
 	cmd := &cobra.Command{
-		Use:   "add",
+		Use:   "add <resource>",
 		Short: "Add a CLI plugin",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/plugin/plugin_remove.go
+++ b/pkg/cmd/plugin/plugin_remove.go
@@ -8,7 +8,7 @@ import (
 // newCmdPluginRemove creates the `dcos plugin remove` subcommand.
 func newCmdPluginRemove(ctx api.Context) *cobra.Command {
 	return &cobra.Command{
-		Use:   "remove",
+		Use:   "remove <plugin>",
 		Short: "Remove a CLI plugin",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Current usage outputs :
```
Usage:
  dcos cluster setup [flags]
```
This changes them to print accepted argument names too :
```
Usage:
  dcos cluster setup <url> [flags]
```