### PR TITLE
Add an --unavailable option to "dcos cluster remove" 

### DIFF
--- a/pkg/cluster/lister/filters.go
+++ b/pkg/cluster/lister/filters.go
@@ -1,0 +1,32 @@
+package lister
+
+// Filters are filtering conditions for cluster lists.
+type Filters struct {
+	AttachedOnly bool
+	Status       string
+	Linked       bool
+}
+
+// Filter is a functional option for list filters.
+type Filter func(filters *Filters)
+
+// AttachedOnly filters cluster items to only keep the current one.
+func AttachedOnly() Filter {
+	return func(filters *Filters) {
+		filters.AttachedOnly = true
+	}
+}
+
+// Status filters cluster items based on the Status field.
+func Status(status string) Filter {
+	return func(filters *Filters) {
+		filters.Status = status
+	}
+}
+
+// Linked indicates that linked clusters should be added to the list.
+func Linked() Filter {
+	return func(filters *Filters) {
+		filters.Linked = true
+	}
+}

--- a/pkg/cluster/lister/lister.go
+++ b/pkg/cluster/lister/lister.go
@@ -12,6 +12,17 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	// StatusAvailable refers to a reachable cluster.
+	StatusAvailable = "AVAILABLE"
+
+	// StatusUnavailable refers to an unreachable cluster.
+	StatusUnavailable = "UNAVAILABLE"
+
+	// StatusUnconfigured refers to an unconfigured cluster (a linked cluster).
+	StatusUnconfigured = "UNCONFIGURED"
+)
+
 // Item represents a cluster item in the list.
 type Item struct {
 	Attached bool   `json:"attached"`
@@ -95,7 +106,7 @@ func (l *Lister) List(filters ...Filter) (items []*Item) {
 				ID:      cluster.ID(),
 				Name:    cluster.Name(),
 				URL:     cluster.URL(),
-				Status:  "UNAVAILABLE",
+				Status:  StatusUnavailable,
 				Version: "UNKNOWN",
 				cluster: cluster,
 			}
@@ -110,12 +121,12 @@ func (l *Lister) List(filters ...Filter) (items []*Item) {
 			httpClient := l.httpClient(cluster)
 			version, err := dcos.NewClient(httpClient).Version()
 			if err == nil {
-				item.Status = "AVAILABLE"
+				item.Status = StatusAvailable
 				item.Version = version.Version
 			}
 
 			if cluster.Config().Path() == "" {
-				item.Status = "UNCONFIGURED"
+				item.Status = StatusUnconfigured
 			}
 
 			if listFilters.Status != "" && item.Status != listFilters.Status {

--- a/pkg/cluster/lister/lister_test.go
+++ b/pkg/cluster/lister/lister_test.go
@@ -69,29 +69,29 @@ func TestList(t *testing.T) {
 	require.Len(t, items, 3)
 
 	require.Equal(t, currentCluster.URL(), items[0].URL)
-	require.Equal(t, "AVAILABLE", items[0].Status)
+	require.Equal(t, StatusAvailable, items[0].Status)
 	require.Equal(t, "1234-56789-01234", items[0].ID)
 	require.Equal(t, "current-cluster", items[0].Name)
 	require.Equal(t, "1.12", items[0].Version)
 
 	require.Equal(t, downCluster.URL(), items[1].URL)
-	require.Equal(t, "UNAVAILABLE", items[1].Status)
+	require.Equal(t, StatusUnavailable, items[1].Status)
 	require.Equal(t, "3234-56789-01234", items[1].ID)
 	require.Equal(t, "invalid-cluster", items[1].Name)
 	require.Equal(t, "UNKNOWN", items[1].Version)
 
 	require.Equal(t, otherCluster.URL(), items[2].URL)
-	require.Equal(t, "AVAILABLE", items[2].Status)
+	require.Equal(t, StatusAvailable, items[2].Status)
 	require.Equal(t, "2234-56789-01234", items[2].ID)
 	require.Equal(t, "other-cluster", items[2].Name)
 	require.Equal(t, "1.18", items[2].Version)
 
 	// Test the Status filter.
-	items = lister.List(Status("UNAVAILABLE"))
+	items = lister.List(Status(StatusUnavailable))
 	require.Len(t, items, 1)
 
 	require.Equal(t, downCluster.URL(), items[0].URL)
-	require.Equal(t, "UNAVAILABLE", items[0].Status)
+	require.Equal(t, StatusUnavailable, items[0].Status)
 	require.Equal(t, "3234-56789-01234", items[0].ID)
 	require.Equal(t, "invalid-cluster", items[0].Name)
 	require.Equal(t, "UNKNOWN", items[0].Version)
@@ -160,6 +160,6 @@ func TestListLegacyConfigWithLink(t *testing.T) {
 	require.Equal(t, "22c85511-4f0c-42e7-80d2-c697796e47f1", items[0].ID)
 	require.Equal(t, "Zelda", items[0].Name)
 	require.Equal(t, linkTS.URL, items[0].URL)
-	require.Equal(t, "UNCONFIGURED", items[0].Status)
+	require.Equal(t, StatusUnconfigured, items[0].Status)
 	require.Equal(t, "1.15", items[0].Version)
 }

--- a/pkg/cluster/lister/lister_test.go
+++ b/pkg/cluster/lister/lister_test.go
@@ -24,10 +24,10 @@ func TestEmptyList(t *testing.T) {
 		EnvLookup: env.EnvLookup,
 	}), logger)
 
-	items := lister.List(false)
+	items := lister.List()
 	require.Len(t, items, 0)
 
-	items = lister.List(true)
+	items = lister.List(AttachedOnly())
 	require.Len(t, items, 0)
 }
 
@@ -65,7 +65,7 @@ func TestList(t *testing.T) {
 		EnvLookup: env.EnvLookup,
 	}), logger)
 
-	items := lister.List(false)
+	items := lister.List()
 	require.Len(t, items, 3)
 
 	require.Equal(t, currentCluster.URL(), items[0].URL)
@@ -85,6 +85,16 @@ func TestList(t *testing.T) {
 	require.Equal(t, "2234-56789-01234", items[2].ID)
 	require.Equal(t, "other-cluster", items[2].Name)
 	require.Equal(t, "1.18", items[2].Version)
+
+	// Test the Status filter.
+	items = lister.List(Status("UNAVAILABLE"))
+	require.Len(t, items, 1)
+
+	require.Equal(t, downCluster.URL(), items[0].URL)
+	require.Equal(t, "UNAVAILABLE", items[0].Status)
+	require.Equal(t, "3234-56789-01234", items[0].ID)
+	require.Equal(t, "invalid-cluster", items[0].Name)
+	require.Equal(t, "UNKNOWN", items[0].Version)
 }
 
 func TestListIgnoresLegacyConfig(t *testing.T) {
@@ -105,8 +115,8 @@ func TestListIgnoresLegacyConfig(t *testing.T) {
 		Fs:        env.Fs,
 		EnvLookup: env.EnvLookup,
 	}), logger)
-	require.Len(t, lister.List(true), 0)
-	require.Len(t, lister.List(false), 0)
+	require.Len(t, lister.List(AttachedOnly()), 0)
+	require.Len(t, lister.List(), 0)
 }
 
 func TestListLegacyConfigWithLink(t *testing.T) {
@@ -143,9 +153,9 @@ func TestListLegacyConfigWithLink(t *testing.T) {
 		EnvLookup: env.EnvLookup,
 	}), logger)
 
-	require.Len(t, lister.List(true), 0)
+	require.Len(t, lister.List(AttachedOnly()), 0)
 
-	items := lister.List(false)
+	items := lister.List(Linked())
 	require.Len(t, items, 1)
 	require.Equal(t, "22c85511-4f0c-42e7-80d2-c697796e47f1", items[0].ID)
 	require.Equal(t, "Zelda", items[0].Name)

--- a/pkg/cmd/cluster/cluster_list.go
+++ b/pkg/cmd/cluster/cluster_list.go
@@ -19,7 +19,14 @@ func newCmdClusterList(ctx api.Context) *cobra.Command {
 		Short: "List the clusters configured and the ones linked to the current cluster",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			items := lister.New(ctx.ConfigManager(), ctx.Logger()).List(attachedOnly)
+			var filters []lister.Filter
+			if attachedOnly {
+				filters = append(filters, lister.AttachedOnly())
+			} else {
+				filters = append(filters, lister.Linked())
+			}
+
+			items := lister.New(ctx.ConfigManager(), ctx.Logger()).List(filters...)
 			if attachedOnly && len(items) == 0 {
 				return errors.New("no cluster is attached. Please run `dcos cluster attach <cluster-name>`")
 			}

--- a/pkg/cmd/cluster/cluster_remove.go
+++ b/pkg/cmd/cluster/cluster_remove.go
@@ -39,7 +39,7 @@ func newCmdClusterRemove(ctx api.Context) *cobra.Command {
 
 			var filters []lister.Filter
 			if removeUnavailable {
-				filters = append(filters, lister.Status("UNAVAILABLE"))
+				filters = append(filters, lister.Status(lister.StatusUnavailable))
 			}
 
 			items := lister.New(ctx.ConfigManager(), ctx.Logger()).List(filters...)


### PR DESCRIPTION
It allows to remove unreachable clusters. This is useful as a clean-up
command, to get rid of outdated clusters still configured in the CLI.

https://jira.mesosphere.com/browse/DCOS_OSS-3881
