### PR TITLE
Don't return a nil slice when listing clusters

### DIFF
--- a/pkg/cluster/lister/lister.go
+++ b/pkg/cluster/lister/lister.go
@@ -61,7 +61,9 @@ func New(configManager *config.Manager, logger *logrus.Logger) *Lister {
 }
 
 // List retrieves all known clusters.
-func (l *Lister) List(filters ...Filter) (items []*Item) {
+func (l *Lister) List(filters ...Filter) []*Item {
+	items := []*Item{}
+
 	listFilters := Filters{}
 	for _, filter := range filters {
 		filter(&listFilters)
@@ -147,7 +149,7 @@ func (l *Lister) List(filters ...Filter) (items []*Item) {
 		}(cluster)
 	}
 	wg.Wait()
-	return
+	return items
 }
 
 func (l *Lister) httpClient(cluster *config.Cluster) *httpclient.Client {

--- a/pkg/cluster/lister/lister_test.go
+++ b/pkg/cluster/lister/lister_test.go
@@ -25,9 +25,11 @@ func TestEmptyList(t *testing.T) {
 	}), logger)
 
 	items := lister.List()
+	require.NotNil(t, items)
 	require.Len(t, items, 0)
 
 	items = lister.List(AttachedOnly())
+	require.NotNil(t, items)
 	require.Len(t, items, 0)
 }
 


### PR DESCRIPTION
Otherwise it causes the `dcos cluster list --json` command to print `null`.

From https://github.com/golang/go/wiki/CodeReviewComments#declaring-empty-slices :

>  Note that there are limited circumstances where a non-nil but
  zero-length slice is preferred, such as when encoding JSON objects (a
  nil slice encodes to null, while []string{} encodes to the JSON array
  []).

https://jira.mesosphere.com/browse/DCOS_OSS-3934