### PR TITLE
Setup integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ pydoc/_build/
 .tox/
 .coverage
 .cache
+.pytest_cache
 
 *.pyc
 bundle.zip

--- a/ci/integration-tests.groovy
+++ b/ci/integration-tests.groovy
@@ -1,0 +1,128 @@
+#!/usr/bin/env groovy
+
+pipeline {
+  agent none
+
+  options {
+    timeout(time: 6, unit: 'HOURS')
+  }
+
+  stages {
+    stage("Build binaries") {
+      agent { label 'mesos-ubuntu' }
+
+      steps {
+          sh 'make linux darwin windows'
+          stash includes: 'build/linux/**', name: 'dcos-linux'
+          stash includes: 'build/darwin/**', name: 'dcos-darwin'
+          stash includes: 'build/windows/**', name: 'dcos-windows'
+      }
+    }
+
+    stage("Launch DC/OS cluster") {
+      agent { label 'py36' }
+
+      steps {
+        withCredentials([
+          [$class: 'AmazonWebServicesCredentialsBinding',
+          credentialsId: 'a20fbd60-2528-4e00-9175-ebe2287906cf',
+          accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+          secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
+          [$class: 'StringBinding',
+          credentialsId: '0b513aad-e0e0-4a82-95f4-309a80a02ff9',
+          variable: 'DCOS_TEST_INSTALLER_URL'],
+          [$class: 'StringBinding',
+          credentialsId: 'ca159ad3-7323-4564-818c-46a8f03e1389',
+          variable: 'DCOS_TEST_LICENSE']
+        ]) {
+            sh '''
+              bash -exc " \
+                cd tests; \
+                python3 -m venv env; \
+                source env/bin/activate; \
+                pip install -r requirements.txt; \
+                flake8 integration; \
+                ./launch_cluster.py ${DCOS_TEST_INSTALLER_URL}"
+            '''
+            stash includes: 'tests/test_cluster.env.sh', name: 'test-cluster'
+        }
+      }
+    }
+
+    stage('Run integration tests') {
+      parallel {
+        stage("Run Linux integration tests") {
+          agent { label 'py36' }
+
+          steps {
+              unstash 'test-cluster'
+              unstash 'dcos-linux'
+
+              sh '''
+                bash -exc " \
+                  PATH=$PWD/build/linux:$PATH; \
+                  cd tests; \
+                  python3 -m venv env; \
+                  source env/bin/activate; \
+                  source test_cluster.env.sh; \
+                  pip install -U pip; \
+                  pip install -r requirements.txt; \
+                  pytest integration"
+              '''
+          }
+        }
+
+        stage("Run macOS integration tests") {
+          agent { label 'mac-hh-yosemite' }
+
+          steps {
+              unstash 'test-cluster'
+              unstash 'dcos-darwin'
+
+              sh '''
+                bash -exc " \
+                  export LC_ALL=en_US.UTF-8; \
+                  export PYTHONIOENCODING=utf-8; \
+                  PATH=$PWD/build/darwin:$PATH; \
+                  cd tests; \
+                  python3 -m venv env; \
+                  source env/bin/activate; \
+                  source test_cluster.env.sh; \
+                  pip install -U pip; \
+                  pip install -r requirements.txt; \
+                  pytest integration"
+              '''
+          }
+        }
+
+        stage("Run Windows integration tests") {
+          agent {
+            node {
+              label 'windows'
+              customWorkspace 'C:\\windows\\workspace'
+            }
+          }
+
+          steps {
+              unstash 'test-cluster'
+              unstash 'dcos-windows'
+
+              bat '''
+                bash -exc " \
+                  export PYTHONIOENCODING=utf-8; \
+                  bash -c "rm -rf ${HOME}/.dcos"; \
+                  export DCOS_DIR=${HOME}/.dcos; \
+                  PATH=$PWD/build/windows:$PATH; \
+                  cd tests; \
+                  source test_cluster.env.sh; \
+                  python -m venv env; \
+                  env/Scripts/python -m pip install -U pip; \
+                  env/Scripts/pip install -r requirements.txt; \
+                  env/Scripts/pytest -vv integration"
+              '''
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/integration/.flake8
+++ b/tests/integration/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+ignore = E501, F811

--- a/tests/integration/common.py
+++ b/tests/integration/common.py
@@ -1,0 +1,114 @@
+import json
+import os
+import subprocess
+import sys
+import uuid
+
+import pytest
+
+
+def exec_cmd(cmd, env=None, stdin=None, timeout=None):
+    """Execute CLI command
+
+    :param cmd: Program and arguments
+    :type cmd: [str]
+    :param env: Environment variables
+    :type env: dict | None
+    :param stdin: File to use for stdin
+    :type stdin: file
+    :param timeout: The timeout for the process to terminate.
+    :type timeout: int
+    :raises: subprocess.TimeoutExpired when the timeout is reached
+             before the process finished.
+    :returns: A tuple with the returncode, stdout and stderr
+    :rtype: (int, bytes, bytes)
+    """
+
+    print('CMD: {!r}'.format(cmd))
+
+    process = subprocess.Popen(
+        cmd,
+        stdin=stdin,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env)
+
+    try:
+        streams = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        # The child process is not killed if the timeout expires, so in order
+        # to cleanup properly a well-behaved application should kill the child
+        # process and finish communication.
+        # https://docs.python.org/3.5/library/subprocess.html#subprocess.Popen.communicate
+        process.kill()
+        stdout, stderr = process.communicate()
+        print('STDOUT: {}'.format(stdout.decode('utf-8')))
+        print('STDERR: {}'.format(stderr.decode('utf-8')))
+        raise
+
+    # This is needed to get rid of '\r' from Windows's lines endings.
+    stdout, stderr = [stream.replace(b'\r', b'').decode('utf-8') for stream in streams]
+
+    # We should always print the stdout and stderr
+    print('STDOUT: {}'.format(stdout))
+    print('STDERR: {}'.format(stderr))
+
+    return (process.returncode, stdout, stderr)
+
+
+@pytest.fixture()
+def default_cluster():
+    cluster = _setup_cluster('DEFAULT')
+
+    yield cluster
+
+    code, _, _ = exec_cmd(['dcos', 'cluster', 'remove', cluster['name']])
+    assert code == 0
+
+
+def _setup_cluster(name, with_plugins=True):
+    cluster = {
+        'variant': os.environ.get('DCOS_TEST_' + name + '_CLUSTER_VARIANT'),
+        'username': os.environ.get('DCOS_TEST_' + name + '_CLUSTER_USERNAME'),
+        'password': os.environ.get('DCOS_TEST_' + name + '_CLUSTER_PASSWORD'),
+        'name': 'test_cluster_' + str(uuid.uuid4()),
+    }
+
+    cmd = 'dcos cluster setup --name={} --username={} --password={} --no-plugin http://{}'.format(
+        cluster['name'],
+        cluster['username'],
+        cluster['password'],
+        os.environ.get('DCOS_TEST_' + name + '_CLUSTER_HOST'))
+
+    code, _, _ = exec_cmd(cmd.split(' '))
+    assert code == 0
+
+    if with_plugins:
+        # For now we install default plugins manually, this can be changed once universe packages are released.
+        plugins = {
+            'linux': [
+                'https://downloads.dcos.io/cli/plugins/dcos-core-cli/1.12/linux/x86-64/dcos-core-cli.zip',
+                'https://downloads.mesosphere.io/cli/binaries/linux/x86-64/1.4.5/61d301f571fe26883b5122d567ac4b79bae7febbd2090c81b6cdda523659eb43/dcos-enterprise-cli',
+            ],
+            'darwin': [
+                'https://downloads.dcos.io/cli/plugins/dcos-core-cli/1.12/darwin/x86-64/dcos-core-cli.zip',
+                'https://downloads.mesosphere.io/cli/binaries/darwin/x86-64/1.4.5/d0d160a3f1357e4c22792c3ba27e115f5eb7acb7a3c70ccb6f2bc6358e5e1e66/dcos-enterprise-cli',
+            ],
+            'win32': [
+                'https://downloads.dcos.io/cli/plugins/dcos-core-cli/1.12/windows/x86-64/dcos-core-cli.zip',
+                'https://downloads.mesosphere.io/cli/binaries/windows/x86-64/1.4.5/f5a58c636c8c3bb8e146958c7d4d06fcf1ca395757e49ffabb2ef04150e9ece9/dcos-enterprise-cli',
+            ],
+        }
+        for plugin in plugins[sys.platform]:
+            code, _, _ = exec_cmd(['dcos', 'plugin', 'add', plugin])
+            assert code == 0
+
+    code, out, _ = exec_cmd(['dcos', 'cluster', 'list', '--json', '--attached'])
+    clusters = json.loads(out)
+    assert len(clusters) == 1
+    assert clusters[0]['name'] == cluster['name']
+
+    cluster['dcos_url'] = clusters[0]['url']
+    cluster['version'] = clusters[0]['version']
+
+    return cluster

--- a/tests/integration/test_cluster.py
+++ b/tests/integration/test_cluster.py
@@ -1,0 +1,39 @@
+import json
+
+from .common import exec_cmd, default_cluster  # noqa: F401
+
+
+def test_cluster_list(default_cluster):
+    code, out, err = exec_cmd(['dcos', 'cluster', 'list'])
+    assert code == 0
+    assert err == ''
+
+    lines = out.splitlines()
+    assert len(lines) == 2
+
+    # heading
+    assert lines[0].split() == ['NAME', 'ID', 'STATUS', 'VERSION', 'URL']
+
+    # cluster item
+    cluster_item = lines[1].split()
+    assert cluster_item[0] == '*'
+    assert cluster_item[3] == 'AVAILABLE'
+    assert cluster_item[5] == default_cluster['dcos_url']
+
+
+def test_cluster_list_json(default_cluster):
+    code, out, err = exec_cmd(['dcos', 'cluster', 'list', '--json'])
+    assert code == 0
+    assert err == ''
+
+    out = json.loads(out)
+    assert len(out) == 1
+    assert out[0]['status'] == 'AVAILABLE'
+    assert out[0]['url'] == default_cluster['dcos_url']
+
+
+def test_empty_cluster_list():
+    code, out, err = exec_cmd(['dcos', 'cluster', 'list', '--json'])
+    assert code == 0
+    assert err == ''
+    assert out == '[]\n'

--- a/tests/integration/test_help.py
+++ b/tests/integration/test_help.py
@@ -1,0 +1,81 @@
+from .common import exec_cmd, default_cluster  # noqa: F401
+
+
+def test_dcos_help():
+    code, out, err = exec_cmd(['dcos'])
+    assert code == 0
+    assert err == ''
+    assert out == '''Usage:
+  dcos [command]
+
+Commands:
+  auth
+      Authenticate to DC/OS cluster
+  cluster
+      Manage your DC/OS clusters
+  config
+      Manage the DC/OS configuration file
+  help
+      Help about any command
+  plugin
+      Manage CLI plugins
+
+Options:
+  --version
+      Print version information
+  -v, -vv
+      Output verbosity (verbose or very verbose)
+  -h, --help
+      Show usage help
+
+Use "dcos [command] --help" for more information about a command.
+'''
+
+
+def test_dcos_help_with_default_plugins(default_cluster):
+    code, out, err = exec_cmd(['dcos'])
+    assert code == 0
+    assert err == ''
+    assert out == '''Usage:
+  dcos [command]
+
+Commands:
+  auth
+      Authenticate to DC/OS cluster
+  backup
+      Access DC/OS backup functionality
+  cluster
+      Manage your DC/OS clusters
+  config
+      Manage the DC/OS configuration file
+  help
+      Help about any command
+  job
+      Deploy and manage jobs in DC/OS
+  license
+      Manage your DC/OS licenses
+  marathon
+      Deploy and manage applications to DC/OS
+  node
+      View DC/OS node information
+  package
+      Install and manage DC/OS software packages
+  plugin
+      Manage CLI plugins
+  security
+      DC/OS security related commands
+  service
+      Manage DC/OS services
+  task
+      Manage DC/OS tasks
+
+Options:
+  --version
+      Print version information
+  -v, -vv
+      Output verbosity (verbose or very verbose)
+  -h, --help
+      Show usage help
+
+Use "dcos [command] --help" for more information about a command.
+'''

--- a/tests/integration/test_plugin.py
+++ b/tests/integration/test_plugin.py
@@ -1,0 +1,21 @@
+from .common import exec_cmd, default_cluster  # noqa: F401
+
+
+def test_plugin_list(default_cluster):
+    code, out, err = exec_cmd(['dcos', 'plugin', 'list'])
+    assert code == 0
+    assert err == ''
+
+    lines = out.splitlines()
+    assert len(lines) == 3
+
+    # heading
+    assert lines[0].split() == ['NAME', 'COMMANDS']
+
+    dcos_core_cli = lines[1].split()
+    assert dcos_core_cli[0] == 'dcos-core-cli'
+    assert dcos_core_cli[1:] == ['job', 'marathon', 'node', 'package', 'service', 'task']
+
+    dcos_enterprise_cli = lines[2].split()
+    assert dcos_enterprise_cli[0] == 'dcos-enterprise-cli'
+    assert dcos_enterprise_cli[1:] == ['backup', 'license', 'security']

--- a/tests/launch_cluster.py
+++ b/tests/launch_cluster.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+import os
+import random
+import string
+import sys
+import time
+
+from dcos_e2e.backends import AWS
+from dcos_e2e.cluster import Cluster
+from passlib.hash import sha512_crypt
+
+if len(sys.argv) != 2:
+    print("Please specify the installer URL as argument.", file=sys.stderr)
+    sys.exit(1)
+
+test_license = os.environ.get('DCOS_TEST_LICENSE')
+if not test_license:
+    print("Please specify a license in $DCOS_TEST_LICENSE.", file=sys.stderr)
+    sys.exit(1)
+
+cluster_backend = AWS()
+cluster = Cluster(cluster_backend=cluster_backend, agents=0, public_agents=0)
+
+username = 'testuser'
+password = ''.join(random.choice(string.ascii_letters + string.digits) for i in range(12))
+
+extra_config = {
+    'superuser_username': username,
+    'superuser_password_hash': sha512_crypt.hash(password),
+    'fault_domain_enabled': False,
+    'license_key_contents': test_license,
+}
+
+dcos_config = {**cluster.base_config, **extra_config}
+
+cluster.install_dcos_from_url(
+    build_artifact=sys.argv[1],
+    dcos_config=dcos_config,
+    log_output_live=True,
+    ip_detect_path=cluster_backend.ip_detect_path,
+)
+
+cluster.wait_for_dcos_ee(
+    superuser_username=username,
+    superuser_password=password,
+)
+
+master_node = next(iter(cluster.masters))
+master_ip = master_node.public_ip_address.exploded
+
+out = '''
+export DCOS_TEST_DEFAULT_CLUSTER_VARIANT=enterprise
+export DCOS_TEST_DEFAULT_CLUSTER_USERNAME={}
+export DCOS_TEST_DEFAULT_CLUSTER_PASSWORD={}
+export DCOS_TEST_DEFAULT_CLUSTER_HOST={}
+'''.format(username, password, master_ip)
+
+with open('test_cluster.env.sh', 'w') as f:
+    f.write(out)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,4 @@
+--find-links git+https://github.com/dcos/dcos-e2e.git@2018.08.03.0#egg=dcos-e2e-2018.08.03.0
+pytest==3.7.1
+flake8==3.5.0
+dcos-e2e==2018.08.03.0


### PR DESCRIPTION
This adds integration tests for the new Go CLI. They are run from Jenkins and written in Python, they rely on pytest, and dcos-e2e to spin-up the DC/OS cluster.

As the test suite doesn't alter the cluster state, a single cluster is shared between all platform tests (Linux, macOS and Windows) which all run in parallel.

The main goal here is not to have full test coverage, but to setup the base structure for integration tests.

https://jira.mesosphere.com/browse/DCOS_OSS-3915