### PR TITLE
Don't run go generate when building or linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ default:
 	@make $(shell uname | tr [A-Z] [a-z])
 
 .PHONY: darwin linux windows
-darwin linux windows: generate
+darwin linux windows: docker-image
 	$(call inDocker,env GOOS=$(@) go build -o build/$(@)/$(BINARY_NAME)$($(@)_EXE) ./cmd/dcos)
 
 .PHONY: test
@@ -23,7 +23,7 @@ vet: lint
 	$(call inDocker,go vet ./...)
 
 .PHONY: lint
-lint: generate
+lint: docker-image
 	# Can be simplified once https://github.com/golang/lint/issues/320 is fixed.
 	$(call inDocker,golint -set_exit_status ./cmd/... ./pkg/...)
 


### PR DESCRIPTION
Otherwise `pkg/cmd/completion/completion_data.gen.go` gets updated on every run.