### PR TITLE
Inject CLI version when building the release binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 CURRENT_DIR=$(shell pwd)
-BUILD_DIR=$(CURRENT_DIR)/build
-PKG_DIR=/go/src/github.com/dcos/dcos-cli
-BINARY_NAME=dcos
+PKG=github.com/dcos/dcos-cli
+PKG_DIR=/go/src/$(PKG)
 IMAGE_NAME=dcos/dcos-cli
+VERSION?=$(shell git rev-parse HEAD)
 
 windows_EXE=.exe
 
@@ -12,7 +12,9 @@ default:
 
 .PHONY: darwin linux windows
 darwin linux windows: docker-image
-	$(call inDocker,env GOOS=$(@) go build -o build/$(@)/$(BINARY_NAME)$($(@)_EXE) ./cmd/dcos)
+	$(call inDocker,env GOOS=$(@) go build \
+		-ldflags '-X $(PKG)/pkg/cli/version.version=$(VERSION)' \
+		-o build/$(@)/dcos$($(@)_EXE) ./cmd/dcos)
 
 .PHONY: test
 test: vet

--- a/ci/release.groovy
+++ b/ci/release.groovy
@@ -12,7 +12,11 @@ pipeline {
       agent { label 'mesos-ubuntu' }
 
       steps {
-          sh 'make linux darwin windows'
+          sh '''
+            bash -exc " \
+              [ -n \"${TAG_NAME}\" ] && export VERSION=${TAG_NAME};
+              make linux darwin windows"
+          '''
           stash includes: 'build/**', name: 'dcos-binaries'
       }
     }


### PR DESCRIPTION
Currently releases would only show SNAPSHOT. This updates the Jenkinsfile to use the commit hash ID for master builds and GIT tags for tag builds.