### PR TITLE
Public CI improvements

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,10 +14,8 @@ environment:
 stack: go 1.10
 
 before_test:
-  - go get -u github.com/golang/dep/cmd/dep
   - go get -u github.com/golang/lint/golint
-  - go get -u github.com/awalterschulze/goderive
-  - go get -u github.com/br-lewis/go-bindata/...
 
 test_script:
+  - make windows
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,8 @@ env:
  - NO_DOCKER=1
 
 before_script:
- - go get -u github.com/golang/dep/cmd/dep
  - go get -u github.com/golang/lint/golint
- - go get -u github.com/awalterschulze/goderive
- - go get -u github.com/br-lewis/go-bindata/...
 
-script: make test
+script:
+ - make
+ - make test


### PR DESCRIPTION
This removes unneeded dependencies as we don't generate Go code automatically anymore.

It also makes sure the binaries can be built before running the tests.