### PR TITLE
Fix release version injection

### DIFF
--- a/ci/release.groovy
+++ b/ci/release.groovy
@@ -14,7 +14,7 @@ pipeline {
       steps {
           sh '''
             bash -exc " \
-              [ -n \"${TAG_NAME}\" ] && export VERSION=${TAG_NAME};
+              export VERSION=\"${TAG_NAME:-$GIT_COMMIT}\";
               make linux darwin windows"
           '''
           stash includes: 'build/**', name: 'dcos-binaries'


### PR DESCRIPTION
Currently master builds get an empty version, I think it's because the git binary is missing, using `GIT_COMMIT` seems to fix it... I made the job pointing to my fork and triggered a master and a tag build.

https://downloads.dcos.io/binaries/cli/linux/x86-64/latest/dcos
```
./dcos --version
dcoscli.version=0e8d69a961f2e20b97386589de9fc5d274ef3ffb
dcos.version=1.12-dev
dcos.commit=acb6fac6f305fe8be0602f38b53e3696a277f09d
dcos.bootstrap-id=93e62c7dc049c65aca115c27a1d09e3cc178135a
```

https://downloads.dcos.io/binaries/cli/linux/x86-64/0.7.0/dcos
```
./dcos --version
dcoscli.version=0.7.0
dcos.version=1.12-dev
dcos.commit=acb6fac6f305fe8be0602f38b53e3696a277f09d
dcos.bootstrap-id=93e62c7dc049c65aca115c27a1d09e3cc178135a
```