### PR TITLE
Treat the json media type suffix as textual

### DIFF
--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"mime"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -270,5 +271,13 @@ func (c *Client) BaseURL() *url.URL {
 
 // isText returns whether the Content-type header refers to a textual body.
 func (c *Client) isText(contentType string) bool {
-	return contentType == "application/json" || strings.HasPrefix(contentType, "text/")
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		c.opts.Logger.Debug(err)
+		return false
+	}
+	if mediaType == "application/json" || strings.HasSuffix(mediaType, "+json") {
+		return true
+	}
+	return strings.HasPrefix(mediaType, "text/")
 }

--- a/pkg/httpclient/client_test.go
+++ b/pkg/httpclient/client_test.go
@@ -196,3 +196,21 @@ func TestDefaultUserAgent(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, defaultUserAgent, req.Header.Get("User-Agent"))
 }
+
+func TestIsText(t *testing.T) {
+	client := New("")
+
+	fixtures := []struct {
+		contentType string
+		isText      bool
+	}{
+		{"text/plain", true},
+		{"text/html", true},
+		{"application/json", true},
+		{"application/vnd.dcos.package.describe-response+json;charset=utf-8;version=v3", true},
+		{"application/octet-stream", false},
+	}
+	for _, fixture := range fixtures {
+		require.Equal(t, fixture.isText, client.isText(fixture.contentType))
+	}
+}


### PR DESCRIPTION
This lets the httpclient dumping HTTP responses from Cosmos in debug mode.

https://jira.mesosphere.com/browse/DCOS_OSS-3994