### PR TITLE
Install plugins by copy instead by moving them

### DIFF
--- a/pkg/fsutil/fsutil.go
+++ b/pkg/fsutil/fsutil.go
@@ -13,9 +13,42 @@ import (
 	"github.com/spf13/afero"
 )
 
-// Copy copies a file into a given destination.
-func Copy(fs afero.Fs, src, dest string, perm os.FileMode) error {
-	srcFile, err := os.Open(src)
+// CopyDir recursively copies a directory into a given destination.
+func CopyDir(fs afero.Fs, src, dest string) error {
+	info, err := fs.Stat(src)
+	if err != nil {
+		return err
+	}
+	if err := fs.Mkdir(dest, info.Mode()); err != nil {
+		return err
+	}
+	list, err := afero.ReadDir(fs, src)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range list {
+		entrySrc := filepath.Join(src, entry.Name())
+		entryDest := filepath.Join(dest, entry.Name())
+
+		if entry.IsDir() {
+			err := CopyDir(fs, entrySrc, entryDest)
+			if err != nil {
+				return err
+			}
+		} else {
+			err := CopyFile(fs, entrySrc, entryDest, entry.Mode())
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// CopyFile copies a file into a given destination.
+func CopyFile(fs afero.Fs, src, dest string, perm os.FileMode) error {
+	srcFile, err := fs.Open(src)
 	if err != nil {
 		return err
 	}
@@ -30,9 +63,8 @@ func CopyReader(fs afero.Fs, r io.Reader, dest string, perm os.FileMode) error {
 	if err != nil {
 		return err
 	}
-	defer destFile.Close()
-
 	_, err = io.Copy(destFile, r)
+	destFile.Close()
 	return err
 }
 
@@ -120,13 +152,5 @@ func unzipFile(fs afero.Fs, f *zip.File, dest string) error {
 	if err := fs.MkdirAll(filepath.Dir(fpath), 0755); err != nil {
 		return err
 	}
-
-	outFile, err := fs.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
-	if err != nil {
-		return err
-	}
-
-	_, err = io.Copy(outFile, rc)
-	outFile.Close()
-	return err
+	return CopyReader(fs, rc, fpath, f.Mode())
 }

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -307,7 +307,7 @@ func (m *Manager) buildPlugin(installOpts *InstallOpts) error {
 			return err
 		}
 		binPath := filepath.Join(binDir, filepath.Base(installOpts.path))
-		err := fsutil.Copy(m.fs, installOpts.path, binPath, 0751)
+		err := fsutil.CopyFile(m.fs, installOpts.path, binPath, 0751)
 		if err != nil {
 			return err
 		}
@@ -343,11 +343,14 @@ func (m *Manager) installPlugin(installOpts *InstallOpts) error {
 		}
 	}
 
-	// Move the plugin folder to the final location.
 	if err := m.fs.MkdirAll(filepath.Dir(dest), 0755); err != nil {
 		return err
 	}
-	return m.fs.Rename(installOpts.stagingDir, dest)
+
+	// Copy the plugin folder to its final location. We don't move it as this causes
+	// issues when the system's temp dir and the DC/OS dir are on different devices.
+	// See https://groups.google.com/forum/m/#!topic/golang-dev/5w7Jmg_iCJQ.
+	return fsutil.CopyDir(m.fs, installOpts.stagingDir, dest)
 }
 
 // httpClient returns the appropriate HTTP client for a given resource.

--- a/tests/integration/common.py
+++ b/tests/integration/common.py
@@ -66,7 +66,17 @@ def default_cluster():
     assert code == 0
 
 
-def _setup_cluster(name, with_plugins=True):
+@pytest.fixture()
+def default_cluster_with_plugins():
+    cluster = _setup_cluster('DEFAULT', with_plugins=True)
+
+    yield cluster
+
+    code, _, _ = exec_cmd(['dcos', 'cluster', 'remove', cluster['name']])
+    assert code == 0
+
+
+def _setup_cluster(name, with_plugins=False):
     cluster = {
         'variant': os.environ.get('DCOS_TEST_' + name + '_CLUSTER_VARIANT'),
         'username': os.environ.get('DCOS_TEST_' + name + '_CLUSTER_USERNAME'),

--- a/tests/integration/test_help.py
+++ b/tests/integration/test_help.py
@@ -1,4 +1,4 @@
-from .common import exec_cmd, default_cluster  # noqa: F401
+from .common import exec_cmd, default_cluster, default_cluster_with_plugins  # noqa: F401
 
 
 def test_dcos_help():
@@ -32,7 +32,7 @@ Use "dcos [command] --help" for more information about a command.
 '''
 
 
-def test_dcos_help_with_default_plugins(default_cluster):
+def test_dcos_help_with_default_plugins(default_cluster_with_plugins):
     code, out, err = exec_cmd(['dcos'])
     assert code == 0
     assert err == ''

--- a/tests/integration/test_plugin.py
+++ b/tests/integration/test_plugin.py
@@ -3,10 +3,10 @@ import os
 import shutil
 import sys
 
-from .common import exec_cmd, default_cluster  # noqa: F401
+from .common import exec_cmd, default_cluster, default_cluster_with_plugins  # noqa: F401
 
 
-def test_plugin_list(default_cluster):
+def test_plugin_list(default_cluster_with_plugins):
     code, out, err = exec_cmd(['dcos', 'plugin', 'list'])
     assert code == 0
     assert err == ''

--- a/tests/integration/test_plugin.py
+++ b/tests/integration/test_plugin.py
@@ -57,13 +57,7 @@ def test_plugin_invocation(default_cluster):
 
 
 def test_plugin_verbosity(default_cluster):
-    plugins = {
-        'linux': os.path.join(_plugin_dir('dcos-test'), 'linux', 'dcos-test'),
-        'darwin': os.path.join(_plugin_dir('dcos-test'), 'darwin', 'dcos-test'),
-        'win32': os.path.join(_plugin_dir('dcos-test'), 'win32', 'dcos-test.exe'),
-    }
-
-    code, out, err = exec_cmd(['dcos', 'plugin', 'add', plugins[sys.platform]])
+    code, out, err = exec_cmd(['dcos', 'plugin', 'add', _test_plugin_path()])
     assert code == 0
     assert err == ''
     assert out == ''
@@ -104,6 +98,11 @@ def test_plugin_verbosity(default_cluster):
 
         assert out['env'].get('DCOS_VERBOSITY') == fixture['DCOS_VERBOSITY']
         assert out['env'].get('DCOS_LOG_LEVEL') == fixture['DCOS_LOG_LEVEL']
+
+
+def _test_plugin_path():
+    file = 'dcos-test.exe' if sys.platform == 'win32' else 'dcos-test'
+    return os.path.join(_plugin_dir('dcos-test'), sys.platform, file)
 
 
 def _plugin_dir(name):


### PR DESCRIPTION
- Add a pytest cluster fixture without plugins
- Install plugins by copy instead by moving them 
- Intercept "dcos package install dcos-core-cli" 