### PR TITLE
Cosmos permission fix

### DIFF
--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -305,7 +305,13 @@ func (s *Setup) installPlugin(name string, httpClient *httpclient.Client) error 
 	// Get package information from Cosmos.
 	pkgInfo, err := cosmos.NewClient(httpClient).DescribePackage(name)
 	if err != nil {
-		return err
+		switch err {
+		case cosmos.ErrForbidden:
+			s.logger.Error("User does not have permission to access Cosmos. Core CLI must be installed manually")
+			return nil
+		default:
+			return err
+		}
 	}
 
 	// Get the download URL for the current platform.


### PR DESCRIPTION
If a user without the `dcos:adminrouter:package` permission tries to setup the CLI, it will abort because they can't access Cosmos to get package details or download the Core CLI plugin. This doesn't fix that but handles that case and prints out a more descriptive error message.