### PR TITLE
Fixed plugin install during cluster setup

### DIFF
--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -283,17 +283,19 @@ func (s *Setup) installDefaultPlugins(httpClient *httpclient.Client) error {
 		close(enterpriseInstallErr)
 	}()
 
-	err = s.installPlugin("dcos-core-cli", httpClient)
-	if err != nil {
-		// We don't return an error as the EE plugin is not as useful as the core plugin.
-		return fmt.Errorf("unable to install DC/OS core CLI plugin: %s", err)
-	}
-
+	// Install dcos-core-cli.
+	errCore := s.installPlugin("dcos-core-cli", httpClient)
 	// The installation of the core and EE plugins happen in parallel.
 	// We wait for the installation of the enterprise plugin before returning.
-	err = <-enterpriseInstallErr
-	if err != nil {
-		return fmt.Errorf("unable to install DC/OS enterprise CLI plugin: %s", err)
+	errEnterprise := <-enterpriseInstallErr
+
+	switch {
+	case errCore != nil && errEnterprise != nil:
+		return fmt.Errorf("unable to install DC/OS core and enterprise CLI plugins:\n%s\n%s", errCore, errEnterprise)
+	case errCore != nil:
+		return fmt.Errorf("unable to install DC/OS core CLI plugin: %s", errCore)
+	case errEnterprise != nil:
+		return fmt.Errorf("unable to install DC/OS enterprise CLI plugin: %s", errEnterprise)
 	}
 	return nil
 }

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -289,15 +289,10 @@ func (s *Setup) installDefaultPlugins(httpClient *httpclient.Client) error {
 	// We wait for the installation of the enterprise plugin before returning.
 	errEnterprise := <-enterpriseInstallErr
 
-	switch {
-	case errCore != nil && errEnterprise != nil:
-		return fmt.Errorf("unable to install DC/OS core and enterprise CLI plugins:\n%s\n%s", errCore, errEnterprise)
-	case errCore != nil:
-		return fmt.Errorf("unable to install DC/OS core CLI plugin: %s", errCore)
-	case errEnterprise != nil:
-		return fmt.Errorf("unable to install DC/OS enterprise CLI plugin: %s", errEnterprise)
+	if errCore != nil {
+		return errCore
 	}
-	return nil
+	return errEnterprise
 }
 
 // installPlugin installs a plugin by its name. It gets the plugin's download URL through Cosmos.


### PR DESCRIPTION
This commit fixes, that we potentially don't wait for the
enterprise plugin to be installed correctly if the install
for the core plugin fails. We now wait for both installs
to finish before proceeding.

https://jira.mesosphere.com/browse/DCOS_OSS-4003