### PR TITLE
Improve some logging messages

### DIFF
--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -80,12 +80,7 @@ func (m *Manager) Install(resource string, installOpts *InstallOpts) (err error)
 	if err != nil {
 		return err
 	}
-	err = m.installPlugin(installOpts)
-	if err != nil {
-		return err
-	}
-	m.logger.Info("Added plugin to the CLI")
-	return nil
+	return m.installPlugin(installOpts)
 }
 
 // SetCluster sets the plugin manager's target cluster.

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -138,7 +138,7 @@ func (s *Setup) Configure(flags *Flags, clusterURL string, attach bool) (*config
 		}
 	}
 
-	s.logger.Info("Your cluster is now setup")
+	s.logger.Infof("%s is now setup", clusterURL)
 	return cluster, nil
 }
 


### PR DESCRIPTION
Right now a cluster setup in verbose mode finishes like this :

    Using login provider 'dcos-uid-password'.
    Installing dcos-core-cli...
    Installing dcos-enterprise-cli...
    Installing plugin from https://.../dcos-core-cli.zip...
    Installing plugin from https://.../dcos-enterprise-cli...
    Added plugin to the CLI
    Added plugin to the CLI
    Your cluster is now setup

`Added plugin to the CLI` is not very informative as one doesn't know
which one it's about. This removes these logs and replaces `Your
cluster` with the cluster URL.