### PR TITLE
Add a NewOsEnvironment helper in the cli package

### DIFF
--- a/cmd/dcos/main.go
+++ b/cmd/dcos/main.go
@@ -14,20 +14,11 @@ import (
 	"github.com/dcos/dcos-cli/pkg/dcos"
 	"github.com/dcos/dcos-cli/pkg/httpclient"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/spf13/pflag"
 )
 
 func main() {
-	ctx := cli.NewContext(&cli.Environment{
-		Args:      os.Args,
-		Input:     os.Stdin,
-		Out:       os.Stdout,
-		ErrOut:    os.Stderr,
-		EnvLookup: os.LookupEnv,
-		Fs:        afero.NewOsFs(),
-	})
-
+	ctx := cli.NewContext(cli.NewOsEnvironment())
 	if err := run(ctx, os.Args); err != nil {
 		os.Exit(1)
 	}

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"io"
+	"os"
 
 	"github.com/spf13/afero"
 )
@@ -27,4 +28,16 @@ type Environment struct {
 
 	// Fs is an abstraction for the filesystem.
 	Fs afero.Fs
+}
+
+// NewOsEnvironment returns an environment backed by the os package.
+func NewOsEnvironment() *Environment {
+	return &Environment{
+		Args:      os.Args,
+		Input:     os.Stdin,
+		Out:       os.Stdout,
+		ErrOut:    os.Stderr,
+		EnvLookup: os.LookupEnv,
+		Fs:        afero.NewOsFs(),
+	}
 }


### PR DESCRIPTION
This lets package users creating an OS environment more easily.

See https://github.com/mesosphere/resilience-tester/pull/5#discussion_r213241595