### PR TITLE
Use mingw64 instead of mingw32 on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,5 @@
 install:
-  # https://stackoverflow.com/questions/12881854/how-to-use-gnu-make-on-windows
-  - copy c:\MinGW\bin\mingw32-make.exe c:\MinGW\bin\make.exe
-  - SET PATH=c:\\MinGW\\bin;c:\gopath\bin;%PATH%
+  - SET PATH=C:\msys64\mingw64\bin;c:\gopath\bin;%PATH%
 
 build: off
 
@@ -17,5 +15,5 @@ before_test:
   - go get -u github.com/golang/lint/golint
 
 test_script:
-  - make windows
-  - make test
+  - mingw32-make windows
+  - mingw32-make test


### PR DESCRIPTION
It started to fail with:

    cc1.exe: sorry, unimplemented: 64-bit mode not compiled in

https://jira.mesosphere.com/browse/DCOS_OSS-4025