### PR TITLE
Display logs when reading credentials from env vars

### DIFF
--- a/pkg/cmd/auth/auth_login.go
+++ b/pkg/cmd/auth/auth_login.go
@@ -8,7 +8,7 @@ import (
 
 // newCmdAuthLogin creates the `dcos auth login` subcommand.
 func newCmdAuthLogin(ctx api.Context) *cobra.Command {
-	flags := login.NewFlags(ctx.Fs(), ctx.EnvLookup)
+	flags := login.NewFlags(ctx.Fs(), ctx.EnvLookup, ctx.Logger())
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Log in to the current cluster",

--- a/pkg/cmd/cluster/cluster_attach.go
+++ b/pkg/cmd/cluster/cluster_attach.go
@@ -71,7 +71,7 @@ func newCmdClusterAttach(ctx api.Context) *cobra.Command {
 					return config.ErrTooManyConfigs
 				}
 				// One matching linked cluster, no matching cluster.
-				flags := setup.NewFlags(ctx.Fs(), ctx.EnvLookup)
+				flags := setup.NewFlags(ctx.Fs(), ctx.EnvLookup, ctx.Logger())
 				flags.LoginFlags().SetProviderID(matchingLinkedClusters[0].LoginProvider.ID)
 				_, err := ctx.Setup(flags, matchingLinkedClusters[0].URL, true)
 				if err != nil {

--- a/pkg/cmd/cluster/cluster_link.go
+++ b/pkg/cmd/cluster/cluster_link.go
@@ -13,7 +13,7 @@ import (
 
 // newCmdClusterLink links the attached cluster to another one.
 func newCmdClusterLink(ctx api.Context) *cobra.Command {
-	setupFlags := setup.NewFlags(ctx.Fs(), ctx.EnvLookup)
+	setupFlags := setup.NewFlags(ctx.Fs(), ctx.EnvLookup, ctx.Logger())
 	cmd := &cobra.Command{
 		Use:   "link <cluster>",
 		Short: "Link the current cluster to another one",

--- a/pkg/cmd/cluster/cluster_setup.go
+++ b/pkg/cmd/cluster/cluster_setup.go
@@ -9,7 +9,7 @@ import (
 
 // newCmdClusterSetup configures the CLI with a given DC/OS cluster.
 func newCmdClusterSetup(ctx api.Context) *cobra.Command {
-	setupFlags := setup.NewFlags(ctx.Fs(), ctx.EnvLookup)
+	setupFlags := setup.NewFlags(ctx.Fs(), ctx.EnvLookup, ctx.Logger())
 	cmd := &cobra.Command{
 		Use:   "setup <url>",
 		Short: "Set up the CLI to communicate with a cluster",

--- a/pkg/login/flags.go
+++ b/pkg/login/flags.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dcos/dcos-cli/pkg/fsutil"
 	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/pflag"
 )
@@ -14,6 +15,7 @@ import (
 // Flags are command-line flags for a login flow.
 type Flags struct {
 	fs             afero.Fs
+	logger         *logrus.Logger
 	envLookup      func(key string) (string, bool)
 	providerID     string
 	username       string
@@ -24,10 +26,11 @@ type Flags struct {
 }
 
 // NewFlags creates flags for a login flow.
-func NewFlags(fs afero.Fs, envLookup func(key string) (string, bool)) *Flags {
+func NewFlags(fs afero.Fs, envLookup func(key string) (string, bool), logger *logrus.Logger) *Flags {
 	return &Flags{
 		fs:        fs,
 		envLookup: envLookup,
+		logger:    logger,
 	}
 }
 
@@ -79,12 +82,14 @@ func (f *Flags) Resolve() error {
 	if f.username == "" {
 		if username, ok := f.envLookup("DCOS_USERNAME"); ok {
 			f.username = username
+			f.logger.Info("Read username from environment.")
 		}
 	}
 
 	if f.password == "" {
 		if password, ok := f.envLookup("DCOS_PASSWORD"); ok {
 			f.password = password
+			f.logger.Info("Read password from environment.")
 		}
 	}
 

--- a/pkg/setup/flags.go
+++ b/pkg/setup/flags.go
@@ -2,6 +2,7 @@ package setup
 
 import (
 	"github.com/dcos/dcos-cli/pkg/login"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/pflag"
 )
@@ -19,10 +20,10 @@ type Flags struct {
 }
 
 // NewFlags creates flags for a cluster setup.
-func NewFlags(fs afero.Fs, envLookup func(key string) (string, bool)) *Flags {
+func NewFlags(fs afero.Fs, envLookup func(key string) (string, bool), logger *logrus.Logger) *Flags {
 	return &Flags{
 		fs:         fs,
-		loginFlags: login.NewFlags(fs, envLookup),
+		loginFlags: login.NewFlags(fs, envLookup, logger),
 	}
 }
 


### PR DESCRIPTION
This gives more insights to users with unnoticed DCOS_USERNAME / DCOS_PASSWORD env vars, as otherwise they might not understand why no login credentials are being asked or why it fails to login.