### PR TITLE
Accept default values on confirm prompts

### DIFF
--- a/pkg/cmd/cluster/cluster_link.go
+++ b/pkg/cmd/cluster/cluster_link.go
@@ -32,7 +32,7 @@ func newCmdClusterLink(ctx api.Context) *cobra.Command {
 					return err
 				}
 
-				err = ctx.Prompt().Confirm("The cluster you want to link to is not set up locally, would you like to do it now?")
+				err = ctx.Prompt().Confirm("The cluster you want to link to is not set up locally, would you like to do it now? [Y/n] ", "Y")
 				if err != nil {
 					return err
 				}

--- a/pkg/prompt/prompt_test.go
+++ b/pkg/prompt/prompt_test.go
@@ -55,24 +55,30 @@ func TestSelect(t *testing.T) {
 
 func TestConfirm(t *testing.T) {
 	fixtures := []struct {
-		input       string
-		expectError bool
+		input         string
+		defaultChoice string
+		expectError   bool
 	}{
-		{"Y\n", false},
-		{"yes\n", false},
-		{"y\n", false},
-		{"\n\nY", false},
-		{"\n", true},
-		{"N\n", true},
-		{"no\n", true},
-		{"n\n", true},
+		{"", "", true},
+		{"Y\n", "", false},
+		{"Y\r\n", "", false},
+		{"yes\n", "", false},
+		{"yes\r\n", "", false},
+		{"y\n", "", false},
+		{"\n\nY\n", "", false},
+		{"N\n", "", true},
+		{"no\n", "", true},
+		{"n\n", "", true},
+		{"n\r\n", "", true},
+		{"\n", "yes", false},
+		{"\n", "no", true},
 	}
 
 	for _, fixture := range fixtures {
 		var buf bytes.Buffer
 		prompt := New(strings.NewReader(fixture.input), &buf)
 
-		err := prompt.Confirm("Please confirm:")
+		err := prompt.Confirm("Please confirm:", fixture.defaultChoice)
 		if fixture.expectError {
 			require.Error(t, err)
 		} else {

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -348,7 +348,7 @@ func (s *Setup) promptCA(cert *x509.Certificate) error {
 
   SHA256 fingerprint: %s
 
-Do you trust it?`
+Do you trust it? [y/n] `
 
 	return s.prompt.Confirm(fmt.Sprintf(
 		msg,
@@ -356,5 +356,5 @@ Do you trust it?`
 		cert.NotBefore,
 		cert.NotAfter,
 		fingerprintBuf.String(),
-	))
+	), "")
 }


### PR DESCRIPTION
This adds a second argument to the Confirm() function which acts as a
fallback when users only perss [ENTER]. It is a common practice to have
prompts like:

    Please confirm [Y/n]:

In such cases the capital Y indicates that it is the default action.

This also switches the fingerprint prompt to not have a default value,
as it is contains sensitive information which should explicitly be
approved by the user.

https://jira.mesosphere.com/browse/DCOS_OSS-4030