### PR TITLE
Fix cluster attach when no cluster is attached

### DIFF
--- a/pkg/cmd/cluster/cluster_attach_test.go
+++ b/pkg/cmd/cluster/cluster_attach_test.go
@@ -1,0 +1,39 @@
+package cluster
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/dcos/dcos-cli/pkg/mock"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClusterAttach(t *testing.T) {
+	var out bytes.Buffer
+	env := mock.NewEnvironment()
+	env.Fs = afero.NewCopyOnWriteFs(
+		afero.NewReadOnlyFs(afero.NewOsFs()),
+		afero.NewMemMapFs(),
+	)
+	env.EnvLookup = func(key string) (string, bool) {
+		if key == "DCOS_DIR" {
+			return filepath.Join("testdata", "cluster_attach", ".dcos"), true
+		}
+		return "", false
+	}
+	env.Out = &out
+
+	ctx := mock.NewContext(env)
+
+	clusterID := "79893270-f9f1-4293-9225-e6e3900043a9"
+	cmd := newCmdClusterAttach(ctx)
+	cmd.SetArgs([]string{clusterID})
+
+	require.NoError(t, cmd.Execute())
+
+	cluster, err := ctx.Cluster()
+	require.NoError(t, err)
+	require.Equal(t, clusterID, cluster.ID())
+}

--- a/pkg/cmd/cluster/testdata/cluster_attach/.dcos/clusters/79893270-f9f1-4293-9225-e6e3900043a9/dcos.toml
+++ b/pkg/cmd/cluster/testdata/cluster_attach/.dcos/clusters/79893270-f9f1-4293-9225-e6e3900043a9/dcos.toml
@@ -1,0 +1,2 @@
+[cluster]
+name = "single_config_unattached"

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -128,6 +128,7 @@ func (s *Setup) Configure(flags *Flags, clusterURL string, attach bool) (*config
 		if err != nil {
 			return nil, err
 		}
+		s.logger.Infof("You are now attached to cluster %s", cluster.ID())
 	}
 
 	// Install default plugins (dcos-core-cli and dcos-enterprise-cli).


### PR DESCRIPTION
This is about fixing a bug in the `dcos cluster attach` command. When no cluster is attached yet it was failing.

This also adds a non-regression test for it.

https://jira.mesosphere.com/browse/DCOS_OSS-4047