### PR TITLE
Mention GNU standards in the CLI style guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,13 +23,15 @@ Please describe the problem you are addressing and your proposed solution.
 You can make sure your code conforms to our code style conventions by running
 `make lint` directories.
 
+Please also follow our [style guide](design/style.md) when updating user-facing
+parts of the CLI.
+
 ### Tests
 
 Please include test(s) with your changes. Make sure to separate integration and unit tests.
 
 You can use `make test` to run unit tests, in order to run integration tests please follow
 [these instructions](https://github.com/dcos/dcos-cli#integration-tests).
-
 
 ## Thanks!
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ available in the [DC/OS docs](https://dcos.io/docs/).
 2.  Change directory to the repo directory:
 
         cd project/path/outside/$GOPATH/dcos-cli
-        
+
     or:
 
         cd $GOPATH/src/github.com/dcos/dcos-cli
@@ -108,4 +108,4 @@ Tags are released to:
 
 ## Contributing
 
-Contributions are always welcome! Please refer to our [contributing guidelines](https://github.com/dcos/dcos-cli/blob/master/CONTRIBUTING.md) and [style guide](https://github.com/dcos/dcos-cli/blob/master/STYLEGUIDE.md) first.
+Contributions are always welcome! Please refer to our [contributing guidelines](CONTRIBUTING.md).

--- a/design/README.md
+++ b/design/README.md
@@ -1,6 +1,13 @@
 # DC/OS CLI Design Overview
 
+## Go packages
+
 - [cli](cli.md)
 - [config](config.md)
 - [httpclient](httpclient.md)
 - [login](login.md)
+- [setup](setup.md)
+
+## Style guide
+
+[Style guide](style.md) for the DC/OS CLI and its plugins.

--- a/design/style.md
+++ b/design/style.md
@@ -1,9 +1,11 @@
 # DC/OS CLI Style Guide
 
 ## Intro
+
 The DC/OS CLI is the main tool used by developers and operators to interact with DC/OS cluster and services running on the clusters. The teams developing features and CLI plugins should build the CLI per this style guide so that we offer a consistent and usable experience to users of DC/OS.
 
 ## Naming Commands
+
 * Generally top level commands are single nouns e.g. dcos job, dcos service
 * Top level commands are followed by verbs e.g. dcos job create, dcos cluster rename
 * Command names should always be a single, lowercase word without spaces, hyphens, underscores, or other word delimiters
@@ -22,22 +24,20 @@ The DC/OS CLI is the main tool used by developers and operators to interact with
   * Show - Show a description or definition aka Describe, Get
   * List - List all objects
 
-### Arguments/Flags
+### Arguments/Options
 
-Commands should support the following flags.
+CLI arguments should follow the [GNU standards][1] as much as possible.
+
+Commonly used options are:
 
 * `--help` and `-h` should always output one level of help
-* `--version` should always show the version of the plugin
 * `--json` outputs JSON
 * `--force` and `-f` to force
-* `--quiet` and `-q` to silence output
-* `-v` and `-vv` for verbose outputs (for verbose and very verbose)
+* `--quiet` and `-q` to silence standard output
+* `-v` and `-vv` for verbose outputs on stderr ("verbose" or "very verbose")
 * `--lines=N` to restrict amount of results
 
-Flags may or may not accept a value.
-
-* Flags should have smart defaults when no value is provided
-* Support both flags that have values preceded by "=" and values preceded by a space e.g. `dcos <command> <action> --<flag>=<value>` is the same as `dcos <command> <action> --<flag> <value>`
+Please refer to [this table][2] for other common option names.
 
 ## Prompts
 
@@ -50,7 +50,7 @@ $ dcos backup delete <id>
 Are you sure you want to delete this backup? [y/n]
 ```
 
-Commands should support passing confirmation via a flag `--yes` and `-y` to satisfy scriptability needs.
+Commands should support passing confirmation via `--yes` and `-y` options to satisfy scriptability needs.
 
 ```
 $ dcos backup delete <id> --yes
@@ -109,8 +109,6 @@ Description:
 
 Usage:
     dcos <command> <action>
-    dcos <command> <action>
-    …
 
 Examples:
     An optional section of example(s) on how to run the command.
@@ -123,23 +121,24 @@ Commands:
     …
 
 Options:
-    --<flag>
-        <flagDescription>
-    --<flag>
-        <flagDescription>
+    --<option>
+        <optionDescription>
+    --<option>
+        <optionDescription>
     …
 ```
 
 ### Error Messages
 
-Error messages shouldn’t be too low-level.
+In general on success there is no output, this follows a UNIX good practice ("No News Is Good News").
+However on errors the CLI must always display an informative message, it shouldn’t be too low-level.
 
-``` 
+```
 $ dcos cluster setup https://not-reachable.com
 Couldn’t reach https://not-reachable.com, is it a DC/OS cluster master node?
 ```
 
-If users want the low level error messages, they’d need to run the command with the verbose option: 
+If users want the low level error messages, they’d need to run the command with the verbose option:
 
 ```
 $ dcos -v cluster setup https://not-reachable.com
@@ -151,7 +150,7 @@ Couldn’t reach https://not-reachable.com, is it a DC/OS cluster master node?
 
 ### ✅ Do
 
-``` 
+```
 $ dcos <command> <subcommand>
 ```
 
@@ -163,7 +162,7 @@ $ dcos <command> --<subcommand>
 
 ### ✅ Do
 
-``` 
+```
 $ dcos <command> -h
 <Description>
 <Usage>
@@ -177,13 +176,13 @@ $ dcos <command> -h
 ```
 $ dcos <command> -h
 <Usage>
-<Flags>
+<Options>
 <Commands>
 ```
 
 ### ✅ Do
 
-``` 
+```
 $ dcos cluster setup https://not-reachable.com
 Couldn’t reach https://not-reachable.com, is it a DC/OS cluster master node?
 ```
@@ -194,3 +193,6 @@ Couldn’t reach https://not-reachable.com, is it a DC/OS cluster master node?
 $ dcos cluster setup https://not-reachable.com
 Error: couldn’t download CA certificates : dial tcp: lookup not-reachable.com on 127.0.0.53:53: no such host
 ```
+
+[1]: https://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
+[2]: https://www.gnu.org/prep/standards/html_node/Option-Table.html#Option-Table


### PR DESCRIPTION
This moves the style guide under the design folder and adds links to GNU standards (based on POSIX), which are the ones we mostly follow in our CLI and plugins.