### PR TITLE
Don't prompt with fingerprint when using --ca-certs

### DIFF
--- a/pkg/setup/flags.go
+++ b/pkg/setup/flags.go
@@ -70,6 +70,9 @@ func (f *Flags) Resolve() error {
 			return err
 		}
 		f.caBundle = caBundle
+
+		// Don't prompt for fingerprint confirmation when a CA is explicitly passed.
+		f.noCheck = true
 	}
 	return f.loginFlags.Resolve()
 }


### PR DESCRIPTION
The --ca-certs option suggests that the user already retrieved the CA by other means (eg. out-of-band). Thus it is not necessary to print for manual verification of the fingerprint.

This also keeps backwards compatibility with the previous CLI.

https://jira.mesosphere.com/browse/DCOS_OSS-4066