### PR TITLE
Remove temp folder after installing a plugin

### DIFF
--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -3,11 +3,11 @@ package plugin
 //go:generate goderive .
 
 import (
-	"encoding/hex"
-	"io"
 	"crypto/tls"
+	"encoding/hex"
 	"fmt"
 	"hash"
+	"io"
 	"mime"
 	"net/http"
 	"os"
@@ -63,8 +63,8 @@ type InstallOpts struct {
 
 // Checksum contains the hash function and the checksum we expect from a plugin.
 type Checksum struct {
-	Hasher  hash.Hash
-	Value string
+	Hasher hash.Hash
+	Value  string
 }
 
 // Install installs a plugin from a resource.
@@ -383,6 +383,7 @@ func (m *Manager) installPlugin(installOpts *InstallOpts) error {
 	// Copy the plugin folder to its final location. We don't move it as this causes
 	// issues when the system's temp dir and the DC/OS dir are on different devices.
 	// See https://groups.google.com/forum/m/#!topic/golang-dev/5w7Jmg_iCJQ.
+	defer m.fs.RemoveAll(installOpts.stagingDir)
 	return fsutil.CopyDir(m.fs, installOpts.stagingDir, dest)
 }
 


### PR DESCRIPTION
Since we switched from renaming to copying the plugin, we should remove the temp plugin as a cleanup procedure.

This became an issue on the DC/OS integration tests suite where the new CLI caused "No space left on device" errors.

https://jira.mesosphere.com/browse/DCOS-41483