### PR TITLE
Remove downloaded plugins after installation

### DIFF
--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -76,6 +76,8 @@ func (m *Manager) Install(resource string, installOpts *InstallOpts) (err error)
 		if err != nil {
 			return err
 		}
+		// Remove the downloaded resource from the temp dir at the end of installation.
+		defer m.fs.RemoveAll(filepath.Dir(installOpts.path))
 	} else {
 		installOpts.path = resource
 	}


### PR DESCRIPTION
Currently we only remove the temporary staging dir, we should also remove ZIP artifacts from the temp folder.