### PR TITLE
Don't pass DCOS_LOG_LEVEL by default

### DIFF
--- a/pkg/cmd/dcos.go
+++ b/pkg/cmd/dcos.go
@@ -121,24 +121,13 @@ func newPluginCommand(ctx api.Context, cmd plugin.Command) *cobra.Command {
 			execCmd.Stderr = ctx.ErrOut()
 			execCmd.Stdin = ctx.Input()
 
-			logLevel := "error"
-			verbosity := ""
+			execCmd.Env = append(os.Environ(), "DCOS_CLI_EXECUTABLE_PATH="+executablePath)
+
 			switch ctx.Logger().Level {
 			case logrus.DebugLevel:
-				logLevel = "debug"
-				verbosity = "2"
+				execCmd.Env = append(execCmd.Env, "DCOS_VERBOSITY=2", "DCOS_LOG_LEVEL=debug")
 			case logrus.InfoLevel:
-				logLevel = "info"
-				verbosity = "1"
-			}
-
-			execCmd.Env = append(
-				os.Environ(),
-				"DCOS_CLI_EXECUTABLE_PATH="+executablePath,
-				"DCOS_LOG_LEVEL="+logLevel,
-			)
-			if verbosity != "" {
-				execCmd.Env = append(execCmd.Env, "DCOS_VERBOSITY="+verbosity)
+				execCmd.Env = append(execCmd.Env, "DCOS_VERBOSITY=1", "DCOS_LOG_LEVEL=info")
 			}
 
 			err = execCmd.Run()

--- a/tests/integration/test_plugin.py
+++ b/tests/integration/test_plugin.py
@@ -66,7 +66,7 @@ def test_plugin_verbosity(default_cluster):
         {
             'cmd': ['dcos', 'test'],
             'DCOS_VERBOSITY': None,
-            'DCOS_LOG_LEVEL': 'error',
+            'DCOS_LOG_LEVEL': None,
         },
         {
             'cmd': ['dcos', '-v', 'test'],


### PR DESCRIPTION
Defaulting to "error" is not appropriate as with the legacy code in the core CLI some error logs show on successes too. This happens for example with the `dcos marathon app add` command.

https://jira.mesosphere.com/browse/DCOS-41826