### PR TITLE
Support DCOS_ACS_TOKEN when setting-up a cluster

### DIFF
--- a/tests/integration/test_cluster.py
+++ b/tests/integration/test_cluster.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from .common import exec_cmd, default_cluster, default_cluster_with_plugins  # noqa: F401
 
@@ -55,3 +56,16 @@ def test_cluster_setup_non_superuser(default_cluster_with_plugins):
     assert err == ('In order to install the "dcos-enterprise-cli" plugin, '
                    'make sure your user has the "dcos:adminrouter:package" '
                    'permission and run "dcos package install dcos-enterprise-cli".\n')
+
+
+def test_cluster_setup_with_acs_token_env(default_cluster):
+    code, out, _ = exec_cmd(['dcos', 'config', 'show', 'core.dcos_acs_token'])
+    assert code == 0
+
+    env = os.environ.copy()
+    env['DCOS_ACS_TOKEN'] = out.rstrip()
+
+    code, out, err = exec_cmd(['dcos', 'cluster', 'setup', default_cluster['dcos_url']], env=env)
+    assert code == 0
+    assert out == ""
+    assert err == ""


### PR DESCRIPTION
DCOS_ACS_TOKEN is supported in most commands except cluster setup.

This updates the setup command to skip login and use the ACS token from
this env var when it exists. This simplifies other teams scripts as they
sometimes get the ACS token by their own mean and expect the CLI to be
configured with it.

On the other hand we didn't want to add an "--acs-token" flag to the
command as we don't encourage this behaviour.

https://jira.mesosphere.com/browse/DCOS-41803