### PR TITLE
Persist the token when doing a setup with DCOS_ACS_TOKEN

### DIFF
--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -95,14 +95,16 @@ func (s *Setup) Configure(flags *Flags, clusterURL string, attach bool) (*config
 	}
 
 	// Login to get the ACS token, unless it is already present as an env var.
-	if cluster.ACSToken() == "" {
+	acsToken := cluster.ACSToken()
+	if acsToken == "" {
 		httpClient := httpclient.New(cluster.URL(), httpOpts...)
-		acsToken, err := s.loginFlow.Start(flags.loginFlags, httpClient)
+		var err error
+		acsToken, err = s.loginFlow.Start(flags.loginFlags, httpClient)
 		if err != nil {
 			return nil, err
 		}
-		cluster.SetACSToken(acsToken)
 	}
+	cluster.SetACSToken(acsToken)
 	httpClient := httpclient.New(cluster.URL(), append(httpOpts, httpclient.ACSToken(cluster.ACSToken()))...)
 
 	// Read cluster ID from cluster metadata.

--- a/tests/integration/test_cluster.py
+++ b/tests/integration/test_cluster.py
@@ -69,3 +69,7 @@ def test_cluster_setup_with_acs_token_env(default_cluster):
     assert code == 0
     assert out == ""
     assert err == ""
+
+    code, out, _ = exec_cmd(['dcos', 'config', 'show', 'core.dcos_acs_token'])
+    assert code == 0
+    assert out.rstrip() == env['DCOS_ACS_TOKEN']


### PR DESCRIPTION
This is a follow-up from e830f8f98790b5807b53e187c96a690138d0a5d7.

It fixes the setup command to properly persist the ACS token when doing a setup with the DCOS_ACS_TOKEN env var. It updates the integration test accordingly.