### PR TITLE
Pass cluster specific environment variables to plugins 

### DIFF
--- a/tests/integration/test_cluster.py
+++ b/tests/integration/test_cluster.py
@@ -59,11 +59,8 @@ def test_cluster_setup_non_superuser(default_cluster_with_plugins):
 
 
 def test_cluster_setup_with_acs_token_env(default_cluster):
-    code, out, _ = exec_cmd(['dcos', 'config', 'show', 'core.dcos_acs_token'])
-    assert code == 0
-
     env = os.environ.copy()
-    env['DCOS_CLUSTER_SETUP_ACS_TOKEN'] = out.rstrip()
+    env['DCOS_CLUSTER_SETUP_ACS_TOKEN'] = default_cluster['acs_token']
 
     code, out, err = exec_cmd(['dcos', 'cluster', 'setup', default_cluster['dcos_url']], env=env)
     assert code == 0


### PR DESCRIPTION
Follow-up PR from the plugin design update: https://github.com/dcos/dcos-cli/pull/1341

When a plugin is invoked with a cluster currently attached, a given set
of environment variables are passed.

- `DCOS_URL`: The base URL of the DC/OS cluster without a trailing slash
(eg. https://dcos.example.com).

- `DCOS_ACS_TOKEN`: The authentication token for the current user.

- `DCOS_TLS_INSECURE`: Indicates whether the CLI is configured with an
insecure TLS setup. This is set to 1 when the DCOS_URL scheme is http://
or core.ssl_verify is set to false.

- `DCOS_TLS_CA_PATH`: Unless DCOS_TLS_INSECURE=1, this env var indicates the
path to the CA bundle to verify server certificates against. When it is
not set, the system's CA bundle must be used.

https://jira.mesosphere.com/browse/DCOS_OSS-4101