### PR TITLE
Rename DCOS_ACS_TOKEN to DCOS_CLUSTER_SETUP_ACS_TOKEN

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -182,6 +182,7 @@ func (ctx *Context) Setup(flags *setup.Flags, clusterURL string, attach bool) (*
 	return setup.New(setup.Opts{
 		Fs:            ctx.Fs(),
 		Errout:        ctx.ErrOut(),
+		EnvLookup:     ctx.EnvLookup,
 		Prompt:        ctx.Prompt(),
 		Logger:        ctx.Logger(),
 		LoginFlow:     ctx.loginFlow(),

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -40,6 +40,7 @@ type Opts struct {
 	LoginFlow     *login.Flow
 	ConfigManager *config.Manager
 	PluginManager *plugin.Manager
+	EnvLookup     func(key string) (string, bool)
 }
 
 // Setup represents a cluster setup.
@@ -51,6 +52,7 @@ type Setup struct {
 	loginFlow     *login.Flow
 	configManager *config.Manager
 	pluginManager *plugin.Manager
+	envLookup     func(key string) (string, bool)
 }
 
 // New creates a new setup.
@@ -63,6 +65,7 @@ func New(opts Opts) *Setup {
 		loginFlow:     opts.LoginFlow,
 		configManager: opts.ConfigManager,
 		pluginManager: opts.PluginManager,
+		envLookup:     opts.EnvLookup,
 	}
 }
 
@@ -95,7 +98,7 @@ func (s *Setup) Configure(flags *Flags, clusterURL string, attach bool) (*config
 	}
 
 	// Login to get the ACS token, unless it is already present as an env var.
-	acsToken := cluster.ACSToken()
+	acsToken, _ := s.envLookup("DCOS_CLUSTER_SETUP_ACS_TOKEN")
 	if acsToken == "" {
 		httpClient := httpclient.New(cluster.URL(), httpOpts...)
 		var err error

--- a/tests/integration/test_cluster.py
+++ b/tests/integration/test_cluster.py
@@ -63,7 +63,7 @@ def test_cluster_setup_with_acs_token_env(default_cluster):
     assert code == 0
 
     env = os.environ.copy()
-    env['DCOS_ACS_TOKEN'] = out.rstrip()
+    env['DCOS_CLUSTER_SETUP_ACS_TOKEN'] = out.rstrip()
 
     code, out, err = exec_cmd(['dcos', 'cluster', 'setup', default_cluster['dcos_url']], env=env)
     assert code == 0
@@ -72,4 +72,4 @@ def test_cluster_setup_with_acs_token_env(default_cluster):
 
     code, out, _ = exec_cmd(['dcos', 'config', 'show', 'core.dcos_acs_token'])
     assert code == 0
-    assert out.rstrip() == env['DCOS_ACS_TOKEN']
+    assert out.rstrip() == env['DCOS_CLUSTER_SETUP_ACS_TOKEN']


### PR DESCRIPTION
DCOS_ACS_TOKEN is already used and planned to be used for passing
information to plugins. If a plugin does a cluster setup it would then
cause issues as the flow would try to use the current cluster's ACS
token (due to the default child process env var inheritance).

It makes sense to reduce the scope of this env var to the cluster setup
command. It remains an undocumented env var for internal usage at
Mesosphere.

https://jira.mesosphere.com/browse/DCOS_OSS-4176