### PR TITLE
Make browser-prompt_authtoken check for 200/403 status codes

### DIFF
--- a/design/login.md
+++ b/design/login.md
@@ -107,7 +107,7 @@ Each login provider has one of these 5 login methods associated to it (`client-m
     `/acs/api/v1/auth/login`.
 - **browser-prompt-oidcidtoken-get-authtoken** : Open the browser at the page referenced in
     `start_flow_url`. The user is then expected to continue the flow in the browser, eventually
-    they are redirected to a page with the authentication token to copy-paste from the browser
+    they are redirected to a page with an OpenID Connect ID token to copy-paste from the browser
     to their terminal. Make a HEAD request to a well-known resource with the appropriate
     Authorization header in order to verify the token.
 


### PR DESCRIPTION
Follow-up from https://github.com/dcos/dcos-cli/pull/1338

This changes the browser-prompt_authtoken client method to expect a 200
or 403 status code in case of a valid token instead of accepting
anything else than a 401. Otherwise it should also have been checking
for 50X status codes.

This is the same behavior as the Python CLI:

https://github.com/dcos/dcos-core-cli/blob/8a51a0d05ad3ece50d1041bede5a7638f3ed13a6/python/lib/dcos/dcos/auth.py#L295