### PR TITLE
Add a design page for the core CLI bundle

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -4,6 +4,7 @@
 
 - [cli](cli.md)
 - [config](config.md)
+- [corecli](corecli.md)
 - [httpclient](httpclient.md)
 - [login](login.md)
 - [plugin](plugin.md)

--- a/design/corecli.md
+++ b/design/corecli.md
@@ -9,4 +9,4 @@ The CLI will use the bundled plugin in these 2 scenarios:
 
 - **The CLI is attached to a cluster** and there is no `dcos-core-cli` plugin installed. The first time a core command is invoked, the bundled core CLI will get automatically extracted into the plugins dir, the user will see an informational message (`Extracting dcos-core-cli plugin...`), the CLI will then invoke the requested core command and continue normally.
 
-This essentially makes the CLI and its core plugin look like a single piece until we figure out all the details regarding how to extract the core plugin while keeping a seamless user experience.
+This essentially makes the CLI and its core plugin a single piece until we figure out all the details regarding how to extract the core plugin while keeping a seamless user experience.

--- a/design/corecli.md
+++ b/design/corecli.md
@@ -9,4 +9,6 @@ The CLI will use the bundled plugin in these 2 scenarios:
 
 - **The CLI is attached to a cluster** and there is no `dcos-core-cli` plugin installed. The first time a core command is invoked, the bundled core CLI will get automatically extracted into the plugins dir, the user will see an informational message (`Extracting dcos-core-cli plugin...`), the CLI will then invoke the requested core command and continue normally.
 
-This essentially makes the CLI and its core plugin a single piece until we figure out all the details regarding how to extract the core plugin while keeping a seamless user experience.
+This makes the CLI and the dcos-core-cli plugin behave like a single piece pending reliable methods of
+plugin installation in all supported DC/OS configurations. Ensuring that no scripted or manual processes
+were negatively impacted by the architectural changes was a design goal.

--- a/design/corecli.md
+++ b/design/corecli.md
@@ -1,0 +1,12 @@
+# corecli
+
+The 0.7 CLI bundles a version of the [core plugin](https://github.com/dcos/dcos-core-cli) compatible with
+1.12 clusters.
+
+The CLI will use the bundled plugin in these 2 scenarios:
+
+- **The CLI is not attached to any cluster**, it will display the core commands in the help menu, if a user runs any of them they will see an error message indicating that no cluster is attached.
+
+- **The CLI is attached to a cluster** and there is no `dcos-core-cli` plugin installed. The first time a core command is invoked, the bundled core CLI will get automatically extracted into the plugins dir, the user will see an informational message (`Extracting dcos-core-cli plugin...`), the CLI will then invoke the requested core command and continue normally.
+
+This essentially makes the CLI and its core plugin look like a single piece until we figure out all the details regarding how to extract the core plugin while keeping a seamless user experience.

--- a/design/plugin.md
+++ b/design/plugin.md
@@ -95,7 +95,7 @@ While BIN plugins are not deprecated, they do not support the same set of featur
 
 As its name suggests, this command removes plugins (their name being given as arguments) locally by removing their directory from the filesystem.
 
-As the [core CLI is bundled](corecli.md) within the DC/OS CLI, trying to remove the `dcos-core-cli` plugin would trigger an error.
+As the [core CLI is bundled](corecli.md) within the DC/OS CLI, removing the `dcos-core-cli` plugin triggers an error.
 
 ## dcos plugin list
 

--- a/design/plugin.md
+++ b/design/plugin.md
@@ -95,6 +95,8 @@ While BIN plugins are not deprecated, they do not support the same set of featur
 
 As its name suggests, this command removes plugins (their name being given as arguments) locally by removing their directory from the filesystem.
 
+As the [core CLI is bundled](corecli.md) within the DC/OS CLI, trying to remove the `dcos-core-cli` plugin would trigger an error.
+
 ## dcos plugin list
 
 This command lists installed plugins, with their name, version, description and the subcommands they provide. It also accepts a --json flag.

--- a/design/setup.md
+++ b/design/setup.md
@@ -115,9 +115,6 @@ These plugins download URLs are retrieved through Cosmos, where they are registe
 The [core plugin](https://github.com/dcos/dcos-core-cli) contains subcommands such as marathon, job, node,
 package, service, task.
 
-When the core plugin can't be installed (eg. insufficient Cosmos permission or air-gapped environment),
-it then falls back to installing it from the DC/OS CLI binary itself, which bundles a core plugin.
-
 ### dcos-enterprise-cli
 
 The [enterprise plugin](https://github.com/mesosphere/dcos-enterprise-cli) gets installed when an EE
@@ -126,5 +123,4 @@ cluster is detected.
 This is determined through the [DC/OS variant](https://jira.mesosphere.com/browse/DCOS_OSS-2283) field
 (new in 1.12). For previous versions of DC/OS we won’t try to detect open / enterprise as it’d involve
 some hacks, but rather display a message saying “Please run “dcos package install dcos-enterprise-cli” if
-you use a DC/OS Enterprise cluster”. This message would also get displayed when the enterprise plugin
-installation fails, in that the process would still exit with a 0 status code as it's not a critical error.
+you use a DC/OS Enterprise cluster”.


### PR DESCRIPTION
This explains when and how the CLI core bundle is used within the CLI.

It makes sure we capture in the design pages what we're doing for the following tickets:

https://jira.mesosphere.com/browse/DCOS_OSS-4202
https://jira.mesosphere.com/browse/DCOS_OSS-4186
https://jira.mesosphere.com/browse/DCOS_OSS-4187