### PR TITLE
Support uppercase levels on the --log-level flag

### DIFF
--- a/cmd/dcos/main.go
+++ b/cmd/dcos/main.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/dcos/dcos-cli/api"
@@ -62,7 +63,7 @@ func logrusLevel(errout io.Writer, verbosity int, logLevel string) logrus.Level 
 		return logrus.InfoLevel
 	}
 
-	switch logLevel {
+	switch strings.ToLower(logLevel) {
 	case "debug":
 		fmt.Fprintln(errout, "The --log-level flag is deprecated. Please use the -vv flag.")
 		return logrus.DebugLevel


### PR DESCRIPTION
According to the following integration test:

https://github.com/dcos/dcos-core-cli/blob/f502187190bb583dd3b16cb56ba6ac89e158590c/python/lib/dcoscli/tests/integrations/test_dcos.py#L43

This legacy flag used to support uppercase log levels. This updates the
Go CLI to accept them as well.

https://jira.mesosphere.com/browse/DCOS_OSS-4189