### PR TITLE
Disable cgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ default:
 
 .PHONY: darwin linux windows
 darwin linux windows: docker-image
-	$(call inDocker,env GOOS=$(@) GO111MODULE=on go build \
+	$(call inDocker,env GOOS=$(@) GO111MODULE=on CGO_ENABLED=0 go build \
 		-ldflags '-X $(PKG)/pkg/cli/version.version=$(VERSION)' \
 		-tags '$(GO_BUILD_TAGS)' -mod=vendor \
 		-o build/$(@)/dcos$($(@)_EXE) ./cmd/dcos)


### PR DESCRIPTION
Because we're cross-compiling from a Linux jenkins builder and cgo is
disabled when cross-compiling, our Darwin and Windows CLIs don't rely on
cgo while the Linux one might.

Explicitly passing CGO_ENABLED=0 makes sure it is also disabled on
Linux.