### PR TITLE
Fix golint installation

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 install:
   - SET PATH=C:\msys64\mingw64\bin;c:\gopath\bin;%PATH%
-  - go get -u github.com/golang/lint/golint
+  - go get -u golang.org/x/lint/golint
 
 build: off
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
  - NO_DOCKER=1 GO111MODULE=on
 
 before_install:
- - env GO111MODULE=off go get -u github.com/golang/lint/golint
+ - env GO111MODULE=off go get -u golang.org/x/lint/golint
 
 script:
  - make

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.11.1
 
 RUN go get -u \
-    github.com/golang/lint/golint \
+    golang.org/x/lint/golint \
     github.com/awalterschulze/goderive \
     github.com/br-lewis/go-bindata/...
 


### PR DESCRIPTION
It should be referred to as golang.org/x/lint/golint instead.

This started to fail with: https://github.com/golang/lint/commit/9a272034dedb2a3ed05231d5604ce17fb40f0e58