### PR TITLE
Fix handling for clusters with `oauth_enabled: false`

### DIFF
--- a/design/login.md
+++ b/design/login.md
@@ -51,9 +51,9 @@ reading the `WWW-Authenticate` header DC/OS returns in the 401 response:
 }
 ```
 
-If the `Head` request returns a 200 response, the cluster has no authorization. Setup will succeed and
-the cluster will be usable but any calls to `dcos auth login` or `dcos auth list-providers` will result
-in an error.
+If the `Head` request returns a 200 response, authentication is disabled on this cluster. Setup will
+succeed and the cluster will be usable but any calls to `dcos auth login` or
+`dcos auth list-providers` will result in an error.
 
 ## Log in to a DC/OS cluster
 

--- a/design/login.md
+++ b/design/login.md
@@ -51,6 +51,10 @@ reading the `WWW-Authenticate` header DC/OS returns in the 401 response:
 }
 ```
 
+If the `Head` request returns a 200 response, the cluster has no authorization. Setup will succeed and
+the cluster will be usable but any calls to `dcos auth login` or `dcos auth list-providers` will result
+in an error.
+
 ## Log in to a DC/OS cluster
 
 "Login" is the process of presenting some credentials to a DC/OS cluster within an HTTP request which is then,

--- a/design/setup.md
+++ b/design/setup.md
@@ -83,7 +83,7 @@ not from a trusted anchor, the root CA bundle must be installed:
 The next steps is to login to the cluster, the setup command accepts the same flags as the
 `dcos auth login` command and acts similarly in this regard.
 
-If authorization is disabled on the cluster, a warning will be printed and this step will
+If authentication is disabled on the cluster, a warning will be printed and this step will
 be skipped.
 
 ### Cluster ID and name

--- a/design/setup.md
+++ b/design/setup.md
@@ -83,6 +83,9 @@ not from a trusted anchor, the root CA bundle must be installed:
 The next steps is to login to the cluster, the setup command accepts the same flags as the
 `dcos auth login` command and acts similarly in this regard.
 
+If authorization is disabled on the cluster, a warning will be printed and this step will
+be skipped.
+
 ### Cluster ID and name
 
 In order to manage different clusters, the CLI keeps track of their ID and name. The cluster ID is

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -13,6 +13,8 @@ import (
 )
 
 var (
+	// ErrAuthDisabled is the error returned when attempting to get authentication providers
+	// from a cluster without authentication.
 	ErrAuthDisabled = errors.New("authentication disabled")
 )
 

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -3,12 +3,17 @@ package login
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/dcos/dcos-cli/pkg/dcos"
 	"github.com/dcos/dcos-cli/pkg/httpclient"
 	"github.com/sirupsen/logrus"
+)
+
+var (
+	ErrAuthDisabled = errors.New("authentication disabled")
 )
 
 // Credentials is the payload for login POST requests.
@@ -86,7 +91,9 @@ func (c *Client) challengeAuth() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if resp.StatusCode != 401 {
+	if resp.StatusCode == 200 {
+		return "", ErrAuthDisabled
+	} else if resp.StatusCode != 401 {
 		return "", fmt.Errorf("expected status code 401, got %d", resp.StatusCode)
 	}
 	return resp.Header.Get("WWW-Authenticate"), nil

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -124,7 +124,9 @@ func (s *Setup) Configure(flags *Flags, clusterURL string, attach bool) (*config
 		httpClient := httpclient.New(cluster.URL(), httpOpts...)
 		var err error
 		acsToken, err = s.loginFlow.Start(flags.loginFlags, httpClient)
-		if err != nil && err != login.ErrAuthDisabled {
+		if err == login.ErrAuthDisabled {
+			s.logger.Warn("This cluster does not have authorization enabled. Skipping.")
+		} else if err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -124,7 +124,7 @@ func (s *Setup) Configure(flags *Flags, clusterURL string, attach bool) (*config
 		httpClient := httpclient.New(cluster.URL(), httpOpts...)
 		var err error
 		acsToken, err = s.loginFlow.Start(flags.loginFlags, httpClient)
-		if err != nil {
+		if err != nil && err != login.ErrAuthDisabled {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
This makes it so that `dcos cluster setup` of a cluster without authentication will not fail. `dcos auth login` and `dcos auth list-providers` will fail however but considering that a cluster without auth has no use for either of these, that seems like an acceptable tradeoff.