### PR TITLE
Update the master branch for 1.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ PKG=github.com/dcos/dcos-cli
 PKG_DIR=/go/src/$(PKG)
 IMAGE_NAME=dcos/dcos-cli
 VERSION?=$(shell git rev-parse HEAD)
-CORE_VERSION?=1.12-patch.1
+CORE_VERSION?=1.13-patch.x
+CORE_STABILITY?=testing
 
 windows_EXE=.exe
 
@@ -27,9 +28,9 @@ core-bundle: docker-image
 .PHONY: core-download
 core-download:
 	mkdir -p build/linux build/darwin build/windows
-	wget https://downloads.dcos.io/cli/releases/plugins/dcos-core-cli/linux/x86-64/dcos-core-cli-$(CORE_VERSION).zip -O build/linux/core.zip
-	wget https://downloads.dcos.io/cli/releases/plugins/dcos-core-cli/darwin/x86-64/dcos-core-cli-$(CORE_VERSION).zip -O build/darwin/core.zip
-	wget https://downloads.dcos.io/cli/releases/plugins/dcos-core-cli/windows/x86-64/dcos-core-cli-$(CORE_VERSION).zip -O build/windows/core.zip
+	wget https://downloads.dcos.io/cli/$(CORE_STABILITY)/plugins/dcos-core-cli/linux/x86-64/dcos-core-cli-$(CORE_VERSION).zip -O build/linux/core.zip
+	wget https://downloads.dcos.io/cli/$(CORE_STABILITY)/plugins/dcos-core-cli/darwin/x86-64/dcos-core-cli-$(CORE_VERSION).zip -O build/darwin/core.zip
+	wget https://downloads.dcos.io/cli/$(CORE_STABILITY)/plugins/dcos-core-cli/windows/x86-64/dcos-core-cli-$(CORE_VERSION).zip -O build/windows/core.zip
 
 .PHONY: install
 install:

--- a/ci/integration-tests.groovy
+++ b/ci/integration-tests.groovy
@@ -31,7 +31,7 @@ pipeline {
           accessKeyVariable: 'AWS_ACCESS_KEY_ID',
           secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
           [$class: 'StringBinding',
-          credentialsId: 'cee4eba4-5ac3-4b89-8d34-b0440b8b97d1',
+          credentialsId: '0b513aad-e0e0-4a82-95f4-309a80a02ff9',
           variable: 'DCOS_TEST_INSTALLER_URL'],
           [$class: 'FileBinding',
           credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',

--- a/tests/integration/test_corecli.py
+++ b/tests/integration/test_corecli.py
@@ -39,6 +39,6 @@ def test_update_core(default_cluster_with_plugins):
     ]
 
     for cmd in cmds:
-        code, out, err = exec_cmd(cmd)
+        code, out, _ = exec_cmd(cmd)
         assert code == 0
         assert out == ''


### PR DESCRIPTION
- Use DC/OS 1.13 in integration tests
- Bundle the 1.13 testing plugin in the master builds