### PR TITLE
Fix legacy release location.

### DIFF
--- a/ci/release.py
+++ b/ci/release.py
@@ -17,9 +17,9 @@ if os.environ.get("TAG_NAME"):
         ("windows/dcos.exe", "cli/releases/binaries/dcos/windows/x86-64/{}/dcos.exe".format(version)),
 
         # For tag releases, still push to the legacy location.
-        ("linux/dcos",       "binaries/cli/linux/x86-64/{}/dcos".format(version)),
-        ("darwin/dcos",      "binaries/cli/darwin/x86-64/{}/dcos".format(version)),
-        ("windows/dcos.exe", "binaries/cli/windows/x86-64/{}/dcos.exe".format(version))
+        ("linux/dcos",       "binaries/cli/linux/x86-64/dcos-1.12/dcos".format(version)),
+        ("darwin/dcos",      "binaries/cli/darwin/x86-64/dcos-1.12/dcos".format(version)),
+        ("windows/dcos.exe", "binaries/cli/windows/x86-64/dcos-1.12/dcos.exe".format(version))
     ]
 else:
     version = os.environ.get("BRANCH_NAME")

--- a/ci/release.py
+++ b/ci/release.py
@@ -10,6 +10,7 @@ import requests
 
 if os.environ.get("TAG_NAME"):
     version =  os.environ.get("TAG_NAME")
+    legacy_version_tag = "dcos-1.12"
 
     artifacts = [
         ("linux/dcos",       "cli/releases/binaries/dcos/linux/x86-64/{}/dcos".format(version)),
@@ -17,9 +18,9 @@ if os.environ.get("TAG_NAME"):
         ("windows/dcos.exe", "cli/releases/binaries/dcos/windows/x86-64/{}/dcos.exe".format(version)),
 
         # For tag releases, still push to the legacy location.
-        ("linux/dcos",       "binaries/cli/linux/x86-64/dcos-1.12/dcos".format(version)),
-        ("darwin/dcos",      "binaries/cli/darwin/x86-64/dcos-1.12/dcos".format(version)),
-        ("windows/dcos.exe", "binaries/cli/windows/x86-64/dcos-1.12/dcos.exe".format(version))
+        ("linux/dcos",       "binaries/cli/linux/x86-64/{}/dcos".format(legacy_version_tag)),
+        ("darwin/dcos",      "binaries/cli/darwin/x86-64/{}/dcos".format(legacy_version_tag)),
+        ("windows/dcos.exe", "binaries/cli/windows/x86-64/{}/dcos.exe".format(legacy_version_tag))
     ]
 else:
     version = os.environ.get("BRANCH_NAME")


### PR DESCRIPTION
The Web UI currently points to a location that the CLI does not
automatically deploy to on release because we changed the version
scheme. This hardcodes the legacy location to have the version
"dcos-1.12" to ensure that that will always have the latest stable
release