### PR TITLE
[0.7] Handled case when one locally and linked cluster found when attaching.

### DIFF
--- a/pkg/cmd/cluster/cluster_attach.go
+++ b/pkg/cmd/cluster/cluster_attach.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/dcos/dcos-cli/api"
@@ -68,8 +69,14 @@ func newCmdClusterAttach(ctx api.Context) *cobra.Command {
 			case 1:
 				// One matching linked cluster, one matching cluster.
 				if matchingConf != nil {
+					matchingClusterID := filepath.Base(filepath.Dir(matchingConf.Path()))
+					// Cluster already set up locally, attach to it.
+					if matchingLinkedClusters[0].ID == matchingClusterID {
+						return attachTo(matchingConf)
+					}
 					return config.ErrTooManyConfigs
 				}
+
 				// One matching linked cluster, no matching cluster.
 				flags := setup.NewFlags(ctx.Fs(), ctx.EnvLookup, ctx.Logger())
 				flags.LoginFlags().SetProviderID(matchingLinkedClusters[0].LoginProvider.ID)

--- a/pkg/cmd/cluster/cluster_attach_test.go
+++ b/pkg/cmd/cluster/cluster_attach_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/dcos/dcos-cli/pkg/cluster/linker"
+	"github.com/dcos/dcos-cli/pkg/config"
 	"github.com/dcos/dcos-cli/pkg/mock"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
@@ -28,6 +30,54 @@ func TestClusterAttach(t *testing.T) {
 	ctx := mock.NewContext(env)
 
 	clusterID := "79893270-f9f1-4293-9225-e6e3900043a9"
+	cmd := newCmdClusterAttach(ctx)
+	cmd.SetArgs([]string{clusterID})
+
+	require.NoError(t, cmd.Execute())
+
+	cluster, err := ctx.Cluster()
+	require.NoError(t, err)
+	require.Equal(t, clusterID, cluster.ID())
+}
+
+func TestClusterAttachBothConfiguredAndLinked(t *testing.T) {
+	env := mock.NewEnvironment()
+	env.EnvLookup = func(key string) (string, bool) {
+		if key == "DCOS_DIR" {
+			return "", true
+		}
+		return "", false
+	}
+
+	newCluster := func(id, name, url string, attached bool) *config.Cluster {
+		conf := config.New(config.Opts{Fs: env.Fs})
+		conf.Set("core.dcos_url", url)
+		conf.Set("cluster.name", name)
+		conf.SetPath(filepath.Join("clusters", id, "dcos.toml"))
+		if attached {
+			_, err := env.Fs.Create(filepath.Join("clusters", id, "attached"))
+			require.NoError(t, err)
+		}
+		require.NoError(t, conf.Persist())
+		return config.NewCluster(conf)
+	}
+
+	linkedCluster := newCluster("2234-56789-01234", "linked-and-configured", "https://example.com", false)
+
+	ts := mock.NewTestServer(mock.Cluster{
+		Links: []*linker.Link{
+			&linker.Link{
+				ID:   linkedCluster.ID(),
+				Name: linkedCluster.Name(),
+				URL:  linkedCluster.URL(),
+			},
+		},
+	})
+	defer ts.Close()
+	newCluster("1234-56789-01234", "current", ts.URL, true)
+
+	clusterID := "2234-56789-01234"
+	ctx := mock.NewContext(env)
 	cmd := newCmdClusterAttach(ctx)
 	cmd.SetArgs([]string{clusterID})
 


### PR DESCRIPTION
The issue before:
```
➜  dcos-cli (master) ✔ build/darwin/dcos cluster list
           NAME                          ID                     STATUS      VERSION                                        URL
  *  ronzalez-fakjz4f  f3a326bc-134d-47ab-bbf0-6260c857e7c6  AVAILABLE    1.12.0      https://34.212.25.125
     ronzalez-gs0b04n  27e76b1f-f63d-4f54-8d21-ae6c38d13a9b  AVAILABLE    1.12.0      https://34.222.140.41
➜  dcos-cli (master) ✔ build/darwin/dcos cluster attach ronzalez-gs0b04n
Error: multiple matches found
```
This was because ronzalez-gs0b04n xas also a cluster linked to ronzalez-fakjz4f.