### PR TITLE
 Normalize canonical URL host to lowercase

### DIFF
--- a/design/setup.md
+++ b/design/setup.md
@@ -54,7 +54,7 @@ the following redirect codes, the CLI will follow it, up to a maximum of 10 redi
 
 When there are more than 10 redirects or the status code of the last response is not 200,
 the setup flow errors-out. Otherwise, the URL associated with the last response is considered
-as the **canonical cluster URL**.
+as the **canonical cluster URL**. Its host gets normalized with lowercase characters.
 
 When the canonical cluster URL is different than the one given in argument of the `dcos cluster setup`
 command, a warning indicates to the user that the setup will continue with this new URL.

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -98,7 +98,7 @@ func (s *Setup) Configure(flags *Flags, clusterURL string, attach bool) (*config
 		}
 
 		// Make sure we continue the setup flow with the canonical cluster URL.
-		canonicalClusterURL, err := s.detectCanonicalClusterURL(cluster.URL(), httpOpts)
+		canonicalClusterURL, err := detectCanonicalClusterURL(cluster.URL(), httpOpts)
 		if err == nil {
 			if canonicalClusterURL != cluster.URL() {
 				s.logger.Warnf("Continuing cluster setup with: %s", canonicalClusterURL)
@@ -178,7 +178,7 @@ func (s *Setup) Configure(flags *Flags, clusterURL string, attach bool) (*config
 }
 
 // detectCanonicalClusterURL returns the URL with the response of the HEAD request.
-func (s *Setup) detectCanonicalClusterURL(clusterURL string, httpOpts []httpclient.Option) (string, error) {
+func detectCanonicalClusterURL(clusterURL string, httpOpts []httpclient.Option) (string, error) {
 	httpClient := httpclient.New(clusterURL, httpOpts...)
 	req, err := httpClient.NewRequest("HEAD", "/", nil)
 	if err != nil {

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -191,6 +191,8 @@ func detectCanonicalClusterURL(clusterURL string, httpOpts []httpclient.Option) 
 	}
 
 	if resp.StatusCode == 200 {
+		resp.Request.URL.Host = strings.ToLower(resp.Request.URL.Host)
+
 		return strings.TrimRight(resp.Request.URL.String(), "/"), nil
 	}
 	return "", fmt.Errorf("couldn't detect a canonical cluster URL")

--- a/pkg/setup/setup_test.go
+++ b/pkg/setup/setup_test.go
@@ -1,0 +1,24 @@
+package setup
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalURLHostCase(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "HEAD", r.Method)
+		assert.Equal(t, "/", r.URL.Path)
+
+		http.Redirect(w, r, "https://www.ExAmPlE.org", 301)
+	}))
+	defer ts.Close()
+
+	canonicalURL, err := detectCanonicalClusterURL(ts.URL, nil)
+	require.NoError(t, err)
+	require.Equal(t, "https://www.example.org", canonicalURL)
+}


### PR DESCRIPTION
Hostnames are case-insensitive and this caused issues with some
commands.

According to https://tools.ietf.org/html/rfc4343#section-6:

    For example, a user could be confused by believing that two domain
    names differing only in case were actually different names.

    These problems can usually be handled by using a standardized or
    "canonical" form of the DNS ASCII type labels; that is, always
    mapping the ASCII letter value octets in ASCII labels to some
    specific pre-chosen case, either uppercase or lower case.

https://jira.mesosphere.com/browse/DCOS_OSS-4501