### PR TITLE
Add support for relative DCOS_DIR

### DIFF
--- a/api/cli.go
+++ b/api/cli.go
@@ -40,16 +40,16 @@ type Context interface {
 	Logger() *logrus.Logger
 
 	// DCOSDir returns the root directory for the DC/OS CLI.
-	DCOSDir() string
+	DCOSDir() (string, error)
 
 	// ConfigManager returns the ConfigManager for the context.
-	ConfigManager() *config.Manager
+	ConfigManager() (*config.Manager, error)
 
 	// Cluster returns the current cluster.
 	Cluster() (*config.Cluster, error)
 
 	// Clusters returns the configured clusters.
-	Clusters() []*config.Cluster
+	Clusters() ([]*config.Cluster, error)
 
 	// HTTPClient creates an httpclient.Client for a given cluster.
 	HTTPClient(c *config.Cluster, opts ...httpclient.Option) *httpclient.Client

--- a/pkg/cli/context_test.go
+++ b/pkg/cli/context_test.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelativeDCOSDir(t *testing.T) {
+	currentDir, err := os.Getwd()
+	require.NoError(t, err)
+
+	dcosDir, err := NewContext(&Environment{
+		EnvLookup: func(key string) (string, bool) {
+			if key == "DCOS_DIR" {
+				return ".", true
+			}
+			return "", false
+		},
+	}).DCOSDir()
+	require.NoError(t, err)
+	require.Equal(t, currentDir, dcosDir)
+}

--- a/pkg/cmd/auth/auth_logout.go
+++ b/pkg/cmd/auth/auth_logout.go
@@ -13,7 +13,11 @@ func newCmdAuthLogout(ctx api.Context) *cobra.Command {
 		Short: "Log out the CLI from the current cluster",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			conf, err := ctx.ConfigManager().Current()
+			configManager, err := ctx.ConfigManager()
+			if err != nil {
+				return err
+			}
+			conf, err := configManager.Current()
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/cluster/cluster_attach.go
+++ b/pkg/cmd/cluster/cluster_attach.go
@@ -17,7 +17,10 @@ func newCmdClusterAttach(ctx api.Context) *cobra.Command {
 		Short: "Attach the CLI to a cluster",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			manager := ctx.ConfigManager()
+			manager, err := ctx.ConfigManager()
+			if err != nil {
+				return err
+			}
 
 			// We try to find a Config matching the argument given.
 			matchingConf, err := manager.Find(args[0], false)

--- a/pkg/cmd/cluster/cluster_link.go
+++ b/pkg/cmd/cluster/cluster_link.go
@@ -25,7 +25,10 @@ func newCmdClusterLink(ctx api.Context) *cobra.Command {
 			}
 
 			var linkableCluster *config.Cluster
-			manager := ctx.ConfigManager()
+			manager, err := ctx.ConfigManager()
+			if err != nil {
+				return err
+			}
 			linkableClusterConfig, err := manager.Find(args[0], false)
 			if err != nil {
 				if err != config.ErrConfigNotFound {

--- a/pkg/cmd/cluster/cluster_list.go
+++ b/pkg/cmd/cluster/cluster_list.go
@@ -26,7 +26,12 @@ func newCmdClusterList(ctx api.Context) *cobra.Command {
 				filters = append(filters, lister.Linked())
 			}
 
-			items := lister.New(ctx.ConfigManager(), ctx.Logger()).List(filters...)
+			configManager, err := ctx.ConfigManager()
+			if err != nil {
+				return err
+			}
+
+			items := lister.New(configManager, ctx.Logger()).List(filters...)
 			if attachedOnly && len(items) == 0 {
 				return errors.New("no cluster is attached. Please run `dcos cluster attach <cluster-name>`")
 			}

--- a/pkg/cmd/cluster/cluster_remove.go
+++ b/pkg/cmd/cluster/cluster_remove.go
@@ -28,9 +28,14 @@ func newCmdClusterRemove(ctx api.Context) *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			configManager, err := ctx.ConfigManager()
+			if err != nil {
+				return err
+			}
+
 			// Remove a single cluster.
 			if len(args) == 1 {
-				conf, err := ctx.ConfigManager().Find(args[0], false)
+				conf, err := configManager.Find(args[0], false)
 				if err != nil {
 					return err
 				}
@@ -48,7 +53,7 @@ func newCmdClusterRemove(ctx api.Context) *cobra.Command {
 				filters = append(filters, lister.Status(lister.StatusUnavailable))
 			}
 
-			items := lister.New(ctx.ConfigManager(), ctx.Logger()).List(filters...)
+			items := lister.New(configManager, ctx.Logger()).List(filters...)
 
 			for _, item := range items {
 				if err := ctx.Fs().RemoveAll(item.Cluster().Dir()); err != nil {

--- a/pkg/cmd/cluster/cluster_rename.go
+++ b/pkg/cmd/cluster/cluster_rename.go
@@ -12,7 +12,11 @@ func newCmdClusterRename(ctx api.Context) *cobra.Command {
 		Short: "Rename a configured cluster",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			conf, err := ctx.ConfigManager().Find(args[0], false)
+			manager, err := ctx.ConfigManager()
+			if err != nil {
+				return err
+			}
+			conf, err := manager.Find(args[0], false)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/cluster/cluster_unlink.go
+++ b/pkg/cmd/cluster/cluster_unlink.go
@@ -19,7 +19,11 @@ func newCmdClusterUnlink(ctx api.Context) *cobra.Command {
 				return err
 			}
 
-			manager := ctx.ConfigManager()
+			manager, err := ctx.ConfigManager()
+			if err != nil {
+				return err
+			}
+
 			linkedClusterConfig, err := manager.Find(args[0], false)
 			if err != nil {
 				return err

--- a/pkg/mock/mock.go
+++ b/pkg/mock/mock.go
@@ -110,9 +110,9 @@ func (ctx *Context) SetClusters(clusters []*config.Cluster) {
 }
 
 // Clusters returns the configured clusters.
-func (ctx *Context) Clusters() []*config.Cluster {
+func (ctx *Context) Clusters() ([]*config.Cluster, error) {
 	if ctx.clusters != nil {
-		return ctx.clusters
+		return ctx.clusters, nil
 	}
 	return ctx.Context.Clusters()
 }


### PR DESCRIPTION
Prior to this patch, setting a relative DCOS_DIR would cause the CLI to
fail when invoking a plugin starting from the second invocation. It
happened because the CLI prepends the DC/OS dir to a command path when
it sees it as a relative path. When a DC/OS dir is relative, that
operation would happen at every plugin invocation and grow the path
indefinitely.

This updates the DCOSDir method to prepend the current directory in case
DCOS_DIR is a relative path. It also makes it return an explicit error
in case anything goes wrong.

https://jira.mesosphere.com/browse/DCOS_OSS-4405