### PR TITLE
Updated login flow to fix provider selection when uid/password given.

### DIFF
--- a/pkg/login/flow.go
+++ b/pkg/login/flow.go
@@ -86,6 +86,8 @@ func (f *Flow) Start(flags *Flags, httpClient *httpclient.Client) (string, error
 func (f *Flow) selectProvider(providers Providers) (*Provider, error) {
 	// Explicit provider selection.
 	if f.flags.providerID != "" {
+		// TODO: If a provider ID, a username, and a password are given
+		// we should return an error. This might break some use cases.
 		provider, ok := providers[f.flags.providerID]
 		if ok {
 			return provider, nil
@@ -96,6 +98,13 @@ func (f *Flow) selectProvider(providers Providers) (*Provider, error) {
 	// Extract login provider candidates for implicit or manual selection.
 	var providerCandidates []*Provider
 	for _, provider := range providers.Slice() {
+		// If both username and password are passed, we default to dcos-uid-password.
+		// The provider does not matter in the actual request we do to the cluster,
+		// the IAM might delegate the credential validation to a directory backend via LDAP.
+		if provider.ID == DCOSUIDPassword && f.flags.username != "" && f.flags.password != "" {
+			return provider, nil
+		}
+
 		if f.flags.Supports(provider) {
 			providerCandidates = append(providerCandidates, provider)
 		} else {

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -72,7 +72,7 @@ func (prompt *Prompt) Select(msg string, choices interface{}) (int, error) {
 	choice := prompt.Input(fmt.Sprintf("(%d-%d): ", 1, choicesLen))
 	i, err := strconv.Atoi(choice)
 	if err != nil {
-		return 0, err
+		return 0, errors.New("unable to parse selected input")
 	}
 	if i < 1 || i > choicesLen {
 		return 0, fmt.Errorf("choice %d doesn't exist", i)


### PR DESCRIPTION
This resolves two issues seen in https://jira.mesosphere.com/browse/DCOS-45239.

First, if a user provides a uid and a password, we default to the provider
'DCOSUIDPassword'. This makes the behavior of the CLI the same as before.

Second, we have updated the error message when our prompt does not work
due to an input that we cannot parse.