### PR TITLE
[1.12] Updated login flow to detect when dcos-users provider is available.

### DIFF
--- a/pkg/login/flow.go
+++ b/pkg/login/flow.go
@@ -101,7 +101,7 @@ func (f *Flow) selectProvider(providers Providers) (*Provider, error) {
 		// If both username and password are passed, we default to dcos-uid-password.
 		// The provider does not matter in the actual request we do to the cluster,
 		// the IAM might delegate the credential validation to a directory backend via LDAP.
-		if provider.ID == DCOSUIDPassword && f.flags.username != "" && f.flags.password != "" {
+		if provider.Type == DCOSUIDPassword && f.flags.username != "" && f.flags.password != "" {
 			return provider, nil
 		}
 

--- a/pkg/login/flow_test.go
+++ b/pkg/login/flow_test.go
@@ -1,0 +1,41 @@
+package login
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectUIDPasswordProvider(t *testing.T) {
+	flow := NewFlow(FlowOpts{})
+	flow.flags = NewFlags(afero.NewMemMapFs(), nil, nil)
+	flow.flags.username = "hello"
+	flow.flags.password = "itsme"
+
+	providers := Providers{}
+
+	providers["login-provider-1"] = &Provider{
+		ID:           "login-provider-1",
+		Type:         DCOSUIDPassword,
+		Description:  "Default DC/OS login provider",
+		ClientMethod: methodUserCredential,
+		Config: ProviderConfig{
+			StartFlowURL: "/acs/api/v1/auth/login",
+		},
+	}
+
+	providers["login-provider-2"] = &Provider{
+		ID:           "login-provider-2",
+		Type:         DCOSUIDPassword,
+		Description:  "Default DC/OS login provider",
+		ClientMethod: methodUserCredential,
+		Config: ProviderConfig{
+			StartFlowURL: "/acs/api/v1/auth/login",
+		},
+	}
+
+	provider, err := flow.selectProvider(providers)
+	require.NoError(t, err)
+	require.True(t, provider == providers["login-provider-1"] || provider == providers["login-provider-2"])
+}


### PR DESCRIPTION
In a previous commit, we used the provider ID to detect a specific
provider  available for a cluster. This was wrong, the value
`DCOSUIDPassword` we are looking for being the provider type.

We should have caught the issue with an integration test but we
had not added one due to the wish to fix the DC/OS EE CI ASAP.