### PR TITLE
Add a script to generate a universe resource

### DIFF
--- a/ci/generate_universe_resource.py
+++ b/ci/generate_universe_resource.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+# Usage example:
+#   ./generate_universe_resource.py dcos-core-cli 1.12-patch.2
+
+import json
+import sys
+import hashlib as hash
+
+import requests
+
+
+plugin_name = sys.argv[1]
+plugin_version = sys.argv[2]
+
+resource =	{
+  "cli": {
+      "binaries": {}
+  }
+}
+
+for platform in ['linux', 'darwin', 'windows']:
+    url = "https://downloads.dcos.io/cli/releases/plugins/{}/{}/x86-64/{}-{}.zip".format(
+        plugin_name, platform, plugin_name, plugin_version)
+
+    sha = hash.sha256()
+    r = requests.get(url, stream=True)
+    for chunk in r.iter_content(1024):
+        sha.update(chunk)
+
+    resource['cli']['binaries'][platform] = {
+        'x86-64': {
+            'kind': 'zip',
+            'url': url,
+            'contentHash': [
+                {
+                    'algo': 'sha256',
+                    'value': sha.hexdigest()
+                }
+            ]
+        }
+    }
+
+json.dump(resource, sys.stdout, indent=4)


### PR DESCRIPTION
The generate_universe_resource.py script can be used to generate
resource files for universe. It takes as argument a plugin name and a
version and uses them to download the plugins from their canonical URLs
and generate sha256 checksums accordingly.

https://jira.mesosphere.com/browse/DCOS_OSS-1797