### PR TITLE
Updated CHANGELOG.md and bumped `dcos-core-cli` version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Next
 
+## 0.7.4
+
+* Features
+
+  * Build the CLI with 1.12-patch.3
+  * Enable bash completion to be compatible with zsh
+
 * Bugfixes
 
   * Drop support for DCOS_URL and DCOS_ACS_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PKG=github.com/dcos/dcos-cli
 PKG_DIR=/go/src/$(PKG)
 IMAGE_NAME=dcos/dcos-cli
 VERSION?=$(shell git rev-parse HEAD)
-CORE_VERSION?=1.12-patch.2
+CORE_VERSION?=1.12-patch.3
 
 windows_EXE=.exe
 


### PR DESCRIPTION
This commit prepares for a new release of the `dcos-cli`.