### PR TITLE
Fixed emitting empty `uid` value in login credentials.

### DIFF
--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -20,7 +20,7 @@ var (
 
 // Credentials is the payload for login POST requests.
 type Credentials struct {
-	UID      string `json:"uid"`
+	UID      string `json:"uid,omitempty"`
 	Password string `json:"password,omitempty"`
 	Token    string `json:"token,omitempty"`
 }


### PR DESCRIPTION
With this commit we fix that the CLI only emits the `uid` value in the
login credentials when explicitly setting it. This is needed to fix a
bug when using the `browser-prompt-oidcidtoken-get-authtoken` method.

https://jira.mesosphere.com/browse/DCOS_OSS-4599