### PR TITLE
DO NOT MERGE! Testing winpy354 label

### DIFF
--- a/ci/integration-tests.groovy
+++ b/ci/integration-tests.groovy
@@ -107,7 +107,7 @@ pipeline {
         stage("Run Windows integration tests") {
           agent {
             node {
-              label 'windows'
+              label 'winpy354'
               customWorkspace 'C:\\windows\\workspace'
             }
           }


### PR DESCRIPTION
This patch is to ensure that the new potential replacement for the existing Jenkins worker has the proper keys and access, etc.  Please do not merge this patch.