### PR TITLE
 Add validation for `dcos config set core.ssl_verify`

### DIFF
--- a/pkg/cmd/config/config_set.go
+++ b/pkg/cmd/config/config_set.go
@@ -18,7 +18,11 @@ func newCmdConfigSet(ctx api.Context) *cobra.Command {
 				return err
 			}
 			conf := cluster.Config()
-			conf.Set(args[0], args[1])
+			err = conf.Set(args[0], args[1])
+			if err != nil {
+				return err
+			}
+
 			err = conf.Persist()
 			if err != nil {
 				return err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,7 +24,7 @@ const (
 	keyPagination     = "core.pagination"
 	keyReporting      = "core.reporting"
 	keyMesosMasterURL = "core.mesos_master_url"
-	keyPrompLogin     = "core.prompt_login"
+	keyPromptLogin    = "core.prompt_login"
 	keyClusterName    = "cluster.name"
 )
 
@@ -170,8 +170,8 @@ func (c *Config) Set(key string, val interface{}) {
 	case keyTimeout:
 		// go-toml requires int64
 		val = cast.ToInt64(val)
-	case keyPagination, keyReporting, keyPrompLogin:
 		val = cast.ToBool(val)
+	case keyPagination, keyReporting, keyPromptLogin:
 	default:
 		val = cast.ToString(val)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -104,7 +104,7 @@ name = "mr-cluster"
 	require.Equal(t, true, store.Get(keyPagination).(bool))
 	require.Equal(t, true, store.Get(keyReporting).(bool))
 	require.Equal(t, "https://mesos.example.com", store.Get(keyMesosMasterURL).(string))
-	require.Equal(t, true, store.Get(keyPrompLogin).(bool))
+	require.Equal(t, true, store.Get(keyPromptLogin).(bool))
 	require.Equal(t, "mr-cluster", store.Get(keyClusterName).(string))
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -174,6 +174,23 @@ func TestSetAndUnset(t *testing.T) {
 	require.Nil(t, store.Get(keyURL))
 }
 
+func TestSetTLS(t *testing.T) {
+	store := New(Opts{
+		Fs: afero.NewMemMapFs(),
+	})
+
+	require.Error(t, store.Set(keyTLS, "no"))
+	require.Error(t, store.Set(keyTLS, "/invalid/path"))
+
+	f, _ := afero.TempFile(store.Fs(), "/", "ca")
+	f.Write([]byte("Let's say I am an authority."))
+	require.NoError(t, store.Set("core.ssl_verify", f.Name()))
+	require.NoError(t, store.Set(keyTLS, "true"))
+	require.NoError(t, store.Set(keyTLS, "false"))
+	require.NoError(t, store.Set(keyTLS, "1"))
+	require.NoError(t, store.Set(keyTLS, "0"))
+}
+
 func TestACSTokenIsUnsetOnURLUpdate(t *testing.T) {
 	store := New(Opts{})
 


### PR DESCRIPTION
When an invalid value is passed, the command now returns with an error.

https://jira.mesosphere.com/browse/DCOS-11460