### PR TITLE
Build master commits to the dcos-1.13 CLI bucket

### DIFF
--- a/ci/release.py
+++ b/ci/release.py
@@ -35,7 +35,12 @@ else:
     artifacts = [
         ("linux/dcos",       "cli/testing/binaries/dcos/linux/x86-64/{}/dcos".format(version)),
         ("darwin/dcos",      "cli/testing/binaries/dcos/darwin/x86-64/{}/dcos".format(version)),
-        ("windows/dcos.exe", "cli/testing/binaries/dcos/windows/x86-64/{}/dcos.exe".format(version))
+        ("windows/dcos.exe", "cli/testing/binaries/dcos/windows/x86-64/{}/dcos.exe".format(version)),
+
+        # TODO: remove when DC/OS 1.13 is released.
+        ("linux/dcos",       "binaries/cli/linux/x86-64/dcos-1.13/dcos"),
+        ("darwin/dcos",      "binaries/cli/darwin/x86-64/dcos-1.13/dcos"),
+        ("windows/dcos.exe", "binaries/cli/windows/x86-64/dcos-1.13/dcos.exe")
     ]
 
 s3_client = boto3.resource('s3', region_name='us-west-2').meta.client


### PR DESCRIPTION
According to https://jira.mesosphere.com/browse/DCOS-46572, the DC/OS
1.13 CLI will have its own CLI. We'll only drop the dcos-1.XX URL
buckets for DC/OS 1.14, thus we need to have a dcos-1.13 CLI endpoint.

Once DC/OS 1.13 is released this commit needs to be reverted.