### PR TITLE
[backport] Make sure the Auth token is empty when challenging auth

### DIFF
--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -115,6 +115,11 @@ func (c *Client) sniffAuth(acsToken string) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
+	if acsToken == "" {
+		// When an empty ACS token is passed, we're challenging auth.
+		// Make sure the Authorization header is empty.
+		delete(req.Header, "Authorization")
+	}
 	return c.http.Do(req)
 }
 

--- a/pkg/login/login_test.go
+++ b/pkg/login/login_test.go
@@ -107,3 +107,23 @@ func TestSniffAuth(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 403, resp.StatusCode)
 }
+
+func TestChallengeAuth(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/pkgpanda/active.buildinfo.full.json", func(w http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "HEAD", req.Method)
+
+		_, ok := req.Header["Authorization"]
+		assert.False(t, ok)
+		w.WriteHeader(403)
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := NewClient(httpclient.New(ts.URL, httpclient.ACSToken("abc")), &logrus.Logger{Out: ioutil.Discard})
+
+	resp, err := client.sniffAuth("")
+	require.NoError(t, err)
+	require.Equal(t, 403, resp.StatusCode)
+}

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1,0 +1,12 @@
+from .common import exec_cmd, default_cluster  # noqa: F401
+
+
+def test_auth_login(default_cluster):
+    code, out, err = exec_cmd(
+        ['dcos', 'auth', 'login',
+         '--username', default_cluster['username'],
+         '--password', default_cluster['password']])
+
+    assert code == 0
+    assert out == ''
+    assert err == ''


### PR DESCRIPTION
When challenging auth we must ensure the auth token is empty, otherwise
we might get a 200 and the command will fail with "Authentication
disabled".

https://jira.mesosphere.com/browse/DCOS_OSS-4660