### PR TITLE
Add a test installing certified packages CLIs

### DIFF
--- a/tests/integration/test_package.py
+++ b/tests/integration/test_package.py
@@ -1,0 +1,12 @@
+from .common import exec_cmd, default_cluster  # noqa: F401
+
+
+def test_install_certified_packages_cli(default_cluster):
+    pkgs = [
+        'cassandra',
+        'kubernetes',
+    ]
+
+    for pkg in pkgs:
+        code, _, _ = exec_cmd(['dcos', 'package', 'install', '--cli', '--yes', pkg])
+        assert code == 0


### PR DESCRIPTION
For now it only contains `kubernetes` and `cassandra`. We'll add more in the future.

https://jira.mesosphere.com/browse/DCOS-47826