### PR TITLE
Fix cluster attach when no cluster is attached

### DIFF
--- a/pkg/cmd/cluster/cluster_attach.go
+++ b/pkg/cmd/cluster/cluster_attach.go
@@ -39,7 +39,7 @@ func newCmdClusterAttach(ctx api.Context) *cobra.Command {
 
 			currentCluster, err := ctx.Cluster()
 			if err != nil {
-				if err == config.ErrConfigNotFound {
+				if err == config.ErrNotAttached && matchingConf != nil {
 					return attachTo(matchingConf)
 				}
 				return err

--- a/pkg/cmd/cluster/cluster_attach_test.go
+++ b/pkg/cmd/cluster/cluster_attach_test.go
@@ -41,6 +41,34 @@ func TestClusterAttach(t *testing.T) {
 	require.Equal(t, clusterID, cluster.ID())
 }
 
+func TestClusterAttachMultiple(t *testing.T) {
+	var out bytes.Buffer
+	env := mock.NewEnvironment()
+	env.Fs = afero.NewCopyOnWriteFs(
+		afero.NewReadOnlyFs(afero.NewOsFs()),
+		afero.NewMemMapFs(),
+	)
+	env.EnvLookup = func(key string) (string, bool) {
+		if key == cli.EnvDCOSDir {
+			return filepath.Join("testdata", "cluster_attach_multiple", ".dcos"), true
+		}
+		return "", false
+	}
+	env.Out = &out
+
+	ctx := mock.NewContext(env)
+
+	clusterID := "79893270-f9f1-4293-9225-e6e3900043a9"
+	cmd := newCmdClusterAttach(ctx)
+	cmd.SetArgs([]string{clusterID})
+
+	require.NoError(t, cmd.Execute())
+
+	cluster, err := ctx.Cluster()
+	require.NoError(t, err)
+	require.Equal(t, clusterID, cluster.ID())
+}
+
 func TestClusterAttachBothConfiguredAndLinked(t *testing.T) {
 	env := mock.NewEnvironment()
 	env.EnvLookup = func(key string) (string, bool) {

--- a/pkg/cmd/cluster/testdata/cluster_attach_multiple/.dcos/clusters/29891250-f9f1-4293-9225-e6e3900043a8/dcos.toml
+++ b/pkg/cmd/cluster/testdata/cluster_attach_multiple/.dcos/clusters/29891250-f9f1-4293-9225-e6e3900043a8/dcos.toml
@@ -1,0 +1,2 @@
+[cluster]
+name = "config_unattached"

--- a/pkg/cmd/cluster/testdata/cluster_attach_multiple/.dcos/clusters/79893270-f9f1-4293-9225-e6e3900043a9/dcos.toml
+++ b/pkg/cmd/cluster/testdata/cluster_attach_multiple/.dcos/clusters/79893270-f9f1-4293-9225-e6e3900043a9/dcos.toml
@@ -1,0 +1,2 @@
+[cluster]
+name = "other_config_unattached"

--- a/pkg/cmd/dcos.go
+++ b/pkg/cmd/dcos.go
@@ -3,7 +3,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -46,7 +45,7 @@ func NewDCOSCommand(ctx api.Context) *cobra.Command {
 			case "job", "marathon", "node", "package", "service", "task":
 				cluster, err := ctx.Cluster()
 				if err != nil {
-					return errors.New("no cluster is attached")
+					return config.ErrNotAttached
 				}
 				corePlugin, err := extractCorePlugin(ctx, cluster)
 				if err != nil {

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -30,6 +30,9 @@ type Manager struct {
 	dir       string
 }
 
+// ErrNotAttached indicates that no cluster is attached.
+var ErrNotAttached = errors.New("no cluster is attached")
+
 // ErrConfigNotFound means that the manager cannot find a config using a name/id.
 var ErrConfigNotFound = errors.New("no match found")
 
@@ -79,7 +82,7 @@ func (m *Manager) Current() (*Config, error) {
 		}
 	}
 	if currentConfig == nil {
-		return nil, errors.New("no cluster is attached")
+		return nil, ErrNotAttached
 	}
 	return currentConfig, nil
 }


### PR DESCRIPTION
This is a follow-up from 9b85cc927874a51539ccc8525e084689f32369cb,
the patch only worked when no cluster is attached and there is a single
cluster configured...

This fixes the case when there are multiple clusters without any of them
being attached and one runs `dcos cluster attach <cluster>`.

https://jira.mesosphere.com/browse/DCOS-47191