### PR TITLE
Use a 3 minutes timeout for /package/describe

### DIFF
--- a/pkg/internal/cosmos/client.go
+++ b/pkg/internal/cosmos/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/url"
+	"time"
 
 	"github.com/dcos/dcos-cli/pkg/httpclient"
 )
@@ -63,7 +64,16 @@ func (c *Client) DescribePackage(name string) (*PackageInfo, error) {
 		return nil, err
 	}
 
-	req, err := c.http.NewRequest("POST", "/package/describe", &reqBody, httpclient.FailOnErrStatus(true))
+	req, err := c.http.NewRequest(
+		"POST",
+		"/package/describe",
+		&reqBody,
+
+		// Hardcode a 3 minutes timeout as Cosmos can take some time
+		// to respond when there are multiple configured repositories.
+		httpclient.Timeout(3*time.Minute),
+		httpclient.FailOnErrStatus(true),
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The default 5 seconds during cluster setup shown some failures in CI:

https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-cluster-ops%2Fmesosphere-dcos-cli%2Fintegration-tests/detail/integration-tests/178/pipeline/48/