### PR TITLE
Update the deprecation message when using the bundled core plugin

### DIFF
--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -210,6 +210,7 @@ func (ctx *Context) Setup(flags *setup.Flags, clusterURL string, attach bool) (*
 		LoginFlow:     ctx.loginFlow(),
 		ConfigManager: configManager,
 		PluginManager: ctx.PluginManager(nil),
+		Deprecated:    ctx.Deprecated,
 	}).Configure(flags, clusterURL, attach)
 }
 

--- a/pkg/cmd/dcos.go
+++ b/pkg/cmd/dcos.go
@@ -152,11 +152,8 @@ func newPluginCommand(ctx api.Context, cmd plugin.Command) *cobra.Command {
 
 // extractCorePlugin extracts the bundled core plugin into the plugins folder.
 func extractCorePlugin(ctx api.Context, cluster *config.Cluster) (*plugin.Plugin, error) {
-	ctx.Logger().Warn(`Extracting "dcos-core-cli"...
-This setup is deprecated, see https://docs.mesosphere.com/1.12/cli/experiments/#automatic-installation-of-core-and-enterprise-cli-plugins for more information.`)
-
 	pluginManager := ctx.PluginManager(cluster)
-	err := corecli.InstallPlugin(ctx.Fs(), pluginManager)
+	err := corecli.InstallPlugin(ctx.Fs(), pluginManager, ctx.Deprecated)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/internal/corecli/corecli.go
+++ b/pkg/internal/corecli/corecli.go
@@ -59,7 +59,12 @@ func extractPlugin(fs afero.Fs) (string, error) {
 }
 
 // InstallPlugin installs the core plugin bundled with the CLI.
-func InstallPlugin(fs afero.Fs, pluginManager *plugin.Manager) error {
+func InstallPlugin(fs afero.Fs, pluginManager *plugin.Manager, deprecated func(msg string) error) error {
+	if err := deprecated(`Extracting "dcos-core-cli"...
+This setup is deprecated, see https://docs.mesosphere.com/1.13/cli/plugins/ for more information.`); err != nil {
+		return err
+	}
+
 	pluginFilePath, err := extractPlugin(fs)
 	if err != nil {
 		return err

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -44,6 +44,7 @@ type Opts struct {
 	ConfigManager *config.Manager
 	PluginManager *plugin.Manager
 	EnvLookup     func(key string) (string, bool)
+	Deprecated    func(msg string) error
 }
 
 // Setup represents a cluster setup.
@@ -56,6 +57,7 @@ type Setup struct {
 	configManager *config.Manager
 	pluginManager *plugin.Manager
 	envLookup     func(key string) (string, bool)
+	deprecated    func(msg string) error
 }
 
 // New creates a new setup.
@@ -69,6 +71,7 @@ func New(opts Opts) *Setup {
 		configManager: opts.ConfigManager,
 		pluginManager: opts.PluginManager,
 		envLookup:     opts.EnvLookup,
+		deprecated:    opts.Deprecated,
 	}
 }
 
@@ -318,7 +321,7 @@ func (s *Setup) installDefaultPlugins(httpClient *httpclient.Client) error {
 	pbar.Wait()
 	if errCore != nil {
 		// Extract the dcos-core-cli bundle if it coudln't be downloaded.
-		errCore = corecli.InstallPlugin(s.fs, s.pluginManager)
+		errCore = corecli.InstallPlugin(s.fs, s.pluginManager, s.deprecated)
 	}
 	return errCore
 }

--- a/tests/integration/test_cluster.py
+++ b/tests/integration/test_cluster.py
@@ -101,3 +101,26 @@ def test_cluster_setup_bundled_core_plugin():
 
         assert len(plugins) == 1
         assert plugins[0]['name'] == 'dcos-core-cli'
+
+
+def test_cluster_setup_bundled_core_plugin_strict_mode():
+    env = {**os.environ.copy(), **{
+        'DCOS_CLUSTER_SETUP_SKIP_CANONICAL_URL_INSTALL': '1',
+        'DCOS_CLUSTER_SETUP_SKIP_COSMOS_INSTALL': '1',
+        'DCOS_CLI_STRICT_DEPRECATIONS': '1',
+    }}
+
+    cmd = 'dcos cluster setup --username={} --password={} http://{}'.format(
+        os.environ.get('DCOS_TEST_DEFAULT_CLUSTER_USERNAME'),
+        os.environ.get('DCOS_TEST_DEFAULT_CLUSTER_PASSWORD'),
+        os.environ.get('DCOS_TEST_DEFAULT_CLUSTER_HOST'))
+
+    code, out, err = exec_cmd(cmd.split(' '), env=env)
+
+    assert code != 0
+    assert out == ""
+    assert err == ("Extracting \"dcos-core-cli\"...\n"
+                   "This setup is deprecated, see "
+                   "https://docs.mesosphere.com/1.13/cli/plugins/ "
+                   "for more information.\n"
+                   "Error: usage of deprecated feature\n")


### PR DESCRIPTION
It also adds support for the strict deprecations mode. When it is
enabled, the CLI will fail instead of falling back to using the bundled
core plugin.

https://jira.mesosphere.com/browse/DCOS_OSS-4724