### PR TITLE
Add homebrew formula to install `dcos-cli` via `brew`

### DIFF
--- a/dcos-cli.rb
+++ b/dcos-cli.rb
@@ -1,0 +1,25 @@
+class DcosCli < Formula
+  desc "The DC/OS command-line interface"
+  homepage "https://docs.mesosphere.com/latest/cli/"
+  head "https://github.com/dcos/dcos-cli.git"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    ENV["NO_DOCKER"] = "1"
+
+    bin_path = buildpath/"src/github.com/dcos/dcos-cli"
+
+    bin_path.install Dir["*"]
+    cd bin_path do
+      system "make", "darwin"
+      bin.install "build/darwin/dcos"
+    end
+  end
+
+  test do
+    run_output = shell_output("#{bin}/dcos --version 2>&1")
+    assert_match "dcoscli.version=testing/master", run_output
+  end
+end


### PR DESCRIPTION
Version [master](https://github.com/dcos/dcos-cli/archive/master.tar.gz)