### PR TITLE
Upgrade the CLI to use Go 1.12.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 
 language: go
 
-go: "1.11.x"
+go: "1.12.x"
 
 go_import_path: github.com/dcos/dcos-cli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11
+FROM golang:1.12
 
 RUN go get -u \
     golang.org/x/lint/golint \

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ available in the [DC/OS docs](https://dcos.io/docs/).
 
 1.  [git](http://git-scm.com) must be installed to download the source
     code for the DC/OS CLI.
-2.  [go](https://golang.org/dl/) 1.11+ or docker.
+2.  [go](https://golang.org/dl/) 1.12+ or docker.
 3.  [win-bash](https://sourceforge.net/projects/win-bash/files/shell-complete/latest)
    must be installed if you are using Windows in order to run setup scripts
    from the Makefile.


### PR DESCRIPTION
This does not change our supported operating systems, Go 1.12 being the
last release supporting macOS 10.10 Yosemite.