### PR TITLE
Make the plugin runtime safe for concurrent usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+* Bugfixes
+
+  * Make the plugin runtime safe for concurrent usage
+
 ## 0.7.9
 
 * Security fixes

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -26,6 +26,11 @@ import (
 	"github.com/spf13/afero"
 )
 
+// ExistError indicates that a plugin installation failed because it's already installed.
+type ExistError struct {
+	error
+}
+
 // Manager retrieves the plugins available for the current cluster
 // by navigating into the filesystem.
 type Manager struct {
@@ -82,9 +87,17 @@ func (m *Manager) Install(resource string, installOpts *InstallOpts) (err error)
 		installOpts.path = resource
 	}
 
-	// The staging dir is where the plugin will be constructed
-	// before eventually getting moved to its final location.
-	installOpts.stagingDir, err = afero.TempDir(m.fs, os.TempDir(), "dcos-cli")
+	if err := m.fs.MkdirAll(m.tempDir(), 0755); err != nil {
+		return err
+	}
+
+	// The staging dir is where the plugin will be constructed before eventually getting moved to
+	// its final location. It relies on a temp directory inside the cluster directory instead of
+	// the system's temp directory, otherwise this would cause issues when the system's temp dir
+	// and the DC/OS dir are on different devices.
+	//
+	// See https://groups.google.com/forum/m/#!topic/golang-dev/5w7Jmg_iCJQ.
+	installOpts.stagingDir, err = afero.TempDir(m.fs, m.tempDir(), "dcos-cli")
 	if err != nil {
 		return err
 	}
@@ -172,8 +185,8 @@ func (m *Manager) loadPlugin(name string) (*Plugin, error) {
 
 	// Save a deep copy of the plugin once it's loaded from the plugin.toml file.
 	persistedPlugin := &Plugin{}
-	deriveDeepCopy(persistedPlugin, plugin)
 	plugin.dir = pluginPath
+	deriveDeepCopy(persistedPlugin, plugin)
 
 	if len(plugin.Commands) == 0 {
 		plugin.Commands = m.findCommands(pluginPath)
@@ -192,7 +205,9 @@ func (m *Manager) loadPlugin(name string) (*Plugin, error) {
 
 	// Compare the normalized plugin with the saved copy to know whether or not the file should be updated.
 	if !reflect.DeepEqual(persistedPlugin, plugin) {
-		m.persistPlugin(plugin, pluginFilePath)
+		if err := m.persistPlugin(plugin, pluginFilePath); err != nil {
+			m.logger.Debug(err)
+		}
 	}
 	return plugin, nil
 }
@@ -257,19 +272,33 @@ func (m *Manager) unmarshalPlugin(plugin *Plugin, path string) error {
 }
 
 // persistPlugin saves a `plugin.toml` file representing the plugin.
-func (m *Manager) persistPlugin(plugin *Plugin, path string) {
-	pluginTOML, err := toml.Marshal(*plugin)
-	if err == nil {
-		err = afero.WriteFile(m.fs, path, pluginTOML, 0644)
+func (m *Manager) persistPlugin(plugin *Plugin, path string) error {
+	if err := m.fs.MkdirAll(m.tempDir(), 0755); err != nil {
+		return err
 	}
+
+	f, err := afero.TempFile(m.fs, m.tempDir(), "plugin.toml")
 	if err != nil {
-		m.logger.Debug(err)
+		return err
 	}
+
+	defer m.fs.Remove(f.Name())
+	defer f.Close()
+
+	if err := toml.NewEncoder(f).Encode(*plugin); err != nil {
+		return err
+	}
+	return m.fs.Rename(f.Name(), path)
 }
 
 // pluginsDir returns the path to the plugins directory.
 func (m *Manager) pluginsDir() string {
 	return filepath.Join(m.cluster.Dir(), "subcommands")
+}
+
+// tempDir returns the path to the temp directory.
+func (m *Manager) tempDir() string {
+	return filepath.Join(m.cluster.Dir(), "tmp")
 }
 
 // downloadPlugin downloads a plugin and returns the path to the temporary file it stored it to.
@@ -379,29 +408,24 @@ func (m *Manager) buildPlugin(installOpts *InstallOpts) error {
 func (m *Manager) installPlugin(installOpts *InstallOpts) error {
 	dest := filepath.Join(m.pluginsDir(), installOpts.Name)
 
-	if installOpts.Update {
-		if err := m.fs.RemoveAll(dest); err != nil {
-			return err
-		}
-	} else {
-		pluginDirExists, err := afero.DirExists(m.fs, dest)
-		if err != nil {
-			m.logger.Debug(err)
-		}
-		if pluginDirExists {
-			return fmt.Errorf("'%s' is already installed", installOpts.Name)
-		}
-	}
-
 	if err := m.fs.MkdirAll(filepath.Dir(dest), 0755); err != nil {
 		return err
 	}
 
-	// Copy the plugin folder to its final location. We don't move it as this causes
-	// issues when the system's temp dir and the DC/OS dir are on different devices.
-	// See https://groups.google.com/forum/m/#!topic/golang-dev/5w7Jmg_iCJQ.
-	defer m.fs.RemoveAll(installOpts.stagingDir)
-	return fsutil.CopyDir(m.fs, installOpts.stagingDir, dest)
+	if installOpts.Update {
+		if err := m.fs.RemoveAll(dest); err != nil {
+			return err
+		}
+	}
+
+	err := m.fs.Rename(installOpts.stagingDir, dest)
+	if err != nil {
+		defer m.fs.RemoveAll(installOpts.stagingDir)
+		if os.IsExist(err) {
+			return ExistError{fmt.Errorf("'%s' is already installed", installOpts.Name)}
+		}
+	}
+	return err
 }
 
 // httpClient returns the appropriate HTTP client for a given resource.

--- a/tests/integration/test_corecli.py
+++ b/tests/integration/test_corecli.py
@@ -1,9 +1,12 @@
 import json
 import os
+import sys
 
-from .common import exec_cmd, default_cluster, default_cluster_with_plugins  # noqa: F401
+from concurrent import futures
 
 import pytest
+
+from .common import exec_cmd, default_cluster, default_cluster_with_plugins  # noqa: F401
 
 
 @pytest.mark.skipif(os.environ.get('DCOS_TEST_CORECLI') is None, reason="no core CLI bundle")
@@ -28,6 +31,21 @@ def test_extract_core(default_cluster):
     assert code != 0
     assert out == ''
     assert err == "Error: the core plugin can't be removed\n"
+
+
+@pytest.mark.skipif(os.environ.get('DCOS_TEST_CORECLI') is None, reason="no core CLI bundle")
+@pytest.mark.skipif(sys.platform == 'win32',
+                    reason='Not yet concurrent-safe on Windows (DCOS_OSS-4843)')
+def test_extract_core_concurrently(default_cluster):
+    with futures.ThreadPoolExecutor() as pool:
+        cmds = [pool.submit(exec_cmd, ['dcos', 'node']) for _ in range(50)]
+
+        completed, _ = futures.wait(cmds, timeout=60)
+        assert len(completed) == 50
+
+        for cmd in completed:
+            code, out, err = cmd.result()
+            assert code == 0, out + err
 
 
 def test_update_core(default_cluster_with_plugins):

--- a/tests/integration/test_plugin.py
+++ b/tests/integration/test_plugin.py
@@ -3,6 +3,10 @@ import os
 import shutil
 import sys
 
+from concurrent import futures
+
+import pytest
+
 from .common import setup_cluster, exec_cmd, default_cluster, default_cluster_with_plugins  # noqa: F401
 
 
@@ -87,6 +91,22 @@ def test_plugin_invocation_tls():
 
         assert out['env'].get('DCOS_TLS_INSECURE') == '1'
         assert out['env'].get('DCOS_TLS_CA_PATH') is None
+
+
+@pytest.mark.skipif(sys.platform == 'win32',
+                    reason='Not yet concurrent-safe on Windows (DCOS_OSS-4843)')
+def test_plugin_concurrent_invocation(default_cluster):
+    _install_test_plugin()
+
+    with futures.ThreadPoolExecutor() as pool:
+        cmds = [pool.submit(exec_cmd, ['dcos', 'test', 'arg']) for _ in range(50)]
+
+        completed, _ = futures.wait(cmds, timeout=30)
+        assert len(completed) == 50
+
+        for cmd in completed:
+            code, out, err = cmd.result()
+            assert code == 0, out + err
 
 
 def test_plugin_verbosity(default_cluster):


### PR DESCRIPTION
It was previously reading/writing/overwriting files in-place without any
synchronization mechanism.

This commit introduces a `tmp` directory inside the cluster's dir, which
is used as a staging directory for writing files before they are
eventually moved atomically to their final location.

https://jira.mesosphere.com/browse/DCOS_OSS-4843