### PR TITLE
Invalid command usage should return with an error

### DIFF
--- a/pkg/cmd/auth/auth.go
+++ b/pkg/cmd/auth/auth.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"fmt"
+
 	"github.com/dcos/dcos-cli/api"
 	"github.com/spf13/cobra"
 )
@@ -10,6 +12,13 @@ func NewCommand(ctx api.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
 		Short: "Authenticate to DC/OS cluster",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			fmt.Fprintln(ctx.ErrOut(), cmd.UsageString())
+			return fmt.Errorf("unknown command %s", args[0])
+		},
 	}
 	cmd.AddCommand(
 		newCmdAuthListProviders(ctx),

--- a/pkg/cmd/cluster/cluster.go
+++ b/pkg/cmd/cluster/cluster.go
@@ -1,6 +1,8 @@
 package cluster
 
 import (
+	"fmt"
+
 	"github.com/dcos/dcos-cli/api"
 	"github.com/spf13/cobra"
 )
@@ -10,6 +12,13 @@ func NewCommand(ctx api.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cluster",
 		Short: "Manage your DC/OS clusters",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			fmt.Fprintln(ctx.ErrOut(), cmd.UsageString())
+			return fmt.Errorf("unknown command %s", args[0])
+		},
 	}
 	cmd.AddCommand(
 		newCmdClusterAttach(ctx),

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/dcos/dcos-cli/api"
 	"github.com/spf13/cobra"
 )
@@ -10,6 +12,13 @@ func NewCommand(ctx api.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Manage the DC/OS configuration file",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			fmt.Fprintln(ctx.ErrOut(), cmd.UsageString())
+			return fmt.Errorf("unknown command %s", args[0])
+		},
 	}
 	cmd.AddCommand(
 		newCmdConfigSet(ctx),

--- a/pkg/cmd/dcos.go
+++ b/pkg/cmd/dcos.go
@@ -57,6 +57,7 @@ func NewDCOSCommand(ctx api.Context) *cobra.Command {
 					}
 				}
 			}
+			fmt.Fprintln(ctx.ErrOut(), cmd.UsageString())
 			return fmt.Errorf("unknown command %s", args[0])
 		},
 	}

--- a/pkg/cmd/plugin/plugin.go
+++ b/pkg/cmd/plugin/plugin.go
@@ -1,6 +1,8 @@
 package plugin
 
 import (
+	"fmt"
+
 	"github.com/dcos/dcos-cli/api"
 	"github.com/spf13/cobra"
 )
@@ -10,6 +12,13 @@ func NewCommand(ctx api.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "plugin",
 		Short: "Manage CLI plugins",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return cmd.Help()
+			}
+			fmt.Fprintln(ctx.ErrOut(), cmd.UsageString())
+			return fmt.Errorf("unknown command %s", args[0])
+		},
 	}
 	cmd.AddCommand(
 		newCmdPluginAdd(ctx),

--- a/tests/integration/test_auth.py
+++ b/tests/integration/test_auth.py
@@ -1,6 +1,54 @@
 from .common import exec_cmd, default_cluster  # noqa: F401
 
 
+def test_auth_help():
+    code, out, err = exec_cmd(['dcos', 'auth'])
+    assert code == 0
+    assert err == ''
+    assert out == '''Authenticate to DC/OS cluster
+
+Usage:
+  dcos auth [command]
+
+Commands:
+  list-providers
+      List available login providers for a cluster
+  login
+      Log in to the current cluster
+  logout
+      Log out the CLI from the current cluster
+
+Options:
+  -h, --help   help for auth
+
+Use "dcos auth [command] --help" for more information about a command.
+'''
+
+
+def test_auth_invalid_usage():
+    code, out, err = exec_cmd(['dcos', 'auth', 'not-a-command'])
+    assert code != 0
+    assert out == ''
+    assert err == '''Usage:
+  dcos auth [command]
+
+Commands:
+  list-providers
+      List available login providers for a cluster
+  login
+      Log in to the current cluster
+  logout
+      Log out the CLI from the current cluster
+
+Options:
+  -h, --help   help for auth
+
+Use "dcos auth [command] --help" for more information about a command.
+
+Error: unknown command not-a-command
+'''
+
+
 def test_auth_login(default_cluster):
     code, out, err = exec_cmd(
         ['dcos', 'auth', 'login',

--- a/tests/integration/test_cluster.py
+++ b/tests/integration/test_cluster.py
@@ -4,6 +4,70 @@ import os
 from .common import setup_cluster, exec_cmd, default_cluster  # noqa: F401
 
 
+def test_cluster_help():
+    code, out, err = exec_cmd(['dcos', 'cluster'])
+    assert code == 0
+    assert err == ''
+    assert out == '''Manage your DC/OS clusters
+
+Usage:
+  dcos cluster [command]
+
+Commands:
+  attach
+      Attach the CLI to a cluster
+  link
+      Link the current cluster to another one
+  list
+      List the clusters configured and the ones linked to the current cluster
+  remove
+      Remove a configured cluster from the CLI
+  rename
+      Rename a configured cluster
+  setup
+      Set up the CLI to communicate with a cluster
+  unlink
+      Unlink the current cluster with one of its linked clusters
+
+Options:
+  -h, --help   help for cluster
+
+Use "dcos cluster [command] --help" for more information about a command.
+'''
+
+
+def test_cluster_invalid_usage():
+    code, out, err = exec_cmd(['dcos', 'cluster', 'not-a-command'])
+    assert code != 0
+    assert out == ''
+    assert err == '''Usage:
+  dcos cluster [command]
+
+Commands:
+  attach
+      Attach the CLI to a cluster
+  link
+      Link the current cluster to another one
+  list
+      List the clusters configured and the ones linked to the current cluster
+  remove
+      Remove a configured cluster from the CLI
+  rename
+      Rename a configured cluster
+  setup
+      Set up the CLI to communicate with a cluster
+  unlink
+      Unlink the current cluster with one of its linked clusters
+
+Options:
+  -h, --help   help for cluster
+
+Use "dcos cluster [command] --help" for more information about a command.
+
+Error: unknown command not-a-command
+'''
+
+
 def test_cluster_list(default_cluster):
     code, out, err = exec_cmd(['dcos', 'cluster', 'list'])
     assert code == 0

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -1,0 +1,49 @@
+from .common import exec_cmd
+
+
+def test_config_help():
+    code, out, err = exec_cmd(['dcos', 'config'])
+    assert code == 0
+    assert err == ''
+    assert out == '''Manage the DC/OS configuration file
+
+Usage:
+  dcos config [command]
+
+Commands:
+  set
+      Add or set a property in the configuration file used for the current cluster
+  show
+      Print the configuration file related to the current cluster
+  unset
+      Remove a property from the configuration file used for the current cluster
+
+Options:
+  -h, --help   help for config
+
+Use "dcos config [command] --help" for more information about a command.
+'''
+
+
+def test_config_invalid_usage():
+    code, out, err = exec_cmd(['dcos', 'config', 'not-a-command'])
+    assert code != 0
+    assert out == ''
+    assert err == '''Usage:
+  dcos config [command]
+
+Commands:
+  set
+      Add or set a property in the configuration file used for the current cluster
+  show
+      Print the configuration file related to the current cluster
+  unset
+      Remove a property from the configuration file used for the current cluster
+
+Options:
+  -h, --help   help for config
+
+Use "dcos config [command] --help" for more information about a command.
+
+Error: unknown command not-a-command
+'''

--- a/tests/integration/test_plugin.py
+++ b/tests/integration/test_plugin.py
@@ -10,6 +10,54 @@ import pytest
 from .common import setup_cluster, exec_cmd, default_cluster  # noqa: F401
 
 
+def test_plugin_help():
+    code, out, err = exec_cmd(['dcos', 'plugin'])
+    assert code == 0
+    assert err == ''
+    assert out == '''Manage CLI plugins
+
+Usage:
+  dcos plugin [command]
+
+Commands:
+  add
+      Add a CLI plugin
+  list
+      List CLI plugins
+  remove
+      Remove a CLI plugin
+
+Options:
+  -h, --help   help for plugin
+
+Use "dcos plugin [command] --help" for more information about a command.
+'''
+
+
+def test_plugin_invalid_usage():
+    code, out, err = exec_cmd(['dcos', 'plugin', 'not-a-command'])
+    assert code != 0
+    assert out == ''
+    assert err == '''Usage:
+  dcos plugin [command]
+
+Commands:
+  add
+      Add a CLI plugin
+  list
+      List CLI plugins
+  remove
+      Remove a CLI plugin
+
+Options:
+  -h, --help   help for plugin
+
+Use "dcos plugin [command] --help" for more information about a command.
+
+Error: unknown command not-a-command
+'''
+
+
 def test_plugin_list(default_cluster):
     code, out, err = exec_cmd(['dcos', 'plugin', 'list'])
     assert code == 0


### PR DESCRIPTION
Previously, running `dcos cluster invalid-command` used to return with a
0 exit code.

This updates the CLI to return a non-zero exit code in that case, as
well as printing an error message after the help usage.

https://jira.mesosphere.com/browse/DCOS_OSS-3500