### PR TITLE
Add missing entries to the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## Next
 
+* Breaking changes
+
+  * Drop support for DCOS_URL and DCOS_ACS_TOKEN
+
 * Features
 
   * Added static tab completion
   * Introduce a strict deprecation mode (DCOS_CLI_STRICT_DEPRECATIONS=1)
   * Displayed variant when running dcos --version
   * Always auto-install core and EE plugins on `cluster setup`
+  * Add support for relative DCOS_DIR
+  * List commands of each plugin alphabetically with `dcos plugin list`


### PR DESCRIPTION
This adds entries for the following commits, which are only on master:

- https://github.com/dcos/dcos-cli/commit/e52b5bdee44122fce468572779d0c3ab05b061af
- https://github.com/dcos/dcos-cli/commit/7053a88217a5f0c40322a058ba611e4ca79879f4
- https://github.com/dcos/dcos-cli/commit/915806a8cfd75a252f2d9f4cbece2b11b99d350c