### PR TITLE
Display new available commands after `dcos cluster setup`

### DIFF
--- a/tests/integration/test_cluster.py
+++ b/tests/integration/test_cluster.py
@@ -1,6 +1,8 @@
 import json
 import os
 
+import pytest
+
 from .common import setup_cluster, exec_cmd, default_cluster  # noqa: F401
 
 
@@ -152,6 +154,7 @@ def test_cluster_setup_cosmos_plugins():
         assert plugins[1]['name'] == 'dcos-enterprise-cli'
 
 
+@pytest.mark.skipif(os.environ.get('DCOS_TEST_CORECLI') is None, reason="no core CLI bundle")
 def test_cluster_setup_bundled_core_plugin():
     env = {
         'DCOS_CLUSTER_SETUP_SKIP_CANONICAL_URL_INSTALL': '1',


### PR DESCRIPTION
We've extracted the job, marathon, node, package, service, and task
commands into a `dcos-core-cli` plugin which gets automatically
installed during `dcos cluster setup`.

To make this new behaviour clear to users we're displaying the new
available commands at the end of the setup flow:

```
$ dcos cluster setup ...
[...]
dcos-core-cli [================================================] 22.6 MiB / 22.6 MiB
dcos-enterprise-cli [================================================] 26.0 MiB / 26.0 MiB
New commands available: backup, job, license, marathon, node, package, security, service, task
```