### PR TITLE
Run CLI integration tests against DC/OS OSS

### DIFF
--- a/ci/integration-tests-open.groovy
+++ b/ci/integration-tests-open.groovy
@@ -30,15 +30,9 @@ pipeline {
           credentialsId: 'a20fbd60-2528-4e00-9175-ebe2287906cf',
           accessKeyVariable: 'AWS_ACCESS_KEY_ID',
           secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
-          [$class: 'StringBinding',
-          credentialsId: '0b513aad-e0e0-4a82-95f4-309a80a02ff9',
-          variable: 'DCOS_TEST_INSTALLER_URL'],
           [$class: 'FileBinding',
           credentialsId: '23743034-1ac4-49f7-b2e6-a661aee2d11b',
-          variable: 'DCOS_TEST_SSH_KEY_PATH'],
-          [$class: 'StringBinding',
-          credentialsId: 'ca159ad3-7323-4564-818c-46a8f03e1389',
-          variable: 'DCOS_TEST_LICENSE']
+          variable: 'DCOS_TEST_SSH_KEY_PATH']
         ]) {
             sh '''
               bash -exc " \
@@ -47,8 +41,8 @@ pipeline {
                 source env/bin/activate; \
                 pip install -r requirements.txt; \
                 flake8 integration; \
-                export DCOS_TEST_VARIANT=enterprise; \
-                ./launch_cluster.py ${DCOS_TEST_INSTALLER_URL}"
+                export DCOS_TEST_VARIANT=open; \
+                ./launch_cluster.py https://downloads.dcos.io/dcos/testing/master/dcos_generate_config.sh"
             '''
             stash includes: 'tests/test_cluster.env.sh', name: 'test-cluster'
         }

--- a/tests/integration/test_cluster.py
+++ b/tests/integration/test_cluster.py
@@ -106,6 +106,8 @@ def test_empty_cluster_list():
     assert out == '[]\n'
 
 
+@pytest.mark.skipif(os.environ.get('DCOS_TEST_DEFAULT_CLUSTER_VARIANT') == 'open',
+                    reason="This test relies on the 'security' subcommand, only available on DC/OS EE.")
 def test_cluster_setup_non_superuser(default_cluster):
     username = 'nonsuperuser'
     password = 'nonsuperpassword'
@@ -149,9 +151,13 @@ def test_cluster_setup_cosmos_plugins():
 
         plugins = json.loads(out)
 
-        assert len(plugins) == 2
-        assert plugins[0]['name'] == 'dcos-core-cli'
-        assert plugins[1]['name'] == 'dcos-enterprise-cli'
+        if os.environ.get('DCOS_TEST_DEFAULT_CLUSTER_VARIANT') == 'open':
+            assert len(plugins) == 1
+            assert plugins[0]['name'] == 'dcos-core-cli'
+        else:
+            assert len(plugins) == 2
+            assert plugins[0]['name'] == 'dcos-core-cli'
+            assert plugins[1]['name'] == 'dcos-enterprise-cli'
 
 
 @pytest.mark.skipif(os.environ.get('DCOS_TEST_CORECLI') is None, reason="no core CLI bundle")

--- a/tests/integration/test_help.py
+++ b/tests/integration/test_help.py
@@ -1,3 +1,7 @@
+import os
+
+import pytest
+
 from .common import exec_cmd, default_cluster  # noqa: F401
 
 
@@ -32,7 +36,54 @@ Use "dcos [command] --help" for more information about a command.
 '''
 
 
-def test_dcos_help_with_default_plugins(default_cluster):
+@pytest.mark.skipif(os.environ.get('DCOS_TEST_DEFAULT_CLUSTER_VARIANT') != 'open',
+                    reason="Not an OSS cluster")
+def test_dcos_help_with_default_oss_plugins(default_cluster):
+    code, out, err = exec_cmd(['dcos'])
+    assert code == 0
+    assert err == ''
+    assert out == '''Usage:
+  dcos [command]
+
+Commands:
+  auth
+      Authenticate to DC/OS cluster
+  cluster
+      Manage your DC/OS clusters
+  config
+      Manage the DC/OS configuration file
+  help
+      Help about any command
+  job
+      Deploy and manage jobs in DC/OS
+  marathon
+      Deploy and manage applications to DC/OS
+  node
+      View DC/OS node information
+  package
+      Install and manage DC/OS software packages
+  plugin
+      Manage CLI plugins
+  service
+      Manage DC/OS services
+  task
+      Manage DC/OS tasks
+
+Options:
+  --version
+      Print version information
+  -v, -vv
+      Output verbosity (verbose or very verbose)
+  -h, --help
+      Show usage help
+
+Use "dcos [command] --help" for more information about a command.
+'''
+
+
+@pytest.mark.skipif(os.environ.get('DCOS_TEST_DEFAULT_CLUSTER_VARIANT') != 'enterprise',
+                    reason="Not an EE cluster")
+def test_dcos_help_with_default_ee_plugins(default_cluster):
     code, out, err = exec_cmd(['dcos'])
     assert code == 0
     assert err == ''

--- a/tests/integration/test_plugin.py
+++ b/tests/integration/test_plugin.py
@@ -64,7 +64,10 @@ def test_plugin_list(default_cluster):
     assert err == ''
 
     lines = out.splitlines()
-    assert len(lines) == 3
+    if os.environ.get('DCOS_TEST_DEFAULT_CLUSTER_VARIANT') == 'open':
+        assert len(lines) == 2
+    else:
+        assert len(lines) == 3
 
     # heading
     assert lines[0].split() == ['NAME', 'COMMANDS']
@@ -73,12 +76,13 @@ def test_plugin_list(default_cluster):
     assert dcos_core_cli[0] == 'dcos-core-cli'
     assert dcos_core_cli[1:] == ['job', 'marathon', 'node', 'package', 'service', 'task']
 
-    dcos_enterprise_cli = lines[2].split()
-    assert dcos_enterprise_cli[0] == 'dcos-enterprise-cli'
-    assert 'backup' in dcos_enterprise_cli[1:]
-    assert 'license' in dcos_enterprise_cli[1:]
-    assert 'security' in dcos_enterprise_cli[1:]
-    assert len(dcos_enterprise_cli[1:]) == 3
+    if default_cluster['variant'] == 'enterprise':
+        dcos_enterprise_cli = lines[2].split()
+        assert dcos_enterprise_cli[0] == 'dcos-enterprise-cli'
+        assert 'backup' in dcos_enterprise_cli[1:]
+        assert 'license' in dcos_enterprise_cli[1:]
+        assert 'security' in dcos_enterprise_cli[1:]
+        assert len(dcos_enterprise_cli[1:]) == 3
 
 
 def test_plugin_install_invalid_test(default_cluster):
@@ -113,6 +117,8 @@ def test_plugin_invocation(default_cluster):
     assert out['env'].get('DCOS_ACS_TOKEN') == default_cluster['acs_token']
 
 
+@pytest.mark.skipif(os.environ.get('DCOS_TEST_DEFAULT_CLUSTER_VARIANT') == 'open',
+                    reason="No CA on DC/OS Open")
 def test_plugin_invocation_tls():
     with setup_cluster(scheme='https'):
         _install_test_plugin()

--- a/tests/launch_cluster.py
+++ b/tests/launch_cluster.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 
+import json
 import os
 import random
 import string
 import sys
 import time
+
+import requests
 
 from dcos_e2e.backends import AWS
 from dcos_e2e.cluster import Cluster
@@ -15,9 +18,9 @@ if len(sys.argv) != 2:
     print("Please specify the installer URL as argument.", file=sys.stderr)
     sys.exit(1)
 
-test_license = os.environ.get('DCOS_TEST_LICENSE')
-if not test_license:
-    print("Please specify a license in $DCOS_TEST_LICENSE.", file=sys.stderr)
+dcos_variant = os.environ.get('DCOS_TEST_VARIANT')
+if not dcos_variant:
+    print("Please set DCOS_TEST_VARIANT to 'open' or 'enterprise'.", file=sys.stderr)
     sys.exit(1)
 
 private_key_path = os.environ.get('DCOS_TEST_SSH_KEY_PATH')
@@ -32,9 +35,12 @@ password = ''.join(random.choice(string.ascii_letters + string.digits) for i in 
 extra_config = {
     'superuser_username': username,
     'superuser_password_hash': sha512_crypt.hash(password),
-    'fault_domain_enabled': False,
-    'license_key_contents': test_license,
+#    'fault_domain_enabled': False,
 }
+
+test_license = os.environ.get('DCOS_TEST_LICENSE')
+if test_license:
+    extra_config['license_key_contents'] = test_license
 
 dcos_config = {**cluster.base_config, **extra_config}
 
@@ -45,20 +51,52 @@ cluster.install_dcos_from_url(
     output=Output.LOG_AND_CAPTURE,
 )
 
-cluster.wait_for_dcos_ee(
-    superuser_username=username,
-    superuser_password=password,
-)
+if dcos_variant == 'open':
+    cluster.wait_for_dcos_oss()
+else:
+    cluster.wait_for_dcos_ee(
+        superuser_username=username,
+        superuser_password=password,
+    )
 
 master_node = next(iter(cluster.masters))
 master_ip = master_node.public_ip_address.exploded
 
+# In order to create a user with a password on DC/OS Open, we login with the well-known key
+# from the default user to get an ACS token and then hit the IAM API directly.
+# Hopefully in the future there will be a simpler way to do it.
+if dcos_variant == 'open':
+    response = requests.post(
+        'http://' + master_ip + '/acs/api/v1/auth/login',
+        headers={"Content-Type" : "application/json"},
+        data=json.dumps({
+            "token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik9UQkVOakZFTWtWQ09VRTRPRVpGTlRNMFJrWXlRa015Tnprd1JrSkVRemRCTWpBM1FqYzVOZyJ9.eyJlbWFpbCI6ImFsYmVydEBiZWtzdGlsLm5ldCIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJpc3MiOiJodHRwczovL2Rjb3MuYXV0aDAuY29tLyIsInN1YiI6Imdvb2dsZS1vYXV0aDJ8MTA5OTY0NDk5MDExMTA4OTA1MDUwIiwiYXVkIjoiM3lGNVRPU3pkbEk0NVExeHNweHplb0dCZTlmTnhtOW0iLCJleHAiOjIwOTA4ODQ5NzQsImlhdCI6MTQ2MDE2NDk3NH0.OxcoJJp06L1z2_41_p65FriEGkPzwFB_0pA9ULCvwvzJ8pJXw9hLbmsx-23aY2f-ydwJ7LSibL9i5NbQSR2riJWTcW4N7tLLCCMeFXKEK4hErN2hyxz71Fl765EjQSO5KD1A-HsOPr3ZZPoGTBjE0-EFtmXkSlHb1T2zd0Z8T5Z2-q96WkFoT6PiEdbrDA-e47LKtRmqsddnPZnp0xmMQdTr2MjpVgvqG7TlRvxDcYc-62rkwQXDNSWsW61FcKfQ-TRIZSf2GS9F9esDF4b5tRtrXcBNaorYa9ql0XAWH5W_ct4ylRNl3vwkYKWa4cmPvOqT5Wlj9Tf0af4lNO40PQ"
+        }),
+    )
+
+    if response.status_code != 200:
+        print("Couldn't login.", file=sys.stderr)
+        sys.exit(1)
+
+    response = requests.put(
+        'http://' + master_ip + '/acs/api/v1/users/' + username,
+        headers={
+            "Authorization" : "token=" + response.json().get('token'),
+            "Content-Type" : "application/json",
+        },
+        data=json.dumps({'password': password}),
+    )
+
+    if response.status_code != 201:
+        print("Unexpected status code " + response.status_code + " when creating user", file=sys.stderr)
+        sys.exit(1)
+
 out = '''
-export DCOS_TEST_DEFAULT_CLUSTER_VARIANT=enterprise
+export DCOS_TEST_DEFAULT_CLUSTER_VARIANT={}
 export DCOS_TEST_DEFAULT_CLUSTER_USERNAME={}
 export DCOS_TEST_DEFAULT_CLUSTER_PASSWORD={}
 export DCOS_TEST_DEFAULT_CLUSTER_HOST={}
-'''.format(username, password, master_ip)
+'''.format(dcos_variant, username, password, master_ip)
 
 with open('test_cluster.env.sh', 'w') as f:
     f.write(out)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,6 @@
---find-links git+https://github.com/dcos/dcos-e2e.git@2019.04.02.1#egg=dcos-e2e-2019.04.02.1
+--find-links git+https://github.com/dcos/dcos-e2e.git@2019.04.25.0#egg=dcos-e2e-2019.04.25.0
 attrs==18.2.0
 pytest==4.1.1
 flake8==3.5.0
-dcos-e2e==2019.04.02.1
+dcos-e2e==2019.04.25.0
+requests==2.21.0


### PR DESCRIPTION
This adds support for running integration tests against DC/OS open.

In order to be enabled, we should create a new Jenkins job using the
integration-tests-open.groovy script.

https://jira.mesosphere.com/browse/DCOS_OSS-4035