### PR TITLE
Improve error messages for `dcos cluster setup` args error

### DIFF
--- a/pkg/cmd/cluster/cluster_setup.go
+++ b/pkg/cmd/cluster/cluster_setup.go
@@ -1,6 +1,9 @@
 package cluster
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/dcos/dcos-cli/api"
 	"github.com/dcos/dcos-cli/pkg/setup"
 
@@ -13,8 +16,15 @@ func newCmdClusterSetup(ctx api.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "setup <url>",
 		Short: "Set up the CLI to communicate with a cluster",
-		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				cmd.SilenceUsage = false
+				return errors.New("missing cluster URL")
+			}
+			if len(args) > 1 {
+				cmd.SilenceUsage = false
+				return fmt.Errorf("received %d arguments %s, expects a single cluster URL", len(args), args)
+			}
 			clusterURL := args[0]
 			_, err := ctx.Setup(setupFlags, clusterURL, true)
 			return err

--- a/tests/integration/test_cluster.py
+++ b/tests/integration/test_cluster.py
@@ -191,3 +191,17 @@ def test_cluster_setup_bundled_core_plugin_strict_mode():
                    "https://docs.mesosphere.com/1.13/cli/plugins/ "
                    "for more information.\n"
                    "Error: usage of deprecated feature\n")
+
+
+def test_cluster_setup_missing_url():
+    code, out, err = exec_cmd(['dcos', 'cluster', 'setup'])
+    assert code != 0
+    assert out == ""
+    assert err.startswith('Error: missing cluster URL\n')
+
+
+def test_cluster_setup_too_many_args():
+    code, out, err = exec_cmd(['dcos', 'cluster', 'setup', 'https://1.example.com', 'https://2.example.com'])
+    assert code != 0
+    assert out == ""
+    assert err.startswith('Error: received 2 arguments [https://1.example.com https://2.example.com], expects a single cluster URL\n')


### PR DESCRIPTION
This makes it clearer that the command expects a single argument which
is a cluster URL.

https://jira.mesosphere.com/browse/DCOS-52029