### PR TITLE
Add a specific error type for HTTP errors

### DIFF
--- a/pkg/cluster/linker/linker.go
+++ b/pkg/cluster/linker/linker.go
@@ -60,7 +60,12 @@ func (l *Linker) Link(link *Link) error {
 	message, err := json.Marshal(link)
 
 	l.logger.Info("Linking the cluster...")
-	resp, err := l.http.Post("/cluster/v1/links", "application/json", bytes.NewReader(message))
+	resp, err := l.http.Post(
+		"/cluster/v1/links",
+		"application/json",
+		bytes.NewReader(message),
+		httpclient.FailOnErrStatus(false),
+	)
 	if err != nil {
 		return err
 	}
@@ -87,7 +92,7 @@ func (l *Linker) Link(link *Link) error {
 // Unlink sends an unlink request to /cluster/v1/links.
 func (l *Linker) Unlink(id string) error {
 	l.logger.Info("Unlinking the cluster...")
-	resp, err := l.http.Delete("/cluster/v1/links/" + id)
+	resp, err := l.http.Delete("/cluster/v1/links/"+id, httpclient.FailOnErrStatus(false))
 	if err != nil {
 		return err
 	}
@@ -101,14 +106,14 @@ func (l *Linker) Unlink(id string) error {
 		}
 		return apiError
 	}
-	
+
 	l.logger.Infof("Unlinked current cluster from cluster %s", id)
 	return nil
 }
 
 // Links returns the links of a cluster.
 func (l *Linker) Links() ([]*Link, error) {
-	resp, err := l.http.Get("/cluster/v1/links")
+	resp, err := l.http.Get("/cluster/v1/links", httpclient.FailOnErrStatus(false))
 	if err != nil {
 		return nil, errors.New("couldn't get linked clusters")
 	}

--- a/pkg/httpclient/client_test.go
+++ b/pkg/httpclient/client_test.go
@@ -176,6 +176,11 @@ func TestFailOnError(t *testing.T) {
 
 	_, err = client.Get("/", FailOnErrStatus(true))
 	require.Error(t, err)
+
+	httpErr, ok := err.(*HTTPError)
+	require.True(t, ok)
+	require.NotNil(t, httpErr.Response())
+	require.Equal(t, 404, httpErr.Response().StatusCode)
 }
 
 func TestDefaultUserAgent(t *testing.T) {

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -112,7 +112,9 @@ func (c *Client) challengeAuth() (string, error) {
 // sniffAuth sends an HTTP request with a given ACS token to a well-known resource.
 // It is mainly used to challenge auth or verify that an ACS token is valid.
 func (c *Client) sniffAuth(acsToken string) (*http.Response, error) {
-	var opts []httpclient.Option
+	opts := []httpclient.Option{
+		httpclient.FailOnErrStatus(false),
+	}
 	if acsToken != "" {
 		opts = append(opts, httpclient.ACSToken(acsToken))
 	}

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -387,7 +387,7 @@ func (s *Setup) installPluginFromCanonicalURL(name string, version *dcos.Version
 		domain, name, platform, name, dcosVersion,
 	)
 	httpClient := httpclient.New("")
-	req, err := httpClient.NewRequest("HEAD", url, nil)
+	req, err := httpClient.NewRequest("HEAD", url, nil, httpclient.FailOnErrStatus(false))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## High-level description

This lets callers make type assertions on the error and possibly augment error messages with additional hints.

## Corresponding DC/OS tickets (obligatory)

- [DCOS_OSS-5117](https://jira.mesosphere.com/browse/DCOS_OSS-5117) Regression: CLI just prints 'HTTP 401 error' when token is expired.


## Checklist for all PRs

- [ ] ~Added a comprehensible changelog entry to `CHANGELOG.md` or explain why this is not a user-facing change:~
- [ ] ~Updated completion script if applicable~
- [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
- [ ] ~Made a [documentation PR](https://github.com/mesosphere/dcos-docs-site) if these changes need to be reflected on https://docs.mesosphere.com/latest/cli/~
- [ ] ~Created backport PRs if needed:~
