### PR TITLE
Export HTTP error response field

### DIFF
--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -48,17 +48,12 @@ type ctxKey int
 
 // HTTPError represents an HTTP error, it is returned when FailOnErrStatus is enabled.
 type HTTPError struct {
-	resp *http.Response
+	Response *http.Response
 }
 
 // Error returns the error message.
 func (err *HTTPError) Error() string {
-	return fmt.Sprintf("HTTP %d error", err.resp.StatusCode)
-}
-
-// Response returns the HTTP error response.
-func (err *HTTPError) Response() *http.Response {
-	return err.resp
+	return fmt.Sprintf("HTTP %d error", err.Response.StatusCode)
 }
 
 // ctxKeyFailOnErrStatus is a request context key which, when sets, indicates that
@@ -266,7 +261,7 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		_, failOnErrStatus := req.Context().Value(ctxKeyFailOnErrStatus).(struct{})
 
 		if failOnErrStatus && resp.StatusCode >= 400 && resp.StatusCode < 600 {
-			return nil, &HTTPError{resp}
+			return nil, &HTTPError{Response: resp}
 		}
 	}
 	return resp, err

--- a/pkg/httpclient/client_test.go
+++ b/pkg/httpclient/client_test.go
@@ -179,8 +179,8 @@ func TestFailOnError(t *testing.T) {
 
 	httpErr, ok := err.(*HTTPError)
 	require.True(t, ok)
-	require.NotNil(t, httpErr.Response())
-	require.Equal(t, 404, httpErr.Response().StatusCode)
+	require.NotNil(t, httpErr.Response)
+	require.Equal(t, 404, httpErr.Response.StatusCode)
 }
 
 func TestDefaultUserAgent(t *testing.T) {


### PR DESCRIPTION
## High-level description

This makes it possible for package users to create errors of this type
as well.

See eg. https://github.com/dcos/dcos-core-cli/pull/255

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

- [DCOS_OSS-5117](https://jira.mesosphere.com/browse/DCOS_OSS-5117) Regression: CLI just prints 'HTTP 401 error' when token is expired

## Checklist for all PRs

- [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
