### PR TITLE
When installing the CLI we want to use the vendored deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ core-download:
 
 .PHONY: install
 install:
-	go install ./cmd/dcos
+	go install -mod=vendor ./cmd/dcos
 
 .PHONY: test
 test: vet

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ VERSION?=$(shell git rev-parse HEAD)
 CORE_VERSION?=1.13-patch.x
 CORE_STABILITY?=testing
 
+export GOFLAGS := -mod=vendor
+export GO111MODULE := on
+
 windows_EXE=.exe
 
 .PHONY: default
@@ -14,9 +17,9 @@ default:
 
 .PHONY: darwin linux windows
 darwin linux windows: docker-image
-	$(call inDocker,env GOOS=$(@) GO111MODULE=on CGO_ENABLED=0 go build \
+	$(call inDocker,env GOOS=$(@) CGO_ENABLED=0 go build \
 		-ldflags '-X $(PKG)/pkg/cli/version.version=$(VERSION)' \
-		-tags '$(GO_BUILD_TAGS)' -mod=vendor \
+		-tags '$(GO_BUILD_TAGS)' \
 		-o build/$(@)/dcos$($(@)_EXE) ./cmd/dcos)
 
 .PHONY: core-bundle
@@ -34,7 +37,7 @@ core-download:
 
 .PHONY: install
 install:
-	go install -mod=vendor ./cmd/dcos
+	go install ./cmd/dcos
 
 .PHONY: test
 test: vet
@@ -74,6 +77,8 @@ ifdef NO_DOCKER
 else
   define inDocker
     docker run \
+      -e GOFLAGS \
+      -e GO111MODULE \
       -v $(CURRENT_DIR):$(PKG_DIR) \
       -w $(PKG_DIR) \
       --rm \


### PR DESCRIPTION
## High-level description

The `install` target didn't use the vendored dependencies but would rather download all deps to the `GOPATH`. This PR fixes this.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

- [DCOS_OSS-<number>](https://jira.mesosphere.com/browse/DCOS_OSS-<number>) Foo the Bar so it stops Bazzing.


## Checklist for all PRs

- [x] Added a comprehensible changelog entry to `CHANGELOG.md` or explain why this is not a user-facing change: only relevant for devs
- [ ] Updated completion script if applicable
- [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: this is a change to the dev setup
- [ ] Made a [documentation PR](https://github.com/mesosphere/dcos-docs-site) if these changes need to be reflected on https://docs.mesosphere.com/latest/cli/
- [ ] Created backport PRs if needed:
