### PR TITLE
Makes installPackageServicesPlugins an experimental feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 * Features
 
-  * Auto-install CLI plugins for running services during `dcos cluster setup`
+  * Auto-install CLI plugins for running services during `dcos cluster setup` when environment variable `DCOS_CLI_EXPERIMENTAL_AUTOINSTALL_PACKAGE_CLIS` set

--- a/ci/integration-tests-open.groovy
+++ b/ci/integration-tests-open.groovy
@@ -59,6 +59,7 @@ pipeline {
           sh '''
             bash -exc " \
               export DCOS_TEST_CORECLI=1; \
+              export DCOS_CLI_EXPERIMENTAL_AUTOINSTALL_PACKAGE_CLIS=1; \
               PATH=$PWD/build/linux:$PATH; \
               cd tests; \
               dcos cluster remove --all; \
@@ -84,6 +85,7 @@ pipeline {
               export LC_ALL=en_US.UTF-8; \
               export PYTHONIOENCODING=utf-8; \
               export DCOS_TEST_CORECLI=1; \
+              export DCOS_CLI_EXPERIMENTAL_AUTOINSTALL_PACKAGE_CLIS=1; \
               PATH=$PWD/build/darwin:$PATH; \
               cd tests; \
               dcos cluster remove --all; \
@@ -113,6 +115,7 @@ pipeline {
             bash -exc " \
               export PYTHONIOENCODING=utf-8; \
               export DCOS_TEST_CORECLI=1; \
+              export DCOS_CLI_EXPERIMENTAL_AUTOINSTALL_PACKAGE_CLIS=1; \
               PATH=$PWD/build/windows:$PATH; \
               cd tests; \
               dcos cluster remove --all; \

--- a/ci/integration-tests.groovy
+++ b/ci/integration-tests.groovy
@@ -65,6 +65,7 @@ pipeline {
           sh '''
             bash -exc " \
               export DCOS_TEST_CORECLI=1; \
+              export DCOS_CLI_EXPERIMENTAL_AUTOINSTALL_PACKAGE_CLIS=1; \
               PATH=$PWD/build/linux:$PATH; \
               cd tests; \
               dcos cluster remove --all; \
@@ -90,6 +91,7 @@ pipeline {
               export LC_ALL=en_US.UTF-8; \
               export PYTHONIOENCODING=utf-8; \
               export DCOS_TEST_CORECLI=1; \
+              export DCOS_CLI_EXPERIMENTAL_AUTOINSTALL_PACKAGE_CLIS=1; \
               PATH=$PWD/build/darwin:$PATH; \
               cd tests; \
               dcos cluster remove --all; \
@@ -119,6 +121,7 @@ pipeline {
             bash -exc " \
               export PYTHONIOENCODING=utf-8; \
               export DCOS_TEST_CORECLI=1; \
+              export DCOS_CLI_EXPERIMENTAL_AUTOINSTALL_PACKAGE_CLIS=1; \
               PATH=$PWD/build/windows:$PATH; \
               cd tests; \
               dcos cluster remove --all; \

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -358,33 +358,48 @@ func (s *Setup) installPackageServicesPlugins(wg *sync.WaitGroup, httpClient *ht
 	}
 
 	pkgMap := make(map[string]dcosclient.CosmosPackage)
-	result, _, err := cosmosClient.PackageList(context.TODO(), &dcosclient.PackageListOpts{
-		CosmosPackageListV1Request: optional.NewInterface(dcosclient.CosmosPackageListV1Request{}),
-	})
-	if err != nil {
-		s.logger.Debug(err)
-		return
-	}
 
-	for _, pkg := range result.Packages {
-		pkgDefinition := pkg.PackageInformation.PackageDefinition
-
-		currentPkg, ok := pkgMap[pkgDefinition.Name]
-		if ok && currentPkg.ReleaseVersion >= pkgDefinition.ReleaseVersion {
-			continue
+	cErr := make(chan error, 1)
+	cResult := make(chan dcosclient.CosmosPackageListV1Response, 1)
+	go func() {
+		result, _, err := cosmosClient.PackageList(context.TODO(), &dcosclient.PackageListOpts{
+			CosmosPackageListV1Request: optional.NewInterface(dcosclient.CosmosPackageListV1Request{}),
+		})
+		if err != nil {
+			cErr <- err
+		} else {
+			cResult <- result
 		}
-		pkgMap[pkgDefinition.Name] = pkgDefinition
-	}
+	}()
 
-	for _, pkg := range pkgMap {
-		wg.Add(1)
-		go func(name, version string) {
-			err := s.installPluginFromCosmos(name, version, httpClient, pbar)
-			if err != nil {
-				s.logger.Debug(err)
+	select {
+	case resErr := <-cErr:
+		s.logger.Debug(resErr)
+		return
+	case result := <-cResult:
+		for _, pkg := range result.Packages {
+			pkgDefinition := pkg.PackageInformation.PackageDefinition
+
+			currentPkg, ok := pkgMap[pkgDefinition.Name]
+			if ok && currentPkg.ReleaseVersion >= pkgDefinition.ReleaseVersion {
+				continue
 			}
-			wg.Done()
-		}(pkg.Name, pkg.Version)
+			pkgMap[pkgDefinition.Name] = pkgDefinition
+		}
+
+		for _, pkg := range pkgMap {
+			wg.Add(1)
+			go func(name, version string) {
+				err := s.installPluginFromCosmos(name, version, httpClient, pbar)
+				if err != nil {
+					s.logger.Debug(err)
+				}
+				wg.Done()
+			}(pkg.Name, pkg.Version)
+		}
+	case <-time.After(3 * time.Second):
+		s.logger.Debug(errors.New("the request to get all the services installed took more than 3 seconds, not installing their CLIs"))
+		return
 	}
 }
 


### PR DESCRIPTION
## High-level description

Adds a timeout to not download the CLI plugins for the services installed in a cluster so that we do not make the `dcos cluster setup` operation longer.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

- [DCOS-54232](https://jira.mesosphere.com/browse/DCOS-54232) Add timeout when auto-installing package CLIs on setup

## Checklist for all PRs

- [x] Added a comprehensible changelog entry to `CHANGELOG.md` or explain why this is not a user-facing change:
- [ ] Updated completion script if applicable
- [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
- [ ] Made a [documentation PR](https://github.com/mesosphere/dcos-docs-site) if these changes need to be reflected on https://docs.mesosphere.com/latest/cli/
- [ ] Created backport PRs if needed:
