### PR TITLE
Added 'dcos config keys' command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 * Features
 
   * Auto-install CLI plugins for running services during `dcos cluster setup` when environment variable `DCOS_CLI_EXPERIMENTAL_AUTOINSTALL_PACKAGE_CLIS` set
+  * New command `dcos config keys` printing all the keys that can be set in a configuration file

--- a/pkg/cmd/completion/completion.sh
+++ b/pkg/cmd/completion/completion.sh
@@ -423,6 +423,14 @@ _dcos_cluster_setup() {
     fi
 }
 
+__dcos_complete_config_keys() {
+    local keys=()
+    while IFS=$'\n' read -r line; do config_keys+=("$line"); done < <(dcos config keys --quiet 2> /dev/null)
+    keys+=("${config_keys[@]}")
+    __dcos_debug "Found config keys" "${config_keys[@]}"
+    __dcos_handle_compreply "${keys[@]}"
+}
+
 _dcos_config() {
     local i command
 
@@ -439,7 +447,7 @@ _dcos_config() {
                 __dcos_handle_compreply "${flags[@]}"
                 ;;
             *)
-                __dcos_handle_compreply "${commands[@]}"
+                __dcos_complete_config_keys
                 ;;
         esac
         return

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -21,6 +21,7 @@ func NewCommand(ctx api.Context) *cobra.Command {
 		},
 	}
 	cmd.AddCommand(
+		newCmdConfigKeys(ctx),
 		newCmdConfigSet(ctx),
 		newCmdConfigShow(ctx),
 		newCmdConfigUnset(ctx),

--- a/pkg/cmd/config/config_keys.go
+++ b/pkg/cmd/config/config_keys.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-cli/pkg/config"
+	"github.com/spf13/cobra"
+)
+
+// newCmdConfigKeys returns the keys that a user can set in a configuration file.
+func newCmdConfigKeys(ctx api.Context) *cobra.Command {
+	var quietOutput bool
+	cmd := &cobra.Command{
+		Use:   "keys",
+		Short: "Print all the keys that can be set in a configuration file",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			configKeys := config.Keys()
+			var sortedKeys []string
+			for k := range configKeys {
+				sortedKeys = append(sortedKeys, k)
+			}
+			sort.Strings(sortedKeys)
+			for _, key := range sortedKeys {
+				if quietOutput {
+					fmt.Fprintln(ctx.Out(), key)
+				} else {
+					fmt.Fprintln(ctx.Out(), key+" : "+configKeys[key])
+				}
+
+			}
+		},
+	}
+	cmd.Flags().BoolVarP(&quietOutput, "quiet", "q", false, "Only print config keys")
+	return cmd
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -96,6 +96,27 @@ func Empty() *Config {
 	return New(Opts{})
 }
 
+// Keys returns the possible config keys. TODO: make all the keys constants.
+func Keys() map[string]string {
+	return map[string]string{
+		keyACSToken:          "the DC/OS authentication token",
+		keyURL:               "the public master URL of your DC/OS cluster",
+		keyMesosMasterURL:    "the Mesos master URL (defaults to 'core.dcos_url')",
+		keyPagination:        "indicates whether to paginate output (defaults to true)",
+		keyTLS:               "indicates whether to verify SSL certificates or set the path to the SSL certificates",
+		keyTimeout:           "the request timeout in seconds, with a minimum value of 1 second (defaults to 3 minutes)",
+		keySSHUser:           "the user used when using ssh to connect to a node of your DC/OS cluster (defaults to 'core')",
+		keySSHProxyHost:      "whether to use a fixed ssh proxy host (Bastion) for node SSH access",
+		keyReporting:         "whether to report usage events to Mesosphere",
+		keyPromptLogin:       "whether to prompt the user to log in when token expired, otherwise automatically initiate login",
+		keyClusterName:       "human readable name of cluster",
+		"job.url":            "API URL for talking to the Metronome scheduler",
+		"job.service_name":   "the name of the metronome cluster",
+		"marathon.url":       "base URL for talking to Marathon, overwrites the value specified in 'core.dcos_url'",
+		"package.cosmos_url": "base URL for talking to Cosmos, overwrites the value specified in 'core.dcos_url'",
+	}
+}
+
 // LoadPath populates the store based on a path to a TOML file.
 // If the file doesn't exist, an empty one is created.
 func (c *Config) LoadPath(path string) error {

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -11,6 +11,8 @@ Usage:
   dcos config [command]
 
 Commands:
+  keys
+      Print all the keys that can be set in a configuration file
   set
       Add or set a property in the configuration file used for the current cluster
   show
@@ -33,6 +35,8 @@ def test_config_invalid_usage():
   dcos config [command]
 
 Commands:
+  keys
+      Print all the keys that can be set in a configuration file
   set
       Add or set a property in the configuration file used for the current cluster
   show


### PR DESCRIPTION
## High-level description

Adds a `dcos config keys` subcommand and uses it for autocompletion.


## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

- [DCOS-53202](https://jira.mesosphere.com/browseDCOS-53202) No dcos config keys subcommand to get all the possible keys without having to check the documentation.


## Checklist for all PRs

- [X] Added a comprehensible changelog entry to `CHANGELOG.md` or explain why this is not a user-facing change:
- [X] Updated completion script if applicable
- [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
- [ ] Made a [documentation PR](https://github.com/mesosphere/dcos-docs-site) if these changes need to be reflected on https://docs.mesosphere.com/latest/cli/
- [ ] Created backport PRs if needed:
