### PR TITLE
Add Put method to httpclient

### DIFF
--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -178,7 +178,7 @@ func (c *Client) Post(path string, contentType string, body io.Reader, opts ...O
 
 // Put issues a PUT to the specified DC/OS cluster path.
 func (c *Client) Put(path string, contentType string, body io.Reader, opts ...Option) (*http.Response, error) {
-	req, err := c.NewRequest(http.MethodPut, path, body, opts...)
+	req, err := c.NewRequest("PUT", path, body, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -176,6 +176,16 @@ func (c *Client) Post(path string, contentType string, body io.Reader, opts ...O
 	return c.Do(req)
 }
 
+// Put issues a PUT to the specified DC/OS cluster path.
+func (c *Client) Put(path string, contentType string, body io.Reader, opts ...Option) (*http.Response, error) {
+	req, err := c.NewRequest(http.MethodPut, path, body, opts...)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", contentType)
+	return c.Do(req)
+}
+
 // Delete issues a DELETE to the specified DC/OS cluster path.
 func (c *Client) Delete(path string, opts ...Option) (*http.Response, error) {
 	req, err := c.NewRequest("DELETE", path, nil, opts...)

--- a/pkg/httpclient/client_test.go
+++ b/pkg/httpclient/client_test.go
@@ -74,7 +74,7 @@ func TestPut(t *testing.T) {
 
 	client := New(ts.URL)
 
-	resp, err := client.Post("/path", "application/json", strings.NewReader(`{"cluster":"DC/OS"}`))
+	resp, err := client.Put("/path", "application/json", strings.NewReader(`{"cluster":"DC/OS"}`))
 	require.NoError(t, err)
 
 	respBody, err := ioutil.ReadAll(resp.Body)

--- a/pkg/httpclient/client_test.go
+++ b/pkg/httpclient/client_test.go
@@ -58,6 +58,30 @@ func TestPost(t *testing.T) {
 	require.Equal(t, "ok", string(respBody))
 }
 
+func TestPut(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "PUT", r.Method)
+		assert.Equal(t, "/path", r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		body, err := ioutil.ReadAll(r.Body)
+		assert.NoError(t, err)
+
+		assert.Equal(t, `{"cluster":"DC/OS"}`, string(body))
+		w.Write([]byte("ok"))
+	}))
+	defer ts.Close()
+
+	client := New(ts.URL)
+
+	resp, err := client.Post("/path", "application/json", strings.NewReader(`{"cluster":"DC/OS"}`))
+	require.NoError(t, err)
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "ok", string(respBody))
+}
+
 func TestNewRequest(t *testing.T) {
 	client := New("https://dcos.io", ACSToken("acsToken"), Timeout(60*time.Second))
 


### PR DESCRIPTION
## High-level description
This adds a `Put` function to `httpclient` to allow it to send `Put` requests which will be needed by DCOS_OSS-5305 to send the proper method to the new diagnostics API.

## Corresponding DC/OS tickets (obligatory)

These DC/OS JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

- [DCOS_OSS-5305](https://jira.mesosphere.com/browse/DCOS_OSS-5305)


## Checklist for all PRs

- [X] Added a comprehensible changelog entry to `CHANGELOG.md` or explain why this is not a user-facing change: Does not affect CLI externally facing API
- [X] Updated completion script if applicable
- [X] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
- [X] Made a [documentation PR](https://github.com/mesosphere/dcos-docs-site) if these changes need to be reflected on https://docs.mesosphere.com/latest/cli/
- [X] Created backport PRs if needed:
