### PR TITLE
Improve help for `dcos cluster open`

### DIFF
--- a/pkg/cmd/auth/auth_listproviders.go
+++ b/pkg/cmd/auth/auth_listproviders.go
@@ -14,7 +14,7 @@ import (
 func newCmdAuthListProviders(ctx api.Context) *cobra.Command {
 	var jsonOutput bool
 	cmd := &cobra.Command{
-		Use:   "list-providers <url>",
+		Use:   "list-providers [<url>]",
 		Short: "List available login providers for a cluster",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cmd/cluster/cluster_open.go
+++ b/pkg/cmd/cluster/cluster_open.go
@@ -8,10 +8,17 @@ import (
 
 // newCmdClusterOpen opens the current cluster UI in the user browser.
 func newCmdClusterOpen(ctx api.Context) *cobra.Command {
+
 	cmd := &cobra.Command{
-		Use:   "open",
-		Short: "Open the current cluster UI in the browser",
-		Args:  cobra.MaximumNArgs(1),
+		Use:   "open [<cluster>]",
+		Short: "Open a cluster UI in the browser",
+		Example: `
+  # Open the current cluster UI in the browser
+  dcos cluster open
+
+  # Open a specific cluster UI in the browser (using a name or ID of a configured cluster)
+  dcos cluster open my-cluster-1`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var cluster *config.Cluster
 


### PR DESCRIPTION
```
Open a cluster UI in the browser

Usage:
  dcos cluster open [<cluster>] [flags]

Examples:

  # Open the current cluster UI in the browser
  dcos cluster open

  # Open a specific cluster UI in the browser (using a name or ID of a configured cluster)
  dcos cluster open my-cluster-1

Options:
  -h, --help   help for open
```
