### PR TITLE
Add support for the local login server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@
   * Auto-install CLI plugins for running services during `dcos cluster setup` when environment variable `DCOS_CLI_EXPERIMENTAL_AUTOINSTALL_PACKAGE_CLIS` set
   * New command `dcos config keys` printing all the keys that can be set in a configuration file
   * The new `dcos cluster open` can be used to open the currently attached cluster UI in the browser.
+  * Log into OSS without copy/pasting authentication token from browser.

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.0-20180130162743-b8a9be070da4
 	github.com/pelletier/go-toml v1.4.0
+	github.com/rs/cors v1.7.0
 	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cast v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,8 @@ github.com/pelletier/go-toml v1.4.0 h1:u3Z1r+oOXJIkxqw34zVhyPgjBsm6X2wn21NWs/HfS
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
+github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/sirupsen/logrus v1.0.5 h1:8c8b5uO0zS4X6RPl/sd1ENwSkIc0/H2PaHxE3udaE8I=
 github.com/sirupsen/logrus v1.0.5/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/pkg/cmd/auth/auth_listproviders_test.go
+++ b/pkg/cmd/auth/auth_listproviders_test.go
@@ -21,9 +21,9 @@ func TestAuthListProvidersTable(t *testing.T) {
 			mock.Cluster{
 				AuthChallenge: "acsjwt",
 				LoginProviders: login.Providers{
-				"dcos-users":   &login.Provider{Type: login.DCOSUIDPassword},
-				"dcos-service": &login.Provider{Type: login.DCOSUIDServiceKey},
-			}},
+					"dcos-users":   &login.Provider{Type: login.DCOSUIDPassword},
+					"dcos-service": &login.Provider{Type: login.DCOSUIDServiceKey},
+				}},
 			func(table *tablewriter.Table) {
 				table.Append([]string{"dcos-service", "Log in using a DC/OS service user account (username and private key)"})
 				table.Append([]string{"dcos-users", "Log in using a standard DC/OS user account (username and password)"})

--- a/pkg/login/loginserver/server.go
+++ b/pkg/login/loginserver/server.go
@@ -1,0 +1,104 @@
+package loginserver
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/rs/cors"
+)
+
+// LoginServer can be used to automatically intercept login tokens.
+type LoginServer struct {
+	listener     net.Listener
+	srv          *http.Server
+	csrfToken    string
+	startFlowURL string
+	tokenCh      chan string
+	errCh        chan error
+}
+
+// LoginData represents a login token and CSRF token pair.
+type LoginData struct {
+	Token     string `json:"token"`
+	CSRFToken string `json:"csrf"`
+}
+
+// New creates a new login server.
+func New(startFlowURL string) (*LoginServer, error) {
+	ls := &LoginServer{
+		tokenCh: make(chan string, 1),
+		errCh:   make(chan error, 1),
+	}
+
+	// Parse start flow URL.
+	u, err := url.Parse(startFlowURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// Generate CSRF token.
+	csrfTokenBytes := make([]byte, 32)
+	_, err = rand.Read(csrfTokenBytes)
+	if err != nil {
+		return nil, err
+	}
+	ls.csrfToken = base64.StdEncoding.EncodeToString(csrfTokenBytes)
+
+	// Create a listener to be used by the HTTP server.
+	ls.listener, err = net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the new start flow URL.
+	q := u.Query()
+	q.Set("dcos_cli_flow", "v1")
+	q.Set("dcos_cli_csrf_token", ls.csrfToken)
+
+	// The auth0 page will validate the redirect URI and only continue the flow if it refers to localhost.
+	// As such, we don't want to have 127.0.0.1 or [::1] as host, we enforce localhost.
+	addr := strings.Split(ls.listener.Addr().String(), ":")
+	q.Set("redirect_uri", fmt.Sprintf("http://localhost:%s", addr[len(addr)-1]))
+	u.RawQuery = q.Encode()
+	ls.startFlowURL = u.String()
+
+	return ls, nil
+}
+
+// Start starts the login server.
+func (ls *LoginServer) Start() error {
+	c := cors.New(cors.Options{
+		AllowedOrigins: []string{"https://dcos.auth0.com"},
+	})
+
+	return http.Serve(ls.listener, c.Handler(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var loginData LoginData
+
+		err := json.NewDecoder(req.Body).Decode(&loginData)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if loginData.CSRFToken != ls.csrfToken {
+			http.Error(w, "Invalid CSRF token.", http.StatusUnauthorized)
+			return
+		}
+		ls.tokenCh <- loginData.Token
+	})))
+}
+
+// StartFlowURL returns the start flow URL for the login server based flow.
+func (ls *LoginServer) StartFlowURL() string {
+	return ls.startFlowURL
+}
+
+// Token returns a channel from which the login token can be retrieved.
+func (ls *LoginServer) Token() <-chan string {
+	return ls.tokenCh
+}

--- a/pkg/login/loginserver/server_test.go
+++ b/pkg/login/loginserver/server_test.go
@@ -1,0 +1,65 @@
+package loginserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/url"
+	"testing"
+
+	"github.com/dcos/dcos-cli/pkg/httpclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServe(t *testing.T) {
+	loginServer, err := New("https://dcos.example.com")
+	require.NoError(t, err)
+
+	startFlowURL, err := url.Parse(loginServer.StartFlowURL())
+	require.NoError(t, err)
+
+	require.Equal(t, "v1", startFlowURL.Query().Get("dcos_cli_flow"))
+
+	go func() {
+		err := loginServer.Start()
+		assert.NoError(t, err)
+	}()
+
+	loginData := &LoginData{
+		Token:     "abc",
+		CSRFToken: startFlowURL.Query().Get("dcos_cli_csrf_token"),
+	}
+
+	var buf bytes.Buffer
+	err = json.NewEncoder(&buf).Encode(loginData)
+	require.NoError(t, err)
+
+	resp, err := httpclient.New("").Post(startFlowURL.Query().Get("redirect_uri"), "application/json", &buf)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+
+	require.Equal(t, loginData.Token, <-loginServer.Token())
+}
+
+func TestServeMissingCSRFToken(t *testing.T) {
+	loginServer, err := New("https://dcos.example.com")
+	require.NoError(t, err)
+
+	startFlowURL, err := url.Parse(loginServer.StartFlowURL())
+	require.NoError(t, err)
+
+	go func() {
+		err := loginServer.Start()
+		assert.NoError(t, err)
+	}()
+
+	loginData := &LoginData{Token: "abc"}
+
+	var buf bytes.Buffer
+	err = json.NewEncoder(&buf).Encode(loginData)
+	require.NoError(t, err)
+
+	resp, err := httpclient.New("").Post(startFlowURL.Query().Get("redirect_uri"), "application/json", &buf)
+	require.NoError(t, err)
+	require.Equal(t, 401, resp.StatusCode)
+}

--- a/pkg/login/provider.go
+++ b/pkg/login/provider.go
@@ -6,6 +6,12 @@ import (
 	"sort"
 )
 
+// This is a non-exhaustive list of login provider IDs for DC/OS.
+const (
+	DCOSOIDCAuth0 = "dcos-oidc-auth0"
+	DCOSUsers     = "dcos-users"
+)
+
 // These are the different login provider types that the DC/OS CLI supports.
 const (
 	DCOSUIDPassword     = "dcos-uid-password"
@@ -92,7 +98,7 @@ func (p Providers) Slice() []*Provider {
 
 func defaultDCOSUIDPasswordProvider() (provider *Provider) {
 	return &Provider{
-		ID:           "dcos-users",
+		ID:           DCOSUsers,
 		Type:         DCOSUIDPassword,
 		Description:  "Default DC/OS login provider",
 		ClientMethod: methodUserCredential,
@@ -104,7 +110,7 @@ func defaultDCOSUIDPasswordProvider() (provider *Provider) {
 
 func defaultOIDCImplicitFlowProvider() (provider *Provider) {
 	return &Provider{
-		ID:           "dcos-oidc-auth0",
+		ID:           DCOSOIDCAuth0,
 		Type:         OIDCImplicitFlow,
 		Description:  "Google, GitHub, or Microsoft",
 		ClientMethod: methodBrowserOIDCToken,

--- a/vendor/github.com/rs/cors/.travis.yml
+++ b/vendor/github.com/rs/cors/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+go:
+- "1.10"
+- "1.11"
+- "1.12"
+- tip
+matrix:
+  allow_failures:
+    - go: tip

--- a/vendor/github.com/rs/cors/LICENSE
+++ b/vendor/github.com/rs/cors/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2014 Olivier Poitrey <rs@dailymotion.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/rs/cors/README.md
+++ b/vendor/github.com/rs/cors/README.md
@@ -1,0 +1,115 @@
+# Go CORS handler [![godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/rs/cors) [![license](http://img.shields.io/badge/license-MIT-red.svg?style=flat)](https://raw.githubusercontent.com/rs/cors/master/LICENSE) [![build](https://img.shields.io/travis/rs/cors.svg?style=flat)](https://travis-ci.org/rs/cors) [![Coverage](http://gocover.io/_badge/github.com/rs/cors)](http://gocover.io/github.com/rs/cors)
+
+CORS is a `net/http` handler implementing [Cross Origin Resource Sharing W3 specification](http://www.w3.org/TR/cors/) in Golang.
+
+## Getting Started
+
+After installing Go and setting up your [GOPATH](http://golang.org/doc/code.html#GOPATH), create your first `.go` file. We'll call it `server.go`.
+
+```go
+package main
+
+import (
+    "net/http"
+
+    "github.com/rs/cors"
+)
+
+func main() {
+    mux := http.NewServeMux()
+    mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+        w.Header().Set("Content-Type", "application/json")
+        w.Write([]byte("{\"hello\": \"world\"}"))
+    })
+
+    // cors.Default() setup the middleware with default options being
+    // all origins accepted with simple methods (GET, POST). See
+    // documentation below for more options.
+    handler := cors.Default().Handler(mux)
+    http.ListenAndServe(":8080", handler)
+}
+```
+
+Install `cors`:
+
+    go get github.com/rs/cors
+
+Then run your server:
+
+    go run server.go
+
+The server now runs on `localhost:8080`:
+
+    $ curl -D - -H 'Origin: http://foo.com' http://localhost:8080/
+    HTTP/1.1 200 OK
+    Access-Control-Allow-Origin: foo.com
+    Content-Type: application/json
+    Date: Sat, 25 Oct 2014 03:43:57 GMT
+    Content-Length: 18
+
+    {"hello": "world"}
+
+### Allow * With Credentials Security Protection
+
+This library has been modified to avoid a well known security issue when configured with `AllowedOrigins` to `*` and `AllowCredentials` to `true`. Such setup used to make the library reflects the request `Origin` header value, working around a security protection embedded into the standard that makes clients to refuse such configuration. This behavior has been removed with [#55](https://github.com/rs/cors/issues/55) and [#57](https://github.com/rs/cors/issues/57).
+
+If you depend on this behavior and understand the implications, you can restore it using the `AllowOriginFunc` with `func(origin string) {return true}`.
+
+Please refer to [#55](https://github.com/rs/cors/issues/55) for more information about the security implications.
+
+### More Examples
+
+* `net/http`: [examples/nethttp/server.go](https://github.com/rs/cors/blob/master/examples/nethttp/server.go)
+* [Goji](https://goji.io): [examples/goji/server.go](https://github.com/rs/cors/blob/master/examples/goji/server.go)
+* [Martini](http://martini.codegangsta.io): [examples/martini/server.go](https://github.com/rs/cors/blob/master/examples/martini/server.go)
+* [Negroni](https://github.com/codegangsta/negroni): [examples/negroni/server.go](https://github.com/rs/cors/blob/master/examples/negroni/server.go)
+* [Alice](https://github.com/justinas/alice): [examples/alice/server.go](https://github.com/rs/cors/blob/master/examples/alice/server.go)
+* [HttpRouter](https://github.com/julienschmidt/httprouter): [examples/httprouter/server.go](https://github.com/rs/cors/blob/master/examples/httprouter/server.go)
+* [Gorilla](http://www.gorillatoolkit.org/pkg/mux): [examples/gorilla/server.go](https://github.com/rs/cors/blob/master/examples/gorilla/server.go)
+* [Buffalo](https://gobuffalo.io): [examples/buffalo/server.go](https://github.com/rs/cors/blob/master/examples/buffalo/server.go)
+* [Gin](https://gin-gonic.github.io/gin): [examples/gin/server.go](https://github.com/rs/cors/blob/master/examples/gin/server.go)
+* [Chi](https://github.com/go-chi/chi): [examples/chi/server.go](https://github.com/rs/cors/blob/master/examples/chi/server.go)
+
+## Parameters
+
+Parameters are passed to the middleware thru the `cors.New` method as follow:
+
+```go
+c := cors.New(cors.Options{
+    AllowedOrigins: []string{"http://foo.com", "http://foo.com:8080"},
+    AllowCredentials: true,
+    // Enable Debugging for testing, consider disabling in production
+    Debug: true,
+})
+
+// Insert the middleware
+handler = c.Handler(handler)
+```
+
+* **AllowedOrigins** `[]string`: A list of origins a cross-domain request can be executed from. If the special `*` value is present in the list, all origins will be allowed. An origin may contain a wildcard (`*`) to replace 0 or more characters (i.e.: `http://*.domain.com`). Usage of wildcards implies a small performance penality. Only one wildcard can be used per origin. The default value is `*`.
+* **AllowOriginFunc** `func (origin string) bool`: A custom function to validate the origin. It takes the origin as an argument and returns true if allowed, or false otherwise. If this option is set, the content of `AllowedOrigins` is ignored.
+* **AllowOriginRequestFunc** `func (r *http.Request origin string) bool`: A custom function to validate the origin. It takes the HTTP Request object and the origin as argument and returns true if allowed or false otherwise. If this option is set, the content of `AllowedOrigins` and `AllowOriginFunc` is ignored
+* **AllowedMethods** `[]string`: A list of methods the client is allowed to use with cross-domain requests. Default value is simple methods (`GET` and `POST`).
+* **AllowedHeaders** `[]string`: A list of non simple headers the client is allowed to use with cross-domain requests.
+* **ExposedHeaders** `[]string`: Indicates which headers are safe to expose to the API of a CORS API specification
+* **AllowCredentials** `bool`: Indicates whether the request can include user credentials like cookies, HTTP authentication or client side SSL certificates. The default is `false`.
+* **MaxAge** `int`: Indicates how long (in seconds) the results of a preflight request can be cached. The default is `0` which stands for no max age.
+* **OptionsPassthrough** `bool`: Instructs preflight to let other potential next handlers to process the `OPTIONS` method. Turn this on if your application handles `OPTIONS`.
+* **Debug** `bool`: Debugging flag adds additional output to debug server side CORS issues.
+
+See [API documentation](http://godoc.org/github.com/rs/cors) for more info.
+
+## Benchmarks
+
+    BenchmarkWithout          20000000    64.6 ns/op      8 B/op    1 allocs/op
+    BenchmarkDefault          3000000      469 ns/op    114 B/op    2 allocs/op
+    BenchmarkAllowedOrigin    3000000      608 ns/op    114 B/op    2 allocs/op
+    BenchmarkPreflight        20000000    73.2 ns/op      0 B/op    0 allocs/op
+    BenchmarkPreflightHeader  20000000    73.6 ns/op      0 B/op    0 allocs/op
+    BenchmarkParseHeaderList  2000000      847 ns/op    184 B/op    6 allocs/op
+    BenchmarkParse…Single     5000000      290 ns/op     32 B/op    3 allocs/op
+    BenchmarkParse…Normalized 2000000      776 ns/op    160 B/op    6 allocs/op
+
+## Licenses
+
+All source code is licensed under the [MIT License](https://raw.github.com/rs/cors/master/LICENSE).

--- a/vendor/github.com/rs/cors/cors.go
+++ b/vendor/github.com/rs/cors/cors.go
@@ -1,0 +1,425 @@
+/*
+Package cors is net/http handler to handle CORS related requests
+as defined by http://www.w3.org/TR/cors/
+
+You can configure it by passing an option struct to cors.New:
+
+    c := cors.New(cors.Options{
+        AllowedOrigins:   []string{"foo.com"},
+        AllowedMethods:   []string{http.MethodGet, http.MethodPost, http.MethodDelete},
+        AllowCredentials: true,
+    })
+
+Then insert the handler in the chain:
+
+    handler = c.Handler(handler)
+
+See Options documentation for more options.
+
+The resulting handler is a standard net/http handler.
+*/
+package cors
+
+import (
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Options is a configuration container to setup the CORS middleware.
+type Options struct {
+	// AllowedOrigins is a list of origins a cross-domain request can be executed from.
+	// If the special "*" value is present in the list, all origins will be allowed.
+	// An origin may contain a wildcard (*) to replace 0 or more characters
+	// (i.e.: http://*.domain.com). Usage of wildcards implies a small performance penalty.
+	// Only one wildcard can be used per origin.
+	// Default value is ["*"]
+	AllowedOrigins []string
+	// AllowOriginFunc is a custom function to validate the origin. It take the origin
+	// as argument and returns true if allowed or false otherwise. If this option is
+	// set, the content of AllowedOrigins is ignored.
+	AllowOriginFunc func(origin string) bool
+	// AllowOriginFunc is a custom function to validate the origin. It takes the HTTP Request object and the origin as
+	// argument and returns true if allowed or false otherwise. If this option is set, the content of `AllowedOrigins`
+	// and `AllowOriginFunc` is ignored.
+	AllowOriginRequestFunc func(r *http.Request, origin string) bool
+	// AllowedMethods is a list of methods the client is allowed to use with
+	// cross-domain requests. Default value is simple methods (HEAD, GET and POST).
+	AllowedMethods []string
+	// AllowedHeaders is list of non simple headers the client is allowed to use with
+	// cross-domain requests.
+	// If the special "*" value is present in the list, all headers will be allowed.
+	// Default value is [] but "Origin" is always appended to the list.
+	AllowedHeaders []string
+	// ExposedHeaders indicates which headers are safe to expose to the API of a CORS
+	// API specification
+	ExposedHeaders []string
+	// MaxAge indicates how long (in seconds) the results of a preflight request
+	// can be cached
+	MaxAge int
+	// AllowCredentials indicates whether the request can include user credentials like
+	// cookies, HTTP authentication or client side SSL certificates.
+	AllowCredentials bool
+	// OptionsPassthrough instructs preflight to let other potential next handlers to
+	// process the OPTIONS method. Turn this on if your application handles OPTIONS.
+	OptionsPassthrough bool
+	// Debugging flag adds additional output to debug server side CORS issues
+	Debug bool
+}
+
+// Logger generic interface for logger
+type Logger interface {
+	Printf(string, ...interface{})
+}
+
+// Cors http handler
+type Cors struct {
+	// Debug logger
+	Log Logger
+	// Normalized list of plain allowed origins
+	allowedOrigins []string
+	// List of allowed origins containing wildcards
+	allowedWOrigins []wildcard
+	// Optional origin validator function
+	allowOriginFunc func(origin string) bool
+	// Optional origin validator (with request) function
+	allowOriginRequestFunc func(r *http.Request, origin string) bool
+	// Normalized list of allowed headers
+	allowedHeaders []string
+	// Normalized list of allowed methods
+	allowedMethods []string
+	// Normalized list of exposed headers
+	exposedHeaders []string
+	maxAge         int
+	// Set to true when allowed origins contains a "*"
+	allowedOriginsAll bool
+	// Set to true when allowed headers contains a "*"
+	allowedHeadersAll bool
+	allowCredentials  bool
+	optionPassthrough bool
+}
+
+// New creates a new Cors handler with the provided options.
+func New(options Options) *Cors {
+	c := &Cors{
+		exposedHeaders:         convert(options.ExposedHeaders, http.CanonicalHeaderKey),
+		allowOriginFunc:        options.AllowOriginFunc,
+		allowOriginRequestFunc: options.AllowOriginRequestFunc,
+		allowCredentials:       options.AllowCredentials,
+		maxAge:                 options.MaxAge,
+		optionPassthrough:      options.OptionsPassthrough,
+	}
+	if options.Debug && c.Log == nil {
+		c.Log = log.New(os.Stdout, "[cors] ", log.LstdFlags)
+	}
+
+	// Normalize options
+	// Note: for origins and methods matching, the spec requires a case-sensitive matching.
+	// As it may error prone, we chose to ignore the spec here.
+
+	// Allowed Origins
+	if len(options.AllowedOrigins) == 0 {
+		if options.AllowOriginFunc == nil && options.AllowOriginRequestFunc == nil {
+			// Default is all origins
+			c.allowedOriginsAll = true
+		}
+	} else {
+		c.allowedOrigins = []string{}
+		c.allowedWOrigins = []wildcard{}
+		for _, origin := range options.AllowedOrigins {
+			// Normalize
+			origin = strings.ToLower(origin)
+			if origin == "*" {
+				// If "*" is present in the list, turn the whole list into a match all
+				c.allowedOriginsAll = true
+				c.allowedOrigins = nil
+				c.allowedWOrigins = nil
+				break
+			} else if i := strings.IndexByte(origin, '*'); i >= 0 {
+				// Split the origin in two: start and end string without the *
+				w := wildcard{origin[0:i], origin[i+1:]}
+				c.allowedWOrigins = append(c.allowedWOrigins, w)
+			} else {
+				c.allowedOrigins = append(c.allowedOrigins, origin)
+			}
+		}
+	}
+
+	// Allowed Headers
+	if len(options.AllowedHeaders) == 0 {
+		// Use sensible defaults
+		c.allowedHeaders = []string{"Origin", "Accept", "Content-Type", "X-Requested-With"}
+	} else {
+		// Origin is always appended as some browsers will always request for this header at preflight
+		c.allowedHeaders = convert(append(options.AllowedHeaders, "Origin"), http.CanonicalHeaderKey)
+		for _, h := range options.AllowedHeaders {
+			if h == "*" {
+				c.allowedHeadersAll = true
+				c.allowedHeaders = nil
+				break
+			}
+		}
+	}
+
+	// Allowed Methods
+	if len(options.AllowedMethods) == 0 {
+		// Default is spec's "simple" methods
+		c.allowedMethods = []string{http.MethodGet, http.MethodPost, http.MethodHead}
+	} else {
+		c.allowedMethods = convert(options.AllowedMethods, strings.ToUpper)
+	}
+
+	return c
+}
+
+// Default creates a new Cors handler with default options.
+func Default() *Cors {
+	return New(Options{})
+}
+
+// AllowAll create a new Cors handler with permissive configuration allowing all
+// origins with all standard methods with any header and credentials.
+func AllowAll() *Cors {
+	return New(Options{
+		AllowedOrigins: []string{"*"},
+		AllowedMethods: []string{
+			http.MethodHead,
+			http.MethodGet,
+			http.MethodPost,
+			http.MethodPut,
+			http.MethodPatch,
+			http.MethodDelete,
+		},
+		AllowedHeaders:   []string{"*"},
+		AllowCredentials: false,
+	})
+}
+
+// Handler apply the CORS specification on the request, and add relevant CORS headers
+// as necessary.
+func (c *Cors) Handler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
+			c.logf("Handler: Preflight request")
+			c.handlePreflight(w, r)
+			// Preflight requests are standalone and should stop the chain as some other
+			// middleware may not handle OPTIONS requests correctly. One typical example
+			// is authentication middleware ; OPTIONS requests won't carry authentication
+			// headers (see #1)
+			if c.optionPassthrough {
+				h.ServeHTTP(w, r)
+			} else {
+				w.WriteHeader(http.StatusOK)
+			}
+		} else {
+			c.logf("Handler: Actual request")
+			c.handleActualRequest(w, r)
+			h.ServeHTTP(w, r)
+		}
+	})
+}
+
+// HandlerFunc provides Martini compatible handler
+func (c *Cors) HandlerFunc(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
+		c.logf("HandlerFunc: Preflight request")
+		c.handlePreflight(w, r)
+	} else {
+		c.logf("HandlerFunc: Actual request")
+		c.handleActualRequest(w, r)
+	}
+}
+
+// Negroni compatible interface
+func (c *Cors) ServeHTTP(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
+		c.logf("ServeHTTP: Preflight request")
+		c.handlePreflight(w, r)
+		// Preflight requests are standalone and should stop the chain as some other
+		// middleware may not handle OPTIONS requests correctly. One typical example
+		// is authentication middleware ; OPTIONS requests won't carry authentication
+		// headers (see #1)
+		if c.optionPassthrough {
+			next(w, r)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	} else {
+		c.logf("ServeHTTP: Actual request")
+		c.handleActualRequest(w, r)
+		next(w, r)
+	}
+}
+
+// handlePreflight handles pre-flight CORS requests
+func (c *Cors) handlePreflight(w http.ResponseWriter, r *http.Request) {
+	headers := w.Header()
+	origin := r.Header.Get("Origin")
+
+	if r.Method != http.MethodOptions {
+		c.logf("  Preflight aborted: %s!=OPTIONS", r.Method)
+		return
+	}
+	// Always set Vary headers
+	// see https://github.com/rs/cors/issues/10,
+	//     https://github.com/rs/cors/commit/dbdca4d95feaa7511a46e6f1efb3b3aa505bc43f#commitcomment-12352001
+	headers.Add("Vary", "Origin")
+	headers.Add("Vary", "Access-Control-Request-Method")
+	headers.Add("Vary", "Access-Control-Request-Headers")
+
+	if origin == "" {
+		c.logf("  Preflight aborted: empty origin")
+		return
+	}
+	if !c.isOriginAllowed(r, origin) {
+		c.logf("  Preflight aborted: origin '%s' not allowed", origin)
+		return
+	}
+
+	reqMethod := r.Header.Get("Access-Control-Request-Method")
+	if !c.isMethodAllowed(reqMethod) {
+		c.logf("  Preflight aborted: method '%s' not allowed", reqMethod)
+		return
+	}
+	reqHeaders := parseHeaderList(r.Header.Get("Access-Control-Request-Headers"))
+	if !c.areHeadersAllowed(reqHeaders) {
+		c.logf("  Preflight aborted: headers '%v' not allowed", reqHeaders)
+		return
+	}
+	if c.allowedOriginsAll {
+		headers.Set("Access-Control-Allow-Origin", "*")
+	} else {
+		headers.Set("Access-Control-Allow-Origin", origin)
+	}
+	// Spec says: Since the list of methods can be unbounded, simply returning the method indicated
+	// by Access-Control-Request-Method (if supported) can be enough
+	headers.Set("Access-Control-Allow-Methods", strings.ToUpper(reqMethod))
+	if len(reqHeaders) > 0 {
+
+		// Spec says: Since the list of headers can be unbounded, simply returning supported headers
+		// from Access-Control-Request-Headers can be enough
+		headers.Set("Access-Control-Allow-Headers", strings.Join(reqHeaders, ", "))
+	}
+	if c.allowCredentials {
+		headers.Set("Access-Control-Allow-Credentials", "true")
+	}
+	if c.maxAge > 0 {
+		headers.Set("Access-Control-Max-Age", strconv.Itoa(c.maxAge))
+	}
+	c.logf("  Preflight response headers: %v", headers)
+}
+
+// handleActualRequest handles simple cross-origin requests, actual request or redirects
+func (c *Cors) handleActualRequest(w http.ResponseWriter, r *http.Request) {
+	headers := w.Header()
+	origin := r.Header.Get("Origin")
+
+	// Always set Vary, see https://github.com/rs/cors/issues/10
+	headers.Add("Vary", "Origin")
+	if origin == "" {
+		c.logf("  Actual request no headers added: missing origin")
+		return
+	}
+	if !c.isOriginAllowed(r, origin) {
+		c.logf("  Actual request no headers added: origin '%s' not allowed", origin)
+		return
+	}
+
+	// Note that spec does define a way to specifically disallow a simple method like GET or
+	// POST. Access-Control-Allow-Methods is only used for pre-flight requests and the
+	// spec doesn't instruct to check the allowed methods for simple cross-origin requests.
+	// We think it's a nice feature to be able to have control on those methods though.
+	if !c.isMethodAllowed(r.Method) {
+		c.logf("  Actual request no headers added: method '%s' not allowed", r.Method)
+
+		return
+	}
+	if c.allowedOriginsAll {
+		headers.Set("Access-Control-Allow-Origin", "*")
+	} else {
+		headers.Set("Access-Control-Allow-Origin", origin)
+	}
+	if len(c.exposedHeaders) > 0 {
+		headers.Set("Access-Control-Expose-Headers", strings.Join(c.exposedHeaders, ", "))
+	}
+	if c.allowCredentials {
+		headers.Set("Access-Control-Allow-Credentials", "true")
+	}
+	c.logf("  Actual response added headers: %v", headers)
+}
+
+// convenience method. checks if a logger is set.
+func (c *Cors) logf(format string, a ...interface{}) {
+	if c.Log != nil {
+		c.Log.Printf(format, a...)
+	}
+}
+
+// isOriginAllowed checks if a given origin is allowed to perform cross-domain requests
+// on the endpoint
+func (c *Cors) isOriginAllowed(r *http.Request, origin string) bool {
+	if c.allowOriginRequestFunc != nil {
+		return c.allowOriginRequestFunc(r, origin)
+	}
+	if c.allowOriginFunc != nil {
+		return c.allowOriginFunc(origin)
+	}
+	if c.allowedOriginsAll {
+		return true
+	}
+	origin = strings.ToLower(origin)
+	for _, o := range c.allowedOrigins {
+		if o == origin {
+			return true
+		}
+	}
+	for _, w := range c.allowedWOrigins {
+		if w.match(origin) {
+			return true
+		}
+	}
+	return false
+}
+
+// isMethodAllowed checks if a given method can be used as part of a cross-domain request
+// on the endpoing
+func (c *Cors) isMethodAllowed(method string) bool {
+	if len(c.allowedMethods) == 0 {
+		// If no method allowed, always return false, even for preflight request
+		return false
+	}
+	method = strings.ToUpper(method)
+	if method == http.MethodOptions {
+		// Always allow preflight requests
+		return true
+	}
+	for _, m := range c.allowedMethods {
+		if m == method {
+			return true
+		}
+	}
+	return false
+}
+
+// areHeadersAllowed checks if a given list of headers are allowed to used within
+// a cross-domain request.
+func (c *Cors) areHeadersAllowed(requestedHeaders []string) bool {
+	if c.allowedHeadersAll || len(requestedHeaders) == 0 {
+		return true
+	}
+	for _, header := range requestedHeaders {
+		header = http.CanonicalHeaderKey(header)
+		found := false
+		for _, h := range c.allowedHeaders {
+			if h == header {
+				found = true
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/github.com/rs/cors/go.mod
+++ b/vendor/github.com/rs/cors/go.mod
@@ -1,0 +1,1 @@
+module github.com/rs/cors

--- a/vendor/github.com/rs/cors/utils.go
+++ b/vendor/github.com/rs/cors/utils.go
@@ -1,0 +1,71 @@
+package cors
+
+import "strings"
+
+const toLower = 'a' - 'A'
+
+type converter func(string) string
+
+type wildcard struct {
+	prefix string
+	suffix string
+}
+
+func (w wildcard) match(s string) bool {
+	return len(s) >= len(w.prefix)+len(w.suffix) && strings.HasPrefix(s, w.prefix) && strings.HasSuffix(s, w.suffix)
+}
+
+// convert converts a list of string using the passed converter function
+func convert(s []string, c converter) []string {
+	out := []string{}
+	for _, i := range s {
+		out = append(out, c(i))
+	}
+	return out
+}
+
+// parseHeaderList tokenize + normalize a string containing a list of headers
+func parseHeaderList(headerList string) []string {
+	l := len(headerList)
+	h := make([]byte, 0, l)
+	upper := true
+	// Estimate the number headers in order to allocate the right splice size
+	t := 0
+	for i := 0; i < l; i++ {
+		if headerList[i] == ',' {
+			t++
+		}
+	}
+	headers := make([]string, 0, t)
+	for i := 0; i < l; i++ {
+		b := headerList[i]
+		switch {
+		case b >= 'a' && b <= 'z':
+			if upper {
+				h = append(h, b-toLower)
+			} else {
+				h = append(h, b)
+			}
+		case b >= 'A' && b <= 'Z':
+			if !upper {
+				h = append(h, b+toLower)
+			} else {
+				h = append(h, b)
+			}
+		case b == '-' || b == '_' || (b >= '0' && b <= '9'):
+			h = append(h, b)
+		}
+
+		if b == ' ' || b == ',' || i == l-1 {
+			if len(h) > 0 {
+				// Flush the found header
+				headers = append(headers, string(h))
+				h = h[:0]
+				upper = true
+			}
+		} else {
+			upper = b == '-' || b == '_'
+		}
+	}
+	return headers
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -24,6 +24,8 @@ github.com/olekukonko/tablewriter
 github.com/pelletier/go-toml
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
+# github.com/rs/cors v1.7.0
+github.com/rs/cors
 # github.com/sirupsen/logrus v1.4.1
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/test


### PR DESCRIPTION
## High-level description

    For the `dcos-oidc-auth0` login provider ID, this removes the need
    to copy-paste the token between the UI / CLI by leveraging a
    local webserver and the `redirect_uri` parameter.
    
    https://jira.mesosphere.com/browse/DCOS-51535


## Corresponding DC/OS tickets (obligatory)

- https://jira.mesosphere.com/browse/DCOS-51535

## Checklist for all PRs

- [x] Added a comprehensible changelog entry to `CHANGELOG.md` or explain why this is not a user-facing change:
- [ ] Updated completion script if applicable
- [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
- [ ] Made a [documentation PR](https://github.com/mesosphere/dcos-docs-site) if these changes need to be reflected on https://docs.mesosphere.com/latest/cli/
- [ ] Created backport PRs if needed:
