### PR TITLE
Return plugin after installation

### DIFF
--- a/pkg/cmd/dcos.go
+++ b/pkg/cmd/dcos.go
@@ -132,7 +132,7 @@ func updateCorePlugin(ctx api.Context) error {
 		return err
 	}
 
-	return ctx.PluginManager(cluster).Install(pluginInfo.Url, &plugin.InstallOpts{
+	_, err = ctx.PluginManager(cluster).Install(pluginInfo.Url, &plugin.InstallOpts{
 		Name:   "dcos-core-cli",
 		Update: true,
 		PostInstall: func(fs afero.Fs, pluginDir string) error {
@@ -145,6 +145,7 @@ func updateCorePlugin(ctx api.Context) error {
 			return json.NewEncoder(pkgInfoFile).Encode(pkg.Package)
 		},
 	})
+	return err
 }
 
 // invokePlugin calls the binary of a plugin, passing in the arguments it's been given.

--- a/pkg/cmd/plugin/plugin_add.go
+++ b/pkg/cmd/plugin/plugin_add.go
@@ -1,6 +1,9 @@
 package plugin
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/dcos/dcos-cli/api"
 	"github.com/dcos/dcos-cli/pkg/plugin"
 	"github.com/spf13/cobra"
@@ -18,7 +21,14 @@ func newCmdPluginAdd(ctx api.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return ctx.PluginManager(cluster).Install(args[0], installOpts)
+
+			p, err := ctx.PluginManager(cluster).Install(args[0], installOpts)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintf(ctx.ErrOut(), "New commands available: %s\n", strings.Join(p.CommandNames(), ", "))
+			return nil
 		},
 	}
 	cmd.Flags().BoolVarP(&installOpts.Update, "update", "u", false, "")

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -1,6 +1,9 @@
 package plugin
 
-import "path/filepath"
+import (
+	"path/filepath"
+	"sort"
+)
 
 // Plugin is the structure representation of a `plugin.toml file.
 // It also contains JSON tags for the `dcos plugin list --json` command.
@@ -26,4 +29,13 @@ func (p *Plugin) Dir() string {
 // CompletionDir returns the absolute path to the directory holding the plugin's completion script files
 func (p *Plugin) CompletionDir() string {
 	return filepath.Join(p.Dir(), "completion")
+}
+
+// CommandNames returns the commands available in the plugin as a sorted list of names.
+func (p *Plugin) CommandNames() (commands []string) {
+	for _, command := range p.Commands {
+		commands = append(commands, command.Name)
+	}
+	sort.Strings(commands)
+	return commands
 }

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -63,6 +63,9 @@ func TestLoadPluginWithMultipleCommands(t *testing.T) {
 			t.FailNow()
 		}
 	}
+
+	// Command names should be sorted.
+	require.Equal(t, []string{"no-test", "test"}, plugins[0].CommandNames())
 }
 
 func pluginManager(t *testing.T, name string) *Manager {

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -333,10 +333,8 @@ func (s *Setup) installDefaultPlugins(httpClient *httpclient.Client) error {
 	}
 
 	var newCommands []string
-	for _, installedPlugin := range s.pluginManager.Plugins() {
-		for _, command := range installedPlugin.Commands {
-			newCommands = append(newCommands, command.Name)
-		}
+	for _, p := range s.pluginManager.Plugins() {
+		newCommands = append(newCommands, p.CommandNames()...)
 	}
 
 	sort.Strings(newCommands)
@@ -440,11 +438,12 @@ func (s *Setup) installPluginFromCanonicalURL(name string, version *dcos.Version
 			domain, name, platform, name, dcosVersion,
 		)
 	}
-	return s.pluginManager.Install(url, &plugin.InstallOpts{
+	_, err = s.pluginManager.Install(url, &plugin.InstallOpts{
 		Name:        name,
 		Update:      true,
 		ProgressBar: pbar,
 	})
+	return err
 }
 
 // installPluginFromCosmos installs a plugin through Cosmos.
@@ -477,7 +476,7 @@ func (s *Setup) installPluginFromCosmos(name string, version string, httpClient 
 			checksum.Value = contentHash.Value
 		}
 	}
-	return s.pluginManager.Install(pluginInfo.Url, &plugin.InstallOpts{
+	_, err = s.pluginManager.Install(pluginInfo.Url, &plugin.InstallOpts{
 		Name:        pkg.Package.Name,
 		Update:      true,
 		Checksum:    checksum,
@@ -492,6 +491,7 @@ func (s *Setup) installPluginFromCosmos(name string, version string, httpClient 
 			return json.NewEncoder(pkgInfoFile).Encode(pkg.Package)
 		},
 	})
+	return err
 }
 
 // promptCA prompts information about the certificate authority to the user.

--- a/tests/integration/test_help.py
+++ b/tests/integration/test_help.py
@@ -52,6 +52,8 @@ Commands:
         Manage your DC/OS clusters
     config
         Manage the DC/OS configuration file
+    diagnostics
+        Create and manage DC/OS diagnostics bundles
     help
         Help about any command
     job
@@ -101,6 +103,8 @@ Commands:
         Manage your DC/OS clusters
     config
         Manage the DC/OS configuration file
+    diagnostics
+        Create and manage DC/OS diagnostics bundles
     help
         Help about any command
     job

--- a/tests/integration/test_plugin.py
+++ b/tests/integration/test_plugin.py
@@ -252,7 +252,7 @@ def test_plugin_help_usage(default_cluster):
 
 def _install_test_plugin():
     code, out, err = exec_cmd(['dcos', 'plugin', 'add', _test_plugin_path()])
-    assert err == ''
+    assert err == 'New commands available: test\n'
     assert out == ''
     assert code == 0
 

--- a/tests/integration/test_plugin.py
+++ b/tests/integration/test_plugin.py
@@ -77,7 +77,7 @@ def test_plugin_list(default_cluster):
 
     dcos_core_cli = lines[1].split()
     assert dcos_core_cli[0] == 'dcos-core-cli'
-    assert dcos_core_cli[1:] == ['job', 'marathon', 'node', 'package', 'quota', 'service', 'task']
+    assert dcos_core_cli[1:] == ['diagnostics', 'job', 'marathon', 'node', 'package', 'quota', 'service', 'task']
 
     if default_cluster['variant'] == 'enterprise':
         dcos_enterprise_cli = lines[2].split()


### PR DESCRIPTION
This returns the installed plugin when the Install() method is called.
This is useful in some cases where the caller needs to do additional
work with a plugin once it's installed, eg. print the new subcommands.

This also updates the `dcos plugin add` command to print the new
commands whenever a plugin is installed.