### PR TITLE
Pass plugin config as environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Features
 
   * Pass plugin config as environment variables.
+  * Pass `DCOS_CLI_VERSION` when invoking plugins.
 
 ## 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Next
+
+* Features
+
+  * Pass plugin config as environment variables.
+
 ## 1.0.1
 
 * Fixes

--- a/design/plugin.md
+++ b/design/plugin.md
@@ -122,6 +122,15 @@ When a cluster is attached, the CLI will also pass the following ENV variables:
                       verify server certificates against. When it is not set, the system's CA bundle
                       must be used.
 
+The CLI will also pass the subcommand config as additional environment variables with the following format:
+
+    DCOS_{COMMAND}_{CONFIG}={VALUE}
+
+Where `COMMAND` is the uppercase subcommand name, if the command contains hyphens, they are replaced by underscores.
+And `CONFIG` is the uppercase config key in the command section.
+
+For instance, when the `hello` subcommand has a config value (`dcos config set hello.world foo`), it will be passed when the subcommand is invoked (as `DCOS_HELLO_WORLD=foo`).
+
 The child process has access to the standard out/standard error of the CLI process. It is not guaranteed to have access to any other file descriptors the parent may have opened.
 
 The child process is not started in a shell. If the command is not startable for any reason an error message is printed (not on the path, executable does not exist, binary incompatibility, etc).

--- a/design/plugin.md
+++ b/design/plugin.md
@@ -112,6 +112,8 @@ For example, if a `dcos-hello` executable in a plugin has a `hello` top level co
 
 Executables contained within plugins are called synchronously from the CLI by spawning a new child process. The CLI waits for the child process to complete. The CLI makes available its own executable path to the child via an ENV variable `DCOS_CLI_EXECUTABLE_PATH`.
 
+The CLI version is passed in the `DCOS_CLI_VERSION` ENV variable.
+
 When a cluster is attached, the CLI will also pass the following ENV variables:
 
 - `DCOS_URL`: The base URL of the DC/OS cluster without a trailing slash (eg. `https://dcos.example.com`).

--- a/pkg/cmd/dcos.go
+++ b/pkg/cmd/dcos.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dcos/dcos-cli/pkg/cmd/completion"
 	configcmd "github.com/dcos/dcos-cli/pkg/cmd/config"
 	plugincmd "github.com/dcos/dcos-cli/pkg/cmd/plugin"
+	"github.com/dcos/dcos-cli/pkg/config"
 	"github.com/dcos/dcos-cli/pkg/internal/cosmos"
 	"github.com/dcos/dcos-cli/pkg/plugin"
 )
@@ -151,48 +152,21 @@ func updateCorePlugin(ctx api.Context) error {
 
 // invokePlugin calls the binary of a plugin, passing in the arguments it's been given.
 func invokePlugin(ctx api.Context, cmd plugin.Command, args []string) error {
-	executablePath, err := os.Executable()
-	if err != nil {
-		return err
-	}
 	execCmd := exec.Command(cmd.Path, args...)
 	execCmd.Stdout = ctx.Out()
 	execCmd.Stderr = ctx.ErrOut()
 	execCmd.Stdin = ctx.Input()
 
-	execCmd.Env = append(os.Environ(), "DCOS_CLI_EXECUTABLE_PATH="+executablePath)
-	execCmd.Env = append(execCmd.Env, "DCOS_CLI_VERSION="+version.Version())
-
-	switch ctx.Logger().Level {
-	case logrus.DebugLevel:
-		execCmd.Env = append(execCmd.Env, "DCOS_VERBOSITY=2", "DCOS_LOG_LEVEL=debug")
-	case logrus.InfoLevel:
-		execCmd.Env = append(execCmd.Env, "DCOS_VERBOSITY=1", "DCOS_LOG_LEVEL=info")
+	executablePath, err := os.Executable()
+	if err != nil {
+		return err
 	}
-
-	// Pass cluster specific env variables when a cluster is attached.
-	if cluster, err := ctx.Cluster(); err == nil {
-		execCmd.Env = append(execCmd.Env, "DCOS_URL="+cluster.URL())
-		execCmd.Env = append(execCmd.Env, "DCOS_ACS_TOKEN="+cluster.ACSToken())
-
-		insecure := cluster.TLS().Insecure || strings.HasPrefix(cluster.URL(), "http://")
-		if insecure {
-			execCmd.Env = append(execCmd.Env, "DCOS_TLS_INSECURE=1")
-		} else if cluster.TLS().RootCAsPath != "" {
-			execCmd.Env = append(execCmd.Env, "DCOS_TLS_CA_PATH="+cluster.TLS().RootCAsPath)
-		}
-
-		// Create env entries based on the subcommand config.
-		if cmdConfig, ok := cluster.Config().ToMap()[cmd.Name].(map[string]interface{}); ok {
-			for key, val := range cmdConfig {
-				execCmd.Env = append(execCmd.Env, fmt.Sprintf(
-					"%s=%v",
-					cmdConfigEnvKey(cmd.Name, key),
-					val,
-				))
-			}
-		}
+	cluster, err := ctx.Cluster()
+	if err != nil && err != config.ErrNotAttached {
+		return err
 	}
+	execCmdEnv := pluginEnv(executablePath, cmd.Name, ctx.Logger().Level, cluster)
+	execCmd.Env = append(os.Environ(), execCmdEnv...)
 
 	err = execCmd.Run()
 	if err != nil {
@@ -209,6 +183,44 @@ func invokePlugin(ctx api.Context, cmd plugin.Command, args []string) error {
 
 	}
 	return err
+}
+
+// pluginEnv returns the environment variables to pass to a given plugin.
+func pluginEnv(executablePath string, cmdName string, logLevel logrus.Level, cluster *config.Cluster) (env []string) {
+	env = append(env, "DCOS_CLI_EXECUTABLE_PATH="+executablePath)
+	env = append(env, "DCOS_CLI_VERSION="+version.Version())
+
+	switch logLevel {
+	case logrus.DebugLevel:
+		env = append(env, "DCOS_VERBOSITY=2", "DCOS_LOG_LEVEL=debug")
+	case logrus.InfoLevel:
+		env = append(env, "DCOS_VERBOSITY=1", "DCOS_LOG_LEVEL=info")
+	}
+
+	// Pass cluster specific env variables when a cluster is attached.
+	if cluster != nil {
+		env = append(env, "DCOS_URL="+cluster.URL())
+		env = append(env, "DCOS_ACS_TOKEN="+cluster.ACSToken())
+
+		insecure := cluster.TLS().Insecure || strings.HasPrefix(cluster.URL(), "http://")
+		if insecure {
+			env = append(env, "DCOS_TLS_INSECURE=1")
+		} else if cluster.TLS().RootCAsPath != "" {
+			env = append(env, "DCOS_TLS_CA_PATH="+cluster.TLS().RootCAsPath)
+		}
+
+		// Create env entries based on the subcommand config.
+		if cmdConfig, ok := cluster.Config().ToMap()[cmdName].(map[string]interface{}); ok {
+			for key, val := range cmdConfig {
+				env = append(env, fmt.Sprintf(
+					"%s=%v",
+					cmdConfigEnvKey(cmdName, key),
+					val,
+				))
+			}
+		}
+	}
+	return env
 }
 
 // cmdConfigEnvKey returns the environment variable key to use for a given command config.

--- a/pkg/cmd/dcos.go
+++ b/pkg/cmd/dcos.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/dcos/dcos-cli/api"
+	"github.com/dcos/dcos-cli/pkg/cli/version"
 	"github.com/dcos/dcos-cli/pkg/cmd/auth"
 	clustercmd "github.com/dcos/dcos-cli/pkg/cmd/cluster"
 	"github.com/dcos/dcos-cli/pkg/cmd/completion"
@@ -160,6 +161,7 @@ func invokePlugin(ctx api.Context, cmd plugin.Command, args []string) error {
 	execCmd.Stdin = ctx.Input()
 
 	execCmd.Env = append(os.Environ(), "DCOS_CLI_EXECUTABLE_PATH="+executablePath)
+	execCmd.Env = append(execCmd.Env, "DCOS_CLI_VERSION="+version.Version())
 
 	switch ctx.Logger().Level {
 	case logrus.DebugLevel:

--- a/pkg/cmd/dcos_test.go
+++ b/pkg/cmd/dcos_test.go
@@ -49,3 +49,9 @@ Use "dcos [command] --help" for more information about a command.
 
 	require.Equal(t, expectedHelp, out.String())
 }
+
+func TestCmdConfigEnvKey(t *testing.T) {
+	require.Equal(t, "DCOS_HELLO_WORLD", cmdConfigEnvKey("hello", "world"))
+	require.Equal(t, "DCOS_HELLO_WORLD_FOO", cmdConfigEnvKey("hello-world", "foo"))
+	require.Equal(t, "DCOS_HELLO_AROUND_THE_WORLD", cmdConfigEnvKey("hello", "around_the_world"))
+}

--- a/pkg/cmd/dcos_test.go
+++ b/pkg/cmd/dcos_test.go
@@ -4,7 +4,10 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/dcos/dcos-cli/pkg/cli/version"
+	"github.com/dcos/dcos-cli/pkg/config"
 	"github.com/dcos/dcos-cli/pkg/mock"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -48,6 +51,24 @@ Use "dcos [command] --help" for more information about a command.
 `
 
 	require.Equal(t, expectedHelp, out.String())
+}
+
+func TestPluginEnv(t *testing.T) {
+	cluster := config.NewCluster(nil)
+	cluster.SetURL("https://dcos.example.com")
+	cluster.SetACSToken("abc")
+	cluster.Config().Set("hello.world", "foo")
+	cluster.Config().Set("hallo.world", "foo")
+
+	env := pluginEnv("/path/to/me", "hello", logrus.DebugLevel, cluster)
+
+	require.Contains(t, env, "DCOS_CLI_EXECUTABLE_PATH=/path/to/me")
+	require.Contains(t, env, "DCOS_CLI_VERSION="+version.Version())
+	require.Contains(t, env, "DCOS_VERBOSITY=2")
+	require.Contains(t, env, "DCOS_URL=https://dcos.example.com")
+	require.Contains(t, env, "DCOS_ACS_TOKEN=abc")
+	require.Contains(t, env, "DCOS_HELLO_WORLD=foo")
+	require.NotContains(t, env, "DCOS_HALLO_WORLD=foo")
 }
 
 func TestCmdConfigEnvKey(t *testing.T) {

--- a/pkg/cmd/dcos_test.go
+++ b/pkg/cmd/dcos_test.go
@@ -57,18 +57,21 @@ func TestPluginEnv(t *testing.T) {
 	cluster := config.NewCluster(nil)
 	cluster.SetURL("https://dcos.example.com")
 	cluster.SetACSToken("abc")
+	cluster.SetTLS(config.TLS{Insecure: false})
 	cluster.Config().Set("hello.world", "foo")
 	cluster.Config().Set("hallo.world", "foo")
 
 	env := pluginEnv("/path/to/me", "hello", logrus.DebugLevel, cluster)
 
-	require.Contains(t, env, "DCOS_CLI_EXECUTABLE_PATH=/path/to/me")
-	require.Contains(t, env, "DCOS_CLI_VERSION="+version.Version())
-	require.Contains(t, env, "DCOS_VERBOSITY=2")
-	require.Contains(t, env, "DCOS_URL=https://dcos.example.com")
-	require.Contains(t, env, "DCOS_ACS_TOKEN=abc")
-	require.Contains(t, env, "DCOS_HELLO_WORLD=foo")
-	require.NotContains(t, env, "DCOS_HALLO_WORLD=foo")
+	require.ElementsMatch(t, env, []string{
+		"DCOS_ACS_TOKEN=abc",
+		"DCOS_CLI_EXECUTABLE_PATH=/path/to/me",
+		"DCOS_CLI_VERSION=" + version.Version(),
+		"DCOS_HELLO_WORLD=foo",
+		"DCOS_LOG_LEVEL=debug",
+		"DCOS_URL=https://dcos.example.com",
+		"DCOS_VERBOSITY=2",
+	})
 }
 
 func TestCmdConfigEnvKey(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -96,7 +96,7 @@ func Empty() *Config {
 	return New(Opts{})
 }
 
-// Keys returns the possible config keys. TODO: make all the keys constants.
+// Keys returns the possible config keys.
 func Keys() map[string]string {
 	return map[string]string{
 		keyACSToken:       "the DC/OS authentication token",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -99,17 +99,20 @@ func Empty() *Config {
 // Keys returns the possible config keys. TODO: make all the keys constants.
 func Keys() map[string]string {
 	return map[string]string{
-		keyACSToken:          "the DC/OS authentication token",
-		keyURL:               "the public master URL of your DC/OS cluster",
-		keyMesosMasterURL:    "the Mesos master URL (defaults to 'core.dcos_url')",
-		keyPagination:        "indicates whether to paginate output (defaults to true)",
-		keyTLS:               "indicates whether to verify SSL certificates or set the path to the SSL certificates",
-		keyTimeout:           "the request timeout in seconds, with a minimum value of 1 second (defaults to 3 minutes)",
-		keySSHUser:           "the user used when using ssh to connect to a node of your DC/OS cluster (defaults to 'core')",
-		keySSHProxyHost:      "whether to use a fixed ssh proxy host (Bastion) for node SSH access",
-		keyReporting:         "whether to report usage events to Mesosphere",
-		keyPromptLogin:       "whether to prompt the user to log in when token expired, otherwise automatically initiate login",
-		keyClusterName:       "human readable name of cluster",
+		keyACSToken:       "the DC/OS authentication token",
+		keyURL:            "the public master URL of your DC/OS cluster",
+		keyMesosMasterURL: "the Mesos master URL (defaults to 'core.dcos_url')",
+		keyPagination:     "indicates whether to paginate output (defaults to true)",
+		keyTLS:            "indicates whether to verify SSL certificates or set the path to the SSL certificates",
+		keyTimeout:        "the request timeout in seconds, with a minimum value of 1 second (defaults to 3 minutes)",
+		keySSHUser:        "the user used when using ssh to connect to a node of your DC/OS cluster (defaults to 'core')",
+		keySSHProxyHost:   "whether to use a fixed ssh proxy host (Bastion) for node SSH access",
+		keyReporting:      "whether to report usage events to Mesosphere",
+		keyPromptLogin:    "whether to prompt the user to log in when token expired, otherwise automatically initiate login",
+		keyClusterName:    "human readable name of cluster",
+
+		// These are configuration sections for the dcos-core-cli plugin.
+		// Ideally they should be defined by the plugin itself in its plugin.toml file.
 		"job.url":            "API URL for talking to the Metronome scheduler",
 		"job.service_name":   "the name of the metronome cluster",
 		"marathon.url":       "base URL for talking to Marathon, overwrites the value specified in 'core.dcos_url'",
@@ -180,6 +183,11 @@ func (c *Config) Get(key string) interface{} {
 	default:
 		return node
 	}
+}
+
+// ToMap recursively generates a representation of the config using Go built-in structures.
+func (c *Config) ToMap() map[string]interface{} {
+	return c.tree.ToMap()
 }
 
 // Set sets a key in the store.

--- a/tests/integration/test_plugin.py
+++ b/tests/integration/test_plugin.py
@@ -208,7 +208,6 @@ def test_plugin_verbosity(default_cluster):
     for fixture in fixtures:
         code, out, _ = exec_cmd(fixture['cmd'])
         assert code == 0
-        assert code == 0
         out = json.loads(out)
 
         assert out['args'][1:] == ['test']
@@ -221,6 +220,20 @@ def test_plugin_exit_code(default_cluster):
 
     code, _, _ = exec_cmd(['dcos', 'test', 'exit', '43'])
     assert code == 43
+
+
+def test_plugin_config_env(default_cluster):
+    _install_test_plugin()
+
+    code, _, _ = exec_cmd(['dcos', 'config', 'set', 'test.escape_sequence', 'bar'])
+    assert code == 0
+
+    code, out, _ = exec_cmd(['dcos', 'test'])
+    assert code == 0
+    out = json.loads(out)
+
+    assert out['args'][1:] == ['test']
+    assert out['env'].get('DCOS_TEST_ESCAPE_SEQUENCE') == 'bar'
 
 
 def test_plugin_remove(default_cluster):


### PR DESCRIPTION
This makes it possible for a plugin to retrieve its config values
through environment variables when it's invoked.

For example, assuming a command `foo` in a given plugin. When the
configuration file contains the `bar` config for the `foo` section,
it will be passed to it as the `DCOS_FOO_BAR` environment variable.