### PR TITLE
Discard the local login server on non-desktop environment

### DIFF
--- a/pkg/login/flow_test.go
+++ b/pkg/login/flow_test.go
@@ -1,9 +1,22 @@
 package login
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
+	"github.com/dcos/dcos-cli/pkg/httpclient"
+	"github.com/dcos/dcos-cli/pkg/login/loginserver"
+	"github.com/dcos/dcos-cli/pkg/open"
+	"github.com/dcos/dcos-cli/pkg/prompt"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,4 +51,100 @@ func TestSelectUIDPasswordProvider(t *testing.T) {
 	provider, err := flow.selectProvider(providers)
 	require.NoError(t, err)
 	require.True(t, provider == providers["login-provider-1"] || provider == providers["login-provider-2"])
+}
+
+func TestTriggerMethodOIDCWithLoginServer(t *testing.T) {
+	expectedLoginToken := "dummy_login_token"
+	expectedACSToken := "dummy_acs_token"
+
+	opener := open.OpenerFunc(func(resource string) error {
+
+		startFlowURL, err := url.Parse(resource)
+		require.NoError(t, err)
+
+		loginData := &loginserver.LoginData{
+			Token:     expectedLoginToken,
+			CSRFToken: startFlowURL.Query().Get("dcos_cli_csrf_token"),
+		}
+
+		var buf bytes.Buffer
+		err = json.NewEncoder(&buf).Encode(loginData)
+		require.NoError(t, err)
+
+		resp, err := httpclient.New("").Post(startFlowURL.Query().Get("redirect_uri"), "application/json", &buf)
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+
+		return nil
+	})
+
+	ts := httptest.NewServer(mockLoginEndpoint(t, expectedLoginToken, expectedACSToken))
+	defer ts.Close()
+
+	logger := &logrus.Logger{Out: ioutil.Discard}
+
+	flow := NewFlow(FlowOpts{
+		Logger: logger,
+		Opener: opener,
+	})
+
+	flow.client = NewClient(httpclient.New(ts.URL), logger)
+
+	acsToken, err := flow.triggerMethod(defaultOIDCImplicitFlowProvider())
+	require.NoError(t, err)
+	require.Equal(t, expectedACSToken, acsToken)
+}
+
+func TestTriggerMethodOIDCWithoutLoginServer(t *testing.T) {
+
+	// We're simulating a container environment where the browser can't be opened.
+	// See https://jira.mesosphere.com/browse/DCOS_OSS-5591
+	opener := open.OpenerFunc(func(_ string) error {
+		return errors.New("couldn't open browser, I'm just a container")
+	})
+
+	expectedLoginToken := "dummy_login_token"
+	expectedACSToken := "dummy_acs_token"
+
+	ts := httptest.NewServer(mockLoginEndpoint(t, expectedLoginToken, expectedACSToken))
+	defer ts.Close()
+
+	logger := &logrus.Logger{Out: ioutil.Discard}
+
+	var in bytes.Buffer
+	in.WriteString(expectedLoginToken)
+
+	flow := NewFlow(FlowOpts{
+		Prompt: prompt.New(&in, ioutil.Discard),
+		Logger: logger,
+		Opener: opener,
+	})
+
+	flow.client = NewClient(httpclient.New(ts.URL), logger)
+
+	acsToken, err := flow.triggerMethod(defaultOIDCImplicitFlowProvider())
+	require.NoError(t, err)
+	require.Equal(t, expectedACSToken, acsToken)
+}
+
+func mockLoginEndpoint(t *testing.T, expectedLoginToken, acsToken string) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc(defaultLoginEndpoint, func(w http.ResponseWriter, req *http.Request) {
+		assert.Equal(t, "POST", req.Method)
+
+		var credentials Credentials
+		if err := json.NewDecoder(req.Body).Decode(&credentials); err != nil {
+			w.WriteHeader(401)
+			return
+		}
+		if !assert.Equal(t, expectedLoginToken, credentials.Token) {
+			w.WriteHeader(401)
+			return
+		}
+		var jwt JWT
+		jwt.Token = acsToken
+		err := json.NewEncoder(w).Encode(&jwt)
+		assert.NoError(t, err)
+	})
+	return mux
 }

--- a/pkg/login/login.go
+++ b/pkg/login/login.go
@@ -12,6 +12,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const defaultLoginEndpoint = "/acs/api/v1/auth/login"
+
 var (
 	// ErrAuthDisabled is the error returned when attempting to get authentication providers
 	// from a cluster without authentication.
@@ -133,7 +135,7 @@ func (c *Client) sniffAuth(acsToken string) (*http.Response, error) {
 // Login makes a POST requests to the login endpoint with the given credentials.
 func (c *Client) Login(loginEndpoint string, credentials *Credentials) (string, error) {
 	if loginEndpoint == "" {
-		loginEndpoint = "/acs/api/v1/auth/login"
+		loginEndpoint = defaultLoginEndpoint
 	}
 
 	reqBody, err := json.Marshal(credentials)

--- a/pkg/open/open.go
+++ b/pkg/open/open.go
@@ -21,3 +21,11 @@ func NewOsOpener(logger *logrus.Logger) *OsOpener {
 		logger: logger,
 	}
 }
+
+// OpenerFunc is a func adapter for the Opener interface.
+type OpenerFunc func(string) error
+
+// Open invokes the OpenerFunc.
+func (f OpenerFunc) Open(resource string) error {
+	return f(resource)
+}


### PR DESCRIPTION
For the `dcos-oidc-auth0` login provider, when the user operates the CLI
from a container or a remote machine, the local webserver will not run
on the same machine as the browser. Later on the browser will try to
send the token to eg. `localhost:43383`, which won't be reachable.

When this situation arises, we had designed the UI to fallback to
printing the login token for copy-pasting, but once the CLI has
successfully initiated the local web server, it doesn't accept input
from STDIN at all, so the user has no chance to copy-paste the token.

This commit updates the CLI to fallback to reading from STDIN when the
browser can't be opened.

Note: as an alternative, it would have been possible to concurrently
wait for data on both the local web server and STDIN, but the current
fix is simpler and covers the container / remote use-cases as expected.

https://jira.mesosphere.com/browse/DCOS_OSS-5591