### PR TITLE
Add timeout option for cluster setup

### DIFF
--- a/constants/timeouts.go
+++ b/constants/timeouts.go
@@ -1,0 +1,6 @@
+package constants
+
+import "time"
+
+const HTTPTimeout = 3 * time.Minute
+const DialTimeout = 10 * time.Second

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -160,9 +160,8 @@ func (ctx *Context) HTTPClient(c *config.Cluster, opts ...httpclient.Option) *ht
 	if c.ACSToken() != "" {
 		baseOpts = append(baseOpts, httpclient.ACSToken(c.ACSToken()))
 	}
-	if c.Timeout() > 0 {
-		baseOpts = append(baseOpts, httpclient.Timeout(c.Timeout()))
-	}
+	baseOpts = append(baseOpts, httpclient.Timeout(c.Timeout()))
+
 	tlsOpt := httpclient.TLS(&tls.Config{
 		InsecureSkipVerify: c.TLS().Insecure,
 		RootCAs:            c.TLS().RootCAs,

--- a/pkg/cmd/cluster/cluster_setup.go
+++ b/pkg/cmd/cluster/cluster_setup.go
@@ -1,9 +1,6 @@
 package cluster
 
 import (
-	"errors"
-	"fmt"
-
 	"github.com/dcos/dcos-cli/api"
 	"github.com/dcos/dcos-cli/pkg/setup"
 
@@ -16,15 +13,8 @@ func newCmdClusterSetup(ctx api.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "setup <url>",
 		Short: "Set up the CLI to communicate with a cluster",
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				cmd.SilenceUsage = false
-				return errors.New("missing cluster URL")
-			}
-			if len(args) > 1 {
-				cmd.SilenceUsage = false
-				return fmt.Errorf("received %d arguments %s, expects a single cluster URL", len(args), args)
-			}
 			clusterURL := args[0]
 			_, err := ctx.Setup(setupFlags, clusterURL, true)
 			return err

--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"crypto/x509"
+	"github.com/dcos/dcos-cli/constants"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -93,13 +94,16 @@ func (c *Cluster) SetTLS(tls TLS) {
 
 // Timeout returns the HTTP request timeout once the connection is established.
 func (c *Cluster) Timeout() time.Duration {
-	timeout := c.config.Get("core.timeout")
+	timeout := c.config.Get(keyTimeout)
+	if timeout == nil {
+		return constants.HTTPTimeout
+	}
 	return time.Duration(cast.ToInt64(timeout)) * time.Second
 }
 
 // SetTimeout sets the HTTP request timeout once the connection is established.
 func (c *Cluster) SetTimeout(timeout time.Duration) {
-	c.config.Set("core.timeout", timeout.Seconds())
+	c.config.Set(keyTimeout, timeout.Seconds())
 }
 
 // ID returns the ID of the cluster.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	toml "github.com/pelletier/go-toml"
 	"github.com/spf13/afero"
@@ -62,6 +63,7 @@ type Config struct {
 	envWhitelist map[string]string
 	envLookup    func(key string) (string, bool)
 	fs           afero.Fs
+	timeout      time.Duration
 }
 
 // New creates a Config based on functional options.

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"github.com/dcos/dcos-cli/constants"
 	"io"
 	"mime"
 	"net"
@@ -118,11 +119,16 @@ func New(baseURL string, opts ...Option) *Client {
 		// Default request timeout to 3 minutes. We don't use http.Client.Timeout on purpose as the
 		// current approach allows to change the timeout on a per-request basis. The same client can
 		// be shared for requests with different timeouts.
-		Timeout: 3 * time.Minute,
+		Timeout: constants.HTTPTimeout,
 	}
 
 	for _, opt := range opts {
 		opt(&options)
+	}
+
+	dialTimeout := constants.DialTimeout
+	if options.Timeout == 0 {
+		dialTimeout = 0
 	}
 
 	return &Client{
@@ -135,11 +141,11 @@ func New(baseURL string, opts ...Option) *Client {
 
 				// Set a 10 seconds timeout for the connection to be established.
 				DialContext: (&net.Dialer{
-					Timeout: 10 * time.Second,
+					Timeout: dialTimeout,
 				}).DialContext,
 
 				// Set it to 10 seconds as well for the TLS handshake when using HTTPS.
-				TLSHandshakeTimeout: 10 * time.Second,
+				TLSHandshakeTimeout: dialTimeout,
 
 				// The client will be dealing with a single host (the one in baseURL),
 				// set max idle connections to 30 regardless of the host.

--- a/pkg/setup/flags.go
+++ b/pkg/setup/flags.go
@@ -16,6 +16,7 @@ type Flags struct {
 	insecure     bool
 	loginFlags   *login.Flags
 	fs           afero.Fs
+	noTimeout    bool
 }
 
 // NewFlags creates flags for a cluster setup.
@@ -51,6 +52,12 @@ func (f *Flags) Register(flags *pflag.FlagSet) {
 		"name",
 		"",
 		"Specify a custom name for the cluster.",
+	)
+	flags.BoolVar(
+		&f.noTimeout,
+		"no-timeout",
+		false,
+		"Specify if HTTP timeout should be disabled. Useful for slow remote connections.",
 	)
 	f.loginFlags.Register(flags)
 }


### PR DESCRIPTION
This option will be saved in cluster `dcos.toml` and used by `ctx.HTTPClient(...)` to create http client.

See: https://github.com/dcos/dcos-cli/blob/b4a7d91628ecec93c4f4dc4ab7cb9ae7b4ccb29f/pkg/cli/context.go#L156-L175