### PR TITLE
Add golangci-lint

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 install:
   - SET PATH=C:\msys64\mingw64\bin;c:\gopath\bin;%PATH%
-  - go get -u golang.org/x/lint/golint
+  - go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 
 build: off
 
@@ -11,7 +11,7 @@ environment:
   NO_DOCKER: 1
   GO111MODULE: off
 
-stack: go 1.11
+stack: go 1.12
 
 test_script:
   - SET GO111MODULE=on

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -1,0 +1,41 @@
+[run]
+concurrency = 4
+deadline = "10m"
+skip-files = [
+    "_(string|test)\\.go",
+    ".py"
+]
+
+modules-download-mode = "vendor"
+
+[linters]
+disable-all = true
+enable = [
+    "deadcode",
+    "goconst",
+    "gocyclo",
+    "gofmt",
+    "goimports",
+    "golint",
+    "gosec",
+    "govet",
+    "ineffassign",
+    "interfacer",
+    "lll",
+    "misspell",
+    "structcheck",
+    "typecheck",
+    "unconvert",
+    "unparam",
+    "unused",
+    "varcheck"
+]
+
+[linters-settings.lll]
+line-length = 150
+
+[linters-settings.gocyclo]
+min-complexity = 22
+
+[linters-settings.govet]
+check-shadowing = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
  - NO_DOCKER=1 GO111MODULE=on
 
 before_install:
- - env GO111MODULE=off go get -u golang.org/x/lint/golint
+ - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
 
 script:
  - make

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,3 +5,4 @@ RUN go get -u \
     github.com/awalterschulze/goderive \
     github.com/br-lewis/go-bindata/...
 
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,7 @@ vet: lint
 
 .PHONY: lint
 lint: docker-image
-	# Can be simplified once https://github.com/golang/lint/issues/320 is fixed.
-	$(call inDocker,golint -set_exit_status ./cmd/... ./pkg/...)
+	$(call inDocker, golangci-lint run)
 
 .PHONY: generate
 generate: docker-image

--- a/cmd/dcos-test/main.go
+++ b/cmd/dcos-test/main.go
@@ -13,17 +13,18 @@ import (
 )
 
 func main() {
-	if len(os.Args) == 3 && os.Args[1] == "test" && os.Args[2] == "--help" {
+	const test = "test"
+	if len(os.Args) == 3 && os.Args[1] == test && os.Args[2] == "--help" {
 		fmt.Println("Help usage for dcos-test")
 		os.Exit(0)
 	}
 
-	if len(os.Args) == 3 && os.Args[1] == "test" && os.Args[2] == "--info" {
+	if len(os.Args) == 3 && os.Args[1] == test && os.Args[2] == "--info" {
 		fmt.Println("Helper for integration tests")
 		os.Exit(0)
 	}
 
-	if len(os.Args) == 4 && os.Args[1] == "test" && os.Args[2] == "exit" {
+	if len(os.Args) == 4 && os.Args[1] == test && os.Args[2] == "exit" {
 		code, err := strconv.Atoi(os.Args[3])
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -91,7 +91,7 @@ func (ctx *Context) PluginManager(cluster *config.Cluster) *plugin.Manager {
 }
 
 // DCOSDir returns the root directory for the DC/OS CLI.
-// It defaults to `~/.dcos` and can be overriden by the `DCOS_DIR` env var.
+// It defaults to `~/.dcos` and can be overridden by the `DCOS_DIR` env var.
 func (ctx *Context) DCOSDir() (string, error) {
 	if dcosDir, ok := ctx.env.EnvLookup(EnvDCOSDir); ok {
 		// Make sure DCOS_DIR is an absolute path, otherwise this causes issues with plugin invocation.
@@ -164,7 +164,7 @@ func (ctx *Context) HTTPClient(c *config.Cluster, opts ...httpclient.Option) *ht
 		baseOpts = append(baseOpts, httpclient.Timeout(c.Timeout()))
 	}
 	tlsOpt := httpclient.TLS(&tls.Config{
-		InsecureSkipVerify: c.TLS().Insecure,
+		InsecureSkipVerify: c.TLS().Insecure, // nolint: gosec
 		RootCAs:            c.TLS().RootCAs,
 	})
 

--- a/pkg/cluster/linker/linker.go
+++ b/pkg/cluster/linker/linker.go
@@ -58,6 +58,9 @@ func New(baseClient *httpclient.Client, logger *logrus.Logger) *Linker {
 // Link sends a link request to /cluster/v1/links using a given client.
 func (l *Linker) Link(link *Link) error {
 	message, err := json.Marshal(link)
+	if err != nil {
+		return err
+	}
 
 	l.logger.Info("Linking the cluster...")
 	resp, err := l.http.Post(

--- a/pkg/cluster/lister/lister.go
+++ b/pkg/cluster/lister/lister.go
@@ -159,7 +159,7 @@ func (l *Lister) httpClient(cluster *config.Cluster) *httpclient.Client {
 		httpclient.ACSToken(cluster.ACSToken()),
 		httpclient.Timeout(3*time.Second),
 		httpclient.TLS(&tls.Config{
-			InsecureSkipVerify: cluster.TLS().Insecure,
+			InsecureSkipVerify: cluster.TLS().Insecure, // nolint: gosec
 			RootCAs:            cluster.TLS().RootCAs,
 		}),
 	)

--- a/pkg/cmd/config/config_set.go
+++ b/pkg/cmd/config/config_set.go
@@ -10,8 +10,10 @@ func newCmdConfigSet(ctx api.Context) *cobra.Command {
 	return &cobra.Command{
 		Use:   "set <name> <value>",
 		Short: "Add or set a property in the configuration file used for the current cluster",
-		Long:  "The properties that can be set are: core.dcos_url, core.dcos_acs_token, core.ssl_verify, core.timeout, core.ssh_user, core.ssh_proxy_ip, core.pagination, core.reporting, core.mesos_master_url, core.prompt_login",
-		Args:  cobra.ExactArgs(2),
+		Long: "The properties that can be set are: " +
+			"core.dcos_url, core.dcos_acs_token, core.ssl_verify, core.timeout, core.ssh_user, " +
+			"core.ssh_proxy_ip, core.pagination, core.reporting, core.mesos_master_url, core.prompt_login",
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cluster, err := ctx.Cluster()
 			if err != nil {

--- a/pkg/cmd/dcos.go
+++ b/pkg/cmd/dcos.go
@@ -152,7 +152,7 @@ func updateCorePlugin(ctx api.Context) error {
 
 // invokePlugin calls the binary of a plugin, passing in the arguments it's been given.
 func invokePlugin(ctx api.Context, cmd plugin.Command, args []string) error {
-	execCmd := exec.Command(cmd.Path, args...)
+	execCmd := exec.Command(cmd.Path, args...) // nolint: gosec
 	execCmd.Stdout = ctx.Out()
 	execCmd.Stderr = ctx.ErrOut()
 	execCmd.Stdin = ctx.Input()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,7 +16,7 @@ import (
 // TOML keys for the DC/OS configuration.
 const (
 	keyURL            = "core.dcos_url"
-	keyACSToken       = "core.dcos_acs_token"
+	keyACSToken       = "core.dcos_acs_token" // nolint: gosec
 	keyTLS            = "core.ssl_verify"
 	keyTimeout        = "core.timeout"
 	keySSHUser        = "core.ssh_user"

--- a/pkg/login/flow.go
+++ b/pkg/login/flow.go
@@ -145,8 +145,8 @@ func (f *Flow) triggerMethod(provider *Provider) (acsToken string, err error) {
 		// token from the --private-key. The token has a 5 minutes lifetime.
 		case methodServiceCredential:
 			uid := f.uid()
-			token, err := f.serviceToken(uid)
-			if err != nil {
+			token, e := f.serviceToken(uid)
+			if e != nil {
 				return "", err
 			}
 			acsToken, err = f.client.Login("", &Credentials{UID: uid, Token: token})

--- a/pkg/login/provider.go
+++ b/pkg/login/provider.go
@@ -14,9 +14,9 @@ const (
 
 // These are the different login provider types that the DC/OS CLI supports.
 const (
-	DCOSUIDPassword     = "dcos-uid-password"
+	DCOSUIDPassword     = "dcos-uid-password" // nolint: gosec
 	DCOSUIDServiceKey   = "dcos-uid-servicekey"
-	DCOSUIDPasswordLDAP = "dcos-uid-password-ldap"
+	DCOSUIDPasswordLDAP = "dcos-uid-password-ldap" // nolint: gosec
 	SAMLSpInitiated     = "saml-sp-initiated"
 	OIDCAuthCodeFlow    = "oidc-authorization-code-flow"
 	OIDCImplicitFlow    = "oidc-implicit-flow"

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -267,7 +267,7 @@ func (m *Manager) findCommands(pluginDir string) (commands []Command) {
 
 // commandDescription gets the command info summary by invoking the binary with the `--info` flag.
 func (m *Manager) commandDescription(cmd Command) (desc string) {
-	infoCmd, err := exec.Command(cmd.Path, cmd.Name, "--info").Output()
+	infoCmd, err := exec.Command(cmd.Path, cmd.Name, "--info").Output() // nolint: gosec
 	if err != nil {
 		m.logger.Debugf("Couldn't get info summary for the '%s' command: %s", cmd.Name, err)
 	} else {
@@ -490,7 +490,7 @@ func (m *Manager) httpClient(url string) *httpclient.Client {
 			httpOpts,
 			httpclient.ACSToken(m.cluster.ACSToken()),
 			httpclient.TLS(&tls.Config{
-				InsecureSkipVerify: m.cluster.TLS().Insecure,
+				InsecureSkipVerify: m.cluster.TLS().Insecure, // nolint: gosec
 				RootCAs:            m.cluster.TLS().RootCAs,
 			}),
 		)

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -99,7 +99,7 @@ func (s *Setup) Configure(flags *Flags, clusterURL string, attach bool) (*config
 	for i := 0; i < 2; i++ {
 		// When using an HTTPS URL, configure TLS for the HTTP client accordingly.
 		if strings.HasPrefix(clusterURL, "https://") {
-			tlsConfig, err := s.configureTLS(httpOpts, flags)
+			tlsConfig, err := s.configureTLS(flags)
 			if err != nil {
 				return nil, err
 			}
@@ -206,10 +206,10 @@ func detectCanonicalClusterURL(clusterURL string, httpOpts []httpclient.Option) 
 }
 
 // configureTLS creates the TLS configuration for a given set of flags.
-func (s *Setup) configureTLS(httpOpts []httpclient.Option, flags *Flags) (*tls.Config, error) {
+func (s *Setup) configureTLS(flags *Flags) (*tls.Config, error) {
 	// Return early with an insecure TLS config when `--insecure` is passed.
 	if flags.insecure {
-		return &tls.Config{InsecureSkipVerify: true}, nil
+		return &tls.Config{InsecureSkipVerify: true}, nil // nolint: gosec
 	}
 
 	// Create a cert pool from the CA bundle PEM. The user is prompted for manual
@@ -239,7 +239,7 @@ func (s *Setup) isX509UnknownAuthorityError(err error) bool {
 // downloadDCOSCABundle downloads the cluster certificate authority at "/ca/dcos-ca.crt".
 func (s *Setup) downloadDCOSCABundle(clusterURL string, httpOpts []httpclient.Option) ([]byte, error) {
 	insecureHTTPClient := httpclient.New(clusterURL, append(httpOpts, httpclient.TLS(&tls.Config{
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: true, // nolint: gosec
 	}))...)
 
 	resp, err := insecureHTTPClient.Get("/ca/dcos-ca.crt")


### PR DESCRIPTION
Use `golangci-lint` instead of just `golint`. Fixes all reported issues.

Refs: https://github.com/dcos/dcos-core-cli/pull/349