### PR TITLE
Fix nil pointer dereference

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -35,7 +35,7 @@ enable = [
 line-length = 150
 
 [linters-settings.gocyclo]
-min-complexity = 22
+min-complexity = 23
 
 [linters-settings.govet]
 check-shadowing = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Next
 
+## 1.1.1
+
+* Fixes
+
+  * Fix panic on non-desktop environments with browser login flows other than auth0
+
 ## 1.1.0
 
 * Features

--- a/pkg/login/flow.go
+++ b/pkg/login/flow.go
@@ -185,7 +185,9 @@ func (f *Flow) triggerMethod(provider *Provider) (acsToken string, err error) {
 					// Falling back to reading from STDIN is safer here.
 					//
 					// See https://jira.mesosphere.com/browse/DCOS_OSS-5591
-					loginServer.Close()
+					if loginServer != nil {
+						loginServer.Close()
+					}
 				} else if loginServer != nil {
 					token = <-loginServer.Token()
 


### PR DESCRIPTION
This fixes a regression introduced in #1502, which can cause a
panic on non-desktop environments with browser-based login flows
other than auth0.

https://jira.mesosphere.com/browse/DCOS-60349