### PR TITLE
Do not comsume all input data on prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+* Fixes
+
+  * Do not consume all input data on prompts.
+
 ## 1.1.1
 
 * Fixes

--- a/pkg/prompt/prompt.go
+++ b/pkg/prompt/prompt.go
@@ -29,10 +29,10 @@ func New(input io.Reader, output io.Writer) *Prompt {
 // Input prompts for a string input.
 func (prompt *Prompt) Input(msg string) string {
 	fmt.Fprint(prompt.out, msg)
-	scanner := bufio.NewScanner(prompt.in)
-	scanner.Scan()
 
-	return scanner.Text()
+	var text string
+	fmt.Fscanln(prompt.in, &text)
+	return text
 }
 
 // Password prompts for a password. It is similar to input, except that it doesn't echo back to the terminal.

--- a/pkg/prompt/prompt_test.go
+++ b/pkg/prompt/prompt_test.go
@@ -16,6 +16,17 @@ func TestInput(t *testing.T) {
 	require.Equal(t, "this", val)
 }
 
+func TestInputMultiline(t *testing.T) {
+	var buf bytes.Buffer
+	prompt := New(strings.NewReader("this\nthat\n"), &buf)
+
+	val := prompt.Input("")
+	require.Equal(t, "this", val)
+
+	val = prompt.Input("")
+	require.Equal(t, "that", val)
+}
+
 func TestPassword(t *testing.T) {
 	var buf bytes.Buffer
 	prompt := New(strings.NewReader("pass\n"), &buf)
@@ -49,7 +60,6 @@ func TestSelect(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedValue, i)
 		}
-
 	}
 }
 


### PR DESCRIPTION
As the `prompt.Input()` function relies on a `bufio.Scanner`, it
currently scans all the lines and would only return the first one.

As the scanner is not re-used across multiple calls, this causes input
data to be discarded for later calls when there is multiline input.

As a concrete example, the following currently wouldn't work:

    echo "username\npassword" | dcos auth login --provider=dcos-users

This is however not a common case as users would usually rather do:

    dcos auth login --username=username --password=password