### PR TITLE
Check TLS config when creating HTTP Client

### DIFF
--- a/api/cli.go
+++ b/api/cli.go
@@ -56,7 +56,7 @@ type Context interface {
 	Clusters() ([]*config.Cluster, error)
 
 	// HTTPClient creates an httpclient.Client for a given cluster.
-	HTTPClient(c *config.Cluster, opts ...httpclient.Option) *httpclient.Client
+	HTTPClient(c *config.Cluster, opts ...httpclient.Option) (*httpclient.Client, error)
 
 	// Prompt returns a *prompt.Prompt.
 	Prompt() *prompt.Prompt

--- a/cmd/dcos/main.go
+++ b/cmd/dcos/main.go
@@ -30,9 +30,7 @@ func main() {
 				"True (will then use CA certificates from certifi), " +
 				"or False (will then send insecure requests).\n"
 			fmt.Fprint(env.ErrOut, msg)
-			os.Exit(1)
 		}
-		fmt.Fprintf(env.ErrOut, "ERROR: %s\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/dcos/main.go
+++ b/cmd/dcos/main.go
@@ -18,8 +18,11 @@ import (
 )
 
 func main() {
-	if err := run(cli.NewOsEnvironment()); err != nil {
+	env := cli.NewOsEnvironment()
+	if err := run(env); err != nil {
+		fmt.Fprintf(env.ErrOut, "ERROR: %s\n", err)
 		os.Exit(1)
+
 	}
 }
 
@@ -86,7 +89,11 @@ func printVersion(ctx api.Context) {
 		return
 	}
 
-	dcosClient := dcos.NewClient(ctx.HTTPClient(cluster, httpclient.Timeout(3*time.Second)))
+	httpClient, err := ctx.HTTPClient(cluster, httpclient.Timeout(3*time.Second))
+	if err != nil {
+		return
+	}
+	dcosClient := dcos.NewClient(httpClient)
 	if dcosVersion, err := dcosClient.Version(); err == nil {
 		fmt.Fprintln(ctx.Out(), "dcos.version="+dcosVersion.Version)
 		fmt.Fprintln(ctx.Out(), "dcos.variant="+dcosVersion.DCOSVariant)

--- a/cmd/dcos/main.go
+++ b/cmd/dcos/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dcos/dcos-cli/pkg/cli"
 	"github.com/dcos/dcos-cli/pkg/cli/version"
 	"github.com/dcos/dcos-cli/pkg/cmd"
+	"github.com/dcos/dcos-cli/pkg/config"
 	"github.com/dcos/dcos-cli/pkg/dcos"
 	"github.com/dcos/dcos-cli/pkg/httpclient"
 	"github.com/sirupsen/logrus"
@@ -19,10 +20,20 @@ import (
 
 func main() {
 	env := cli.NewOsEnvironment()
-	if err := run(env); err != nil {
+	err := run(env)
+	if err != nil {
+		if _, ok := err.(*config.SSLError); ok {
+			msg := "Error: An SSL error occurred. To configure your SSL settings, please " +
+				"run: 'dcos config set core.ssl_verify <value>'\n" +
+				"<value>: Whether to verify SSL certs for HTTPS or path to certs. " +
+				"Valid values are a path to a CA_BUNDLE, " +
+				"True (will then use CA certificates from certifi), " +
+				"or False (will then send insecure requests).\n"
+			fmt.Fprint(env.ErrOut, msg)
+			os.Exit(1)
+		}
 		fmt.Fprintf(env.ErrOut, "ERROR: %s\n", err)
 		os.Exit(1)
-
 	}
 }
 

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -154,7 +154,7 @@ func (ctx *Context) Clusters() ([]*config.Cluster, error) {
 }
 
 // HTTPClient creates an httpclient.Client for a given cluster.
-func (ctx *Context) HTTPClient(c *config.Cluster, opts ...httpclient.Option) *httpclient.Client {
+func (ctx *Context) HTTPClient(c *config.Cluster, opts ...httpclient.Option) (*httpclient.Client, error) {
 	var baseOpts []httpclient.Option
 
 	if c.ACSToken() != "" {
@@ -162,15 +162,19 @@ func (ctx *Context) HTTPClient(c *config.Cluster, opts ...httpclient.Option) *ht
 	}
 	baseOpts = append(baseOpts, httpclient.Timeout(c.Timeout()))
 
+	clusterTLS, err := c.TLS()
+	if err != nil {
+		return nil, fmt.Errorf("cannot create HTTP Client: %s", err)
+	}
 	tlsOpt := httpclient.TLS(&tls.Config{
-		InsecureSkipVerify: c.TLS().Insecure, // nolint: gosec
-		RootCAs:            c.TLS().RootCAs,
+		InsecureSkipVerify: clusterTLS.Insecure, // nolint: gosec
+		RootCAs:            clusterTLS.RootCAs,
 	})
 
 	baseOpts = append(baseOpts, tlsOpt, httpclient.Logger(ctx.Logger()))
 	opts = append(baseOpts, opts...)
 
-	return httpclient.New(c.URL(), opts...)
+	return httpclient.New(c.URL(), opts...), nil
 }
 
 // Prompt is able to prompt for input, password or choices.

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -164,7 +164,7 @@ func (ctx *Context) HTTPClient(c *config.Cluster, opts ...httpclient.Option) (*h
 
 	clusterTLS, err := c.TLS()
 	if err != nil {
-		return nil, fmt.Errorf("cannot create HTTP Client: %s", err)
+		return nil, config.NewSSLError(err)
 	}
 	tlsOpt := httpclient.TLS(&tls.Config{
 		InsecureSkipVerify: clusterTLS.Insecure, // nolint: gosec

--- a/pkg/cmd/auth/auth_listproviders.go
+++ b/pkg/cmd/auth/auth_listproviders.go
@@ -24,7 +24,11 @@ func newCmdAuthListProviders(ctx api.Context) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				client = login.NewClient(ctx.HTTPClient(cluster), ctx.Logger())
+				httpClient, err := ctx.HTTPClient(cluster)
+				if err != nil {
+					return err
+				}
+				client = login.NewClient(httpClient, ctx.Logger())
 			} else {
 				httpClient := httpclient.New(args[0], httpclient.Logger(ctx.Logger()))
 				client = login.NewClient(httpClient, ctx.Logger())

--- a/pkg/cmd/auth/auth_login.go
+++ b/pkg/cmd/auth/auth_login.go
@@ -18,7 +18,11 @@ func newCmdAuthLogin(ctx api.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			acsToken, err := ctx.Login(flags, ctx.HTTPClient(cluster))
+			httpClient, err := ctx.HTTPClient(cluster)
+			if err != nil {
+				return err
+			}
+			acsToken, err := ctx.Login(flags, httpClient)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/cluster/cluster_attach.go
+++ b/pkg/cmd/cluster/cluster_attach.go
@@ -45,7 +45,11 @@ func newCmdClusterAttach(ctx api.Context) *cobra.Command {
 				return err
 			}
 
-			clusterLinker := linker.New(ctx.HTTPClient(currentCluster), ctx.Logger())
+			httpClient, err := ctx.HTTPClient(currentCluster)
+			if err != nil {
+				return err
+			}
+			clusterLinker := linker.New(httpClient, ctx.Logger())
 			linkedClusters, err := clusterLinker.Links()
 			if err != nil {
 				ctx.Logger().Info(err)

--- a/pkg/cmd/cluster/cluster_link.go
+++ b/pkg/cmd/cluster/cluster_link.go
@@ -52,7 +52,11 @@ func newCmdClusterLink(ctx api.Context) *cobra.Command {
 				return errors.New("cannot link a cluster to itself")
 			}
 
-			client := login.NewClient(ctx.HTTPClient(linkableCluster), ctx.Logger())
+			httpClient, err := ctx.HTTPClient(linkableCluster)
+			if err != nil {
+				return err
+			}
+			client := login.NewClient(httpClient, ctx.Logger())
 			rawProviders, err := client.Providers()
 			if err != nil {
 				return err
@@ -97,7 +101,11 @@ func newCmdClusterLink(ctx api.Context) *cobra.Command {
 				},
 			}
 
-			attachedClient := linker.New(ctx.HTTPClient(attachedCluster), ctx.Logger())
+			httpClient, err = ctx.HTTPClient(attachedCluster)
+			if err != nil {
+				return err
+			}
+			attachedClient := linker.New(httpClient, ctx.Logger())
 			return attachedClient.Link(linkRequest)
 		},
 	}

--- a/pkg/cmd/cluster/cluster_unlink.go
+++ b/pkg/cmd/cluster/cluster_unlink.go
@@ -30,7 +30,11 @@ func newCmdClusterUnlink(ctx api.Context) *cobra.Command {
 			}
 			linkedCluster := config.NewCluster(linkedClusterConfig)
 
-			attachedClient := linker.New(ctx.HTTPClient(attachedCluster), ctx.Logger())
+			httpClient, err := ctx.HTTPClient(attachedCluster)
+			if err != nil {
+				return err
+			}
+			attachedClient := linker.New(httpClient, ctx.Logger())
 			return attachedClient.Unlink(linkedCluster.ID())
 		},
 	}

--- a/pkg/cmd/dcos.go
+++ b/pkg/cmd/dcos.go
@@ -172,7 +172,7 @@ func invokePlugin(ctx api.Context, cmd plugin.Command, args []string) error {
 	if cluster != nil {
 		_, err := cluster.TLS()
 		if err != nil {
-			return fmt.Errorf("ssl_verify configuration is invalid: %s", err)
+			return config.NewSSLError(err)
 		}
 	}
 	execCmdEnv := pluginEnv(executablePath, cmd.Name, ctx.Logger().Level, cluster)

--- a/pkg/cmd/dcos.go
+++ b/pkg/cmd/dcos.go
@@ -129,7 +129,11 @@ func updateCorePlugin(ctx api.Context) error {
 		return err
 	}
 
-	pluginInfo, err := cosmos.CLIPluginInfo(pkg, ctx.HTTPClient(cluster).BaseURL())
+	httpClient, err := ctx.HTTPClient(cluster)
+	if err != nil {
+		return err
+	}
+	pluginInfo, err := cosmos.CLIPluginInfo(pkg, httpClient.BaseURL())
 	if err != nil {
 		return err
 	}
@@ -164,6 +168,12 @@ func invokePlugin(ctx api.Context, cmd plugin.Command, args []string) error {
 	cluster, err := ctx.Cluster()
 	if err != nil && err != config.ErrNotAttached {
 		return err
+	}
+	if cluster != nil {
+		_, err := cluster.TLS()
+		if err != nil {
+			return fmt.Errorf("ssl_verify configuration is invalid: %s", err)
+		}
 	}
 	execCmdEnv := pluginEnv(executablePath, cmd.Name, ctx.Logger().Level, cluster)
 	execCmd.Env = append(os.Environ(), execCmdEnv...)
@@ -202,13 +212,6 @@ func pluginEnv(executablePath string, cmdName string, logLevel logrus.Level, clu
 		env = append(env, "DCOS_URL="+cluster.URL())
 		env = append(env, "DCOS_ACS_TOKEN="+cluster.ACSToken())
 
-		insecure := cluster.TLS().Insecure || strings.HasPrefix(cluster.URL(), "http://")
-		if insecure {
-			env = append(env, "DCOS_TLS_INSECURE=1")
-		} else if cluster.TLS().RootCAsPath != "" {
-			env = append(env, "DCOS_TLS_CA_PATH="+cluster.TLS().RootCAsPath)
-		}
-
 		// Create env entries based on the subcommand config.
 		if cmdConfig, ok := cluster.Config().ToMap()[cmdName].(map[string]interface{}); ok {
 			for key, val := range cmdConfig {
@@ -218,6 +221,14 @@ func pluginEnv(executablePath string, cmdName string, logLevel logrus.Level, clu
 					val,
 				))
 			}
+		}
+
+		clusterTLS, _ := cluster.TLS()
+		insecure := clusterTLS.Insecure || strings.HasPrefix(cluster.URL(), "http://")
+		if insecure {
+			env = append(env, "DCOS_TLS_INSECURE=1")
+		} else if clusterTLS.RootCAsPath != "" {
+			env = append(env, "DCOS_TLS_CA_PATH="+clusterTLS.RootCAsPath)
 		}
 	}
 	return env

--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -14,6 +14,18 @@ import (
 	"github.com/spf13/cast"
 )
 
+type SSLError struct {
+	msg error
+}
+
+func (e *SSLError) Error() string {
+	return e.msg.Error()
+}
+
+func NewSSLError(e error) *SSLError {
+	return &SSLError{msg: e}
+}
+
 // Cluster is a subset representation of a DC/OS CLI configuration.
 //
 // It is a proxy struct on top of a config which provides user-friendly getters and setters for common

--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"crypto/x509"
+	"fmt"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -53,14 +54,23 @@ func (c *Cluster) SetACSToken(acsToken string) {
 	c.config.Set("core.dcos_acs_token", acsToken)
 }
 
-// TLS returns the configuration for TLS clients.
-func (c *Cluster) TLS() TLS {
+// SetTLS returns the configuration for TLS clients.
+func (c *Cluster) SetTLS(tls TLS) {
+	c.config.Set("core.ssl_verify", tls.String())
+}
+
+// CheckTLS returns error if provided certificate is invalid
+func (c *Cluster) TLS() (TLS, error) {
 	tlsVal := cast.ToString(c.config.Get("core.ssl_verify"))
+
+	if tlsVal == "" {
+		return TLS{Insecure: false}, nil
+	}
 
 	// Try to cast the value to a bool, true means we verify
 	// server certificates, false means we skip verification.
 	if verify, err := strconv.ParseBool(tlsVal); err == nil {
-		return TLS{Insecure: !verify}
+		return TLS{Insecure: !verify}, nil
 	}
 
 	// The value is not a string representing a bool thus it is a path to a root CA bundle.
@@ -69,7 +79,7 @@ func (c *Cluster) TLS() TLS {
 		return TLS{
 			Insecure:    true,
 			RootCAsPath: tlsVal,
-		}
+		}, fmt.Errorf("can't read %s: %s", tlsVal, err)
 	}
 
 	// Decode the PEM root certificate(s) into a cert pool.
@@ -78,19 +88,14 @@ func (c *Cluster) TLS() TLS {
 		return TLS{
 			Insecure:    true,
 			RootCAsPath: tlsVal,
-		}
+		}, fmt.Errorf("cannot decode the PEM root certificate(s) into a cert pool: %s", tlsVal)
 	}
 
 	// The cert pool has been successfully created, store it in the TLS config.
 	return TLS{
 		RootCAs:     certPool,
 		RootCAsPath: tlsVal,
-	}
-}
-
-// SetTLS returns the configuration for TLS clients.
-func (c *Cluster) SetTLS(tls TLS) {
-	c.config.Set("core.ssl_verify", tls.String())
+	}, nil
 }
 
 // Timeout returns the HTTP request timeout once the connection is established.

--- a/pkg/plugin/manager.go
+++ b/pkg/plugin/manager.go
@@ -491,7 +491,7 @@ func (m *Manager) httpClient(url string) (*httpclient.Client, error) {
 	}
 	clusterTLS, err := m.cluster.TLS()
 	if err != nil {
-		return nil, fmt.Errorf("cannot create HTTP client: %s", err)
+		return nil, config.NewSSLError(err)
 	}
 	if strings.HasPrefix(url, m.cluster.URL()) {
 		httpOpts = append(


### PR DESCRIPTION
We do not check if TLS is set up properly. When we can't read certificate or it was invalid we silently switched to insecure mode. This PR changes this behavior. Whenever HTTP Client is created it
checks for errors and returns one if necessary. The only exception are `list` and `setup` commands. List will allow user to list all clusters but call to attach will fail. `setup` uses `insecureHttpClient` by default – to download certs.

https://github.com/dcos/dcos-cli/blob/51eee402180b99bdf56ebe8356963b98807b8861/pkg/setup/setup.go#L251-L254

Fixes: https://jira.mesosphere.com/browse/DCOS-61005