### PR TITLE
Fix invalid error message

### DIFF
--- a/cmd/dcos/main.go
+++ b/cmd/dcos/main.go
@@ -27,7 +27,7 @@ func main() {
 				"run: 'dcos config set core.ssl_verify <value>'\n" +
 				"<value>: Whether to verify SSL certs for HTTPS or path to certs. " +
 				"Valid values are a path to a CA_BUNDLE, " +
-				"True (will then use CA certificates from certifi), " +
+				"True (will then use system CA certificates), " +
 				"or False (will then send insecure requests).\n"
 			fmt.Fprint(env.ErrOut, msg)
 		}


### PR DESCRIPTION
> certifi is a library that was used in the python codebase, it does not apply anymore.

Refs:

* https://github.com/dcos/dcos-cli/pull/1513#pullrequestreview-320711349
* https://jira.mesosphere.com/browse/DCOS-61005