### PR TITLE
Pin golangci-lint version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,8 +10,7 @@ environment:
   GOPATH: c:\gopath
   NO_DOCKER: 1
 
-stack: go 1.14
-image: Visual Studio 2019
+stack: go 1.12
 
 test_script:
   - SET GO111MODULE=on

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,8 @@ environment:
   NO_DOCKER: 1
   GO111MODULE: off
 
-stack: go 1.12
+stack: go 1.14
+image: Visual Studio 2019
 
 test_script:
   - SET GO111MODULE=on

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 install:
   - SET PATH=C:\msys64\mingw64\bin;c:\gopath\bin;%PATH%
-  - go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+  - go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.27.0
 
 build: off
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,7 +9,6 @@ clone_folder: c:\dcos-cli
 environment:
   GOPATH: c:\gopath
   NO_DOCKER: 1
-  GO111MODULE: off
 
 stack: go 1.14
 image: Visual Studio 2019


### PR DESCRIPTION
We need to pin linter version to prevent failures introduced by changes in in
See https://ci.appveyor.com/project/janisz/dcos-cli/builds/33406479