### PR TITLE
Use terraform to launch cluster

### DIFF
--- a/scripts/launch_aws_cluster.sh
+++ b/scripts/launch_aws_cluster.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -euxo pipefail
+
+export AWS_REGION="us-east-1"
+export TF_VAR_dcos_user=$DCOS_TEST_DEFAULT_CLUSTER_USERNAME
+export TF_VAR_dcos_pass_hash=$(perl -e 'print crypt($ENV{DCOS_TEST_DEFAULT_CLUSTER_PASSWORD},"\$6\$1234567890\$")')
+export TF_VAR_dcos_license_key_contents=$DCOS_TEST_LICENSE
+export TF_VAR_custom_dcos_download_path=$DCOS_TEST_INSTALLER_URL
+export CLI_TEST_SSH_KEY_PATH
+export TF_INPUT=false
+export TF_IN_AUTOMATION=1
+wget -q https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip -O terraform_0.11.14_linux_amd64.zip
+unzip -qq -o terraform_0.11.14_linux_amd64.zip
+mkdir -p $HOME/.ssh
+eval $(ssh-agent) >&2
+ssh-add $CLI_TEST_SSH_KEY_PATH >&2
+ssh-keygen -y -f $CLI_TEST_SSH_KEY_PATH > $HOME/.ssh/id_rsa.pub
+./terraform init -no-color >&2
+./terraform  apply -auto-approve -no-color >&2
+./terraform output master_public_ip

--- a/scripts/main.tf
+++ b/scripts/main.tf
@@ -1,0 +1,121 @@
+provider "aws" {}
+
+variable "custom_dcos_download_path" {
+  type    = "string"
+  default = "https://downloads.mesosphere.com/dcos-enterprise/testing/master/dcos_generate_config.ee.sh"
+}
+
+variable "variant" {
+  type    = "string"
+  default = "ee"
+}
+
+variable "dcos_security" {
+  type    = "string"
+  default = "strict"
+}
+
+variable "owner" {
+  type    = "string"
+  default = "dcos-core-cli"
+}
+
+variable "expiration" {
+  type    = "string"
+  default = "2h"
+}
+
+variable "ssh_public_key_file" {
+  type        = "string"
+  default     = "~/.ssh/id_rsa.pub"
+  description = "Defines the public key to log on the cluster."
+}
+
+variable "dcos_license_key_contents" {
+  type        = "string"
+  default     = ""
+  description = "Defines content of license used for EE."
+}
+
+variable "instance_type" {
+  type        = "string"
+  default     = "m5.large"
+  description = "Defines type of used machine."
+}
+
+variable "build_id" {
+  type        = "string"
+  default     = ""
+  description = "Build ID from CI."
+}
+
+variable "build_type" {
+  type        = "string"
+  default     = ""
+  description = "Build type from CI."
+}
+
+variable "dcos_user" {
+  type        = "string"
+  default     = "bootstrapuser"
+  description = "DC/OS Superuser."
+}
+
+variable "dcos_pass_hash" {
+  type        = "string"
+  default     = "$6$rounds=656000$YSvuFmasQDXheddh$TpYlCxNHF6PbsGkjlK99Pwxg7D0mgWJ.y0hE2JKoa61wHx.1wtxTAHVRHfsJU9zzHWDoE08wpdtToHimNR9FJ/"
+  description = "DC/OS Superuser Password Hash."
+}
+
+resource "random_string" "password" {
+  length  = 12
+  special = false
+}
+
+locals {
+  cluster_name = "generic-dcos-it-${random_string.password.result}"
+}
+
+module "dcos" {
+  source  = "dcos-terraform/dcos/aws"
+  version = "~> 0.2.0"
+
+  providers = {
+    aws = "aws"
+  }
+
+  tags {
+    owner         = "${var.owner}"
+    expiration    = "${var.expiration}"
+    build_id      = "${var.build_id}"
+    build_type_id = "${var.build_type}"
+  }
+
+  cluster_name        = "${local.cluster_name}"
+  ssh_public_key_file = "${var.ssh_public_key_file}"
+  admin_ips           = ["0.0.0.0/0"]
+
+  num_masters        = "1"
+  num_private_agents = "1"
+  num_public_agents  = "1"
+
+  dcos_instance_os = "centos_7.5"
+
+  masters_instance_type        = "${var.instance_type}"
+  private_agents_instance_type = "${var.instance_type}"
+  public_agents_instance_type  = "${var.instance_type}"
+
+  dcos_variant              = "${var.variant}"
+  dcos_security             = "${var.dcos_security}"
+  dcos_license_key_contents = "${var.dcos_license_key_contents}"
+
+  custom_dcos_download_path = "${var.custom_dcos_download_path}"
+
+  dcos_superuser_username      = "${var.dcos_user}"
+  dcos_superuser_password_hash = "${var.dcos_pass_hash}"
+}
+
+output "master_public_ip" {
+  description = "This is the public masters IP to SSH"
+  value       = "${element(module.dcos.infrastructure.masters.public_ips, 0)}"
+}

--- a/tests/integration/common.py
+++ b/tests/integration/common.py
@@ -77,7 +77,7 @@ def setup_cluster(**kwargs):
         assert code == 0
 
 
-def _setup_cluster(name='DEFAULT', scheme='http', insecure=False, env={}):
+def _setup_cluster(name='DEFAULT', scheme='https', insecure=True, env={}):
     env = {**os.environ.copy(), **env}
     cluster = {
         'variant': os.environ.get('DCOS_TEST_' + name + '_CLUSTER_VARIANT'),

--- a/tests/integration/test_cluster.py
+++ b/tests/integration/test_cluster.py
@@ -124,7 +124,7 @@ def test_cluster_setup_non_superuser(default_cluster):
     exec_cmd(['dcos', 'security', 'org', 'users',
               'create', username, '--password', password])
 
-    code, out, err = exec_cmd(['dcos', 'cluster', 'setup', default_cluster['dcos_url'],
+    code, out, err = exec_cmd(['dcos', 'cluster', 'setup', '--insecure', default_cluster['dcos_url'],
                                '--username', username, '--password', password])
     assert code == 0
     assert out == ""
@@ -134,7 +134,7 @@ def test_cluster_setup_with_acs_token_env(default_cluster):
     env = os.environ.copy()
     env['DCOS_CLUSTER_SETUP_ACS_TOKEN'] = default_cluster['acs_token']
 
-    code, out, err = exec_cmd(['dcos', 'cluster', 'setup', default_cluster['dcos_url']], env=env)
+    code, out, err = exec_cmd(['dcos', 'cluster', 'setup', '--insecure', default_cluster['dcos_url']], env=env)
     assert code == 0
     assert out == ""
 

--- a/tests/integration/test_corecli.py
+++ b/tests/integration/test_corecli.py
@@ -4,16 +4,11 @@ import pytest
 
 from .common import exec_cmd, default_cluster  # noqa: F401
 
-
-def test_update_core(default_cluster):
-    cmds = [
-        ['dcos', 'package', 'install', 'dcos-core-cli'],
-        ['dcos', 'package', 'install', 'dcos-core-cli', '--cli'],
-        ['dcos', 'package', 'install', 'dcos-core-cli', '--yes'],
-        ['dcos', '-vv', 'package', 'install', 'dcos-core-cli'],
-    ]
-
-    for cmd in cmds:
+@pytest.mark.parametrize("cmd", [['dcos', 'package', 'install', 'dcos-core-cli'],
+                                ['dcos', 'package', 'install', 'dcos-core-cli', '--cli'],
+                                ['dcos', 'package', 'install', 'dcos-core-cli', '--yes'],
+                                ['dcos', '-vv', 'package', 'install', 'dcos-core-cli']])
+def test_update_core(cmd, default_cluster):
         code, out, _ = exec_cmd(cmd)
         assert code == 0
         assert out == ''

--- a/tests/integration/test_help.py
+++ b/tests/integration/test_help.py
@@ -48,6 +48,8 @@ def test_dcos_help_with_default_oss_plugins(default_cluster):
 Commands:
     auth
         Authenticate to DC/OS cluster
+    calico
+        Manage Calico in DC/OS
     cluster
         Manage your DC/OS clusters
     config
@@ -99,6 +101,8 @@ Commands:
         Authenticate to DC/OS cluster
     backup
         Access DC/OS backup functionality
+    calico
+        Manage Calico in DC/OS
     cluster
         Manage your DC/OS clusters
     config

--- a/tests/integration/test_plugin.py
+++ b/tests/integration/test_plugin.py
@@ -77,7 +77,7 @@ def test_plugin_list(default_cluster):
 
     dcos_core_cli = lines[1].split()
     assert dcos_core_cli[0] == 'dcos-core-cli'
-    assert dcos_core_cli[1:] == ['diagnostics', 'job', 'marathon', 'node', 'package', 'quota', 'service', 'task']
+    assert dcos_core_cli[1:] == ['calico', 'diagnostics', 'job', 'marathon', 'node', 'package', 'quota', 'service', 'task']
 
     if default_cluster['variant'] == 'enterprise':
         dcos_enterprise_cli = lines[2].split()
@@ -120,8 +120,7 @@ def test_plugin_invocation(default_cluster):
     assert out['env'].get('DCOS_ACS_TOKEN') == default_cluster['acs_token']
 
 
-@pytest.mark.skipif(os.environ.get('DCOS_TEST_DEFAULT_CLUSTER_VARIANT') == 'open',
-                    reason="No CA on DC/OS Open")
+@pytest.mark.skip(reason="Cluster created with terraform have untrusted certificate")
 def test_plugin_invocation_tls():
     with setup_cluster(scheme='https'):
         _install_test_plugin()


### PR DESCRIPTION
dcos-launch is deprecated and is no longer working for us.
This commit changes EE CI to use terraform.