### PR TITLE
Release script unzip overrite files

### DIFF
--- a/ci/release.groovy
+++ b/ci/release.groovy
@@ -50,7 +50,7 @@ pipeline {
                 make linux darwin windows"
             '''
             sh 'mkdir -p ${WORKSPACE}/usr/local/bin'
-            sh 'wget -O /tmp/gon.zip https://github.com/mitchellh/gon/releases/download/v\${GON_VER}/gon_\${GON_VER}_macos.zip && unzip /tmp/gon.zip -d ${WORKSPACE}/usr/local/bin'
+            sh 'wget -O /tmp/gon.zip https://github.com/mitchellh/gon/releases/download/v\${GON_VER}/gon_\${GON_VER}_macos.zip && unzip -o /tmp/gon.zip -d ${WORKSPACE}/usr/local/bin'
             sh '''
                 export PATH=$PATH:${WORKSPACE}/usr/local/bin
                 export AC_USERNAME="${APPLE_DEVACC_USR}"


### PR DESCRIPTION
Master releases are failing because file already exists and unzip prompt user.
By adding `-o` we force overwrite.

See: https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/public-dcos-cluster-ops%2Fmesosphere-dcos-cli%2Frelease/detail/master/9/pipeline#step-30-log-130